### PR TITLE
feat(upload-dialog): add subtitle field for video upload

### DIFF
--- a/packages/ui/src/watch/dialogs/upload/dialog.test.tsx
+++ b/packages/ui/src/watch/dialogs/upload/dialog.test.tsx
@@ -28,6 +28,7 @@ describe('DialogComponent', () => {
     isSubmitting: false,
     title: '',
     url: '',
+    subtitle: '',
     description: '',
     playlistId: '',
     newPlaylistName: '',
@@ -64,6 +65,7 @@ describe('DialogComponent', () => {
     renderComponent();
     expect(screen.getByPlaceholderText(texts.form.titleInput.placeholder)).toBeInTheDocument();
     expect(screen.getByPlaceholderText(texts.form.urlInput.placeholder)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(texts.form.subtitleInput.placeholder)).toBeInTheDocument();
     expect(screen.getByPlaceholderText(texts.form.descriptionInput.placeholder)).toBeInTheDocument();
     expect(screen.getByPlaceholderText(texts.form.playlistInput.placeholder)).toBeInTheDocument();
     expect(screen.getByPlaceholderText(texts.form.videoPositionInPlaylistInput.placeholder)).toBeInTheDocument();

--- a/packages/ui/src/watch/dialogs/upload/dialog.tsx
+++ b/packages/ui/src/watch/dialogs/upload/dialog.tsx
@@ -88,6 +88,7 @@ const DialogComponent = (props: DialogComponentProps) => {
     isSubmitting,
     title,
     url,
+    subtitle,
     description,
     playlistId,
     newPlaylistName,
@@ -119,6 +120,10 @@ const DialogComponent = (props: DialogComponentProps) => {
   };
   const urlTextFieldProps = {
     ...fieldConfigs.url,
+    disabled: isSubmitting,
+  };
+  const subtitleTextFieldProps = {
+    ...fieldConfigs.subtitle,
     disabled: isSubmitting,
   };
   const descriptionTextFieldProps = {
@@ -160,6 +165,7 @@ const DialogComponent = (props: DialogComponentProps) => {
         <Box component="form" noValidate aria-label="Video URL validation form" sx={{ mt: 2 }}>
           <TextField value={title} onChange={onFormFieldChange('title')} {...titleTextFieldProps} />
           <TextField value={url} onChange={onFormFieldChange('url')} {...urlTextFieldProps} />
+          <TextField value={subtitle} onChange={onFormFieldChange('subtitle')} {...subtitleTextFieldProps} />
           <TextField value={description} onChange={onFormFieldChange('description')} {...descriptionTextFieldProps} />
           <TextField select value={playlistId} onChange={onFormFieldChange('playlistId')} {...playlistTextFieldProps}>
             <MenuItem value="">

--- a/packages/ui/src/watch/dialogs/upload/fields-config.ts
+++ b/packages/ui/src/watch/dialogs/upload/fields-config.ts
@@ -25,6 +25,17 @@ const getFormFieldStaticConfigs = () => {
       inputProps: { 'data-testid': 'url-input-text' },
       required: true,
     },
+    subtitle: {
+      fullWidth: true,
+      placeholder: texts.form.subtitleInput.placeholder,
+      label: texts.form.subtitleInput.label,
+      helperText: texts.form.subtitleInput.helperText,
+      variant: 'outlined' as TextFieldVariants,
+      sx: { mb: 2 },
+      'aria-label': texts.form.subtitleInput.label,
+      inputProps: { 'data-testid': 'subtitle-input-text' },
+      required: false,
+    },
     description: {
       fullWidth: true,
       multiline: true,

--- a/packages/ui/src/watch/dialogs/upload/index.tsx
+++ b/packages/ui/src/watch/dialogs/upload/index.tsx
@@ -17,6 +17,7 @@ interface VideoUploadDialogProps {
 const defaultState: DialogState = {
   title: '',
   url: '',
+  subtitle: '',
   description: '',
   isSubmitting: false,
   error: null,

--- a/packages/ui/src/watch/dialogs/upload/texts.ts
+++ b/packages/ui/src/watch/dialogs/upload/texts.ts
@@ -14,6 +14,11 @@ export const texts = {
       label: 'Video URL',
       helperText: 'Can be either direct video url or platform like youtube url',
     },
+    subtitleInput: {
+      placeholder: 'Enter subtitle URL (*.vtt)',
+      label: 'Subtitle URL',
+      helperText: 'Should be a valid vtt file',
+    },
     descriptionInput: {
       placeholder: 'Description for the video (optional)',
       label: 'Video description',

--- a/packages/ui/src/watch/dialogs/upload/texts.ts
+++ b/packages/ui/src/watch/dialogs/upload/texts.ts
@@ -50,6 +50,7 @@ export const texts = {
     emptyTitle: '✗ Video title is required',
     emptyNewPlaylistName: '✗ Playlist name is required',
     invalidUrl: '✗ Invalid video URL',
+    invalidSubtitleFormat: '✗ Invalid subtitle URL',
     failedToSave: 'Failed to upload',
     unexpected: 'An unexpected error occurred while upload',
   },

--- a/packages/ui/src/watch/dialogs/upload/types.ts
+++ b/packages/ui/src/watch/dialogs/upload/types.ts
@@ -6,6 +6,7 @@ interface ValidationResult {
 interface DialogState {
   title: string;
   url: string;
+  subtitle?: string;
   description?: string;
   playlistId?: string;
   newPlaylistName?: string;
@@ -15,4 +16,4 @@ interface DialogState {
   closeDialogCountdown: number | null;
 }
 
-export { type ValidationResult, type DialogState };
+export { type DialogState, type ValidationResult };

--- a/packages/ui/src/watch/dialogs/upload/utils.test.ts
+++ b/packages/ui/src/watch/dialogs/upload/utils.test.ts
@@ -8,6 +8,7 @@ describe('formalizeState', () => {
       title: '  Test Title  ',
       description: ' Test Description ',
       url: '  https://example.com/video  ',
+      subtitle: '  https://example.com/sub.vtt  ',
       playlistId: 'playlist-123',
       newPlaylistName: '  New Playlist  ',
       videoPositionInPlaylist: 5,
@@ -19,6 +20,7 @@ describe('formalizeState', () => {
       title: 'Test Title',
       description: 'Test Description',
       url: 'https://example.com/video',
+      subtitle: 'https://example.com/sub.vtt',
       playlistId: 'playlist-123',
       newPlaylistName: 'New Playlist',
       videoPositionInPlaylist: 5,
@@ -41,6 +43,7 @@ describe('formalizeState', () => {
       title: undefined,
       description: '',
       url: 'https://example.com/video',
+      subtitle: '',
       playlistId: undefined,
       newPlaylistName: undefined,
       videoPositionInPlaylist: 0,
@@ -61,6 +64,7 @@ describe('formalizeState', () => {
       title: 'Test Title',
       description: '',
       url: 'https://example.com/video',
+      subtitle: '',
       playlistId: CREATE_NEW_PLAYLIST,
       newPlaylistName: undefined,
       videoPositionInPlaylist: 10,
@@ -348,6 +352,102 @@ describe('buildVariables', () => {
               {
                 playlist_id: 'playlist-123',
                 position: 2,
+              },
+            ],
+          },
+        },
+      ],
+    });
+  });
+
+  // Add new tests for subtitle handling
+  it('should add subtitle data when subtitle URL is provided', () => {
+    const dialogState = {
+      title: 'Test Video',
+      description: 'Test Description',
+      url: 'https://example.com/video',
+      subtitle: 'https://example.com/subtitle.vtt',
+    } as DialogState;
+
+    const result = buildVariables(dialogState);
+
+    expect(result).toEqual({
+      objects: [
+        {
+          title: 'Test Video',
+          description: 'Test Description',
+          slug: 'test-video',
+          video_url: 'https://example.com/video',
+          subtitles: {
+            data: [
+              {
+                url: 'https://example.com/subtitle.vtt',
+                lang: 'vi',
+                isDefault: true,
+              },
+            ],
+          },
+        },
+      ],
+    });
+  });
+
+  it('should not add subtitle data when subtitle URL is empty', () => {
+    const dialogState = {
+      title: 'Test Video',
+      description: 'Test Description',
+      url: 'https://example.com/video',
+      subtitle: '',
+    } as DialogState;
+
+    const result = buildVariables(dialogState);
+
+    expect(result).toEqual({
+      objects: [
+        {
+          title: 'Test Video',
+          description: 'Test Description',
+          slug: 'test-video',
+          video_url: 'https://example.com/video',
+          // No subtitles property
+        },
+      ],
+    });
+  });
+
+  it('should handle both subtitle and playlist data together', () => {
+    const dialogState = {
+      title: 'Test Video',
+      description: 'Test Description',
+      url: 'https://example.com/video',
+      subtitle: 'https://example.com/subtitle.vtt',
+      playlistId: 'playlist-123',
+      videoPositionInPlaylist: 2,
+    } as DialogState;
+
+    const result = buildVariables(dialogState);
+
+    expect(result).toEqual({
+      objects: [
+        {
+          title: 'Test Video',
+          description: 'Test Description',
+          slug: 'test-video',
+          video_url: 'https://example.com/video',
+          playlist_videos: {
+            data: [
+              {
+                playlist_id: 'playlist-123',
+                position: 2,
+              },
+            ],
+          },
+          subtitles: {
+            data: [
+              {
+                url: 'https://example.com/subtitle.vtt',
+                lang: 'vi',
+                isDefault: true,
               },
             ],
           },

--- a/packages/ui/src/watch/dialogs/upload/utils.ts
+++ b/packages/ui/src/watch/dialogs/upload/utils.ts
@@ -38,7 +38,7 @@ const formalizeState = (dialogState: DialogState) => {
     title: title?.trim(),
     description: description?.trim() || '',
     url: url?.trim(),
-    subtitle: subtitle?.trim(),
+    subtitle: subtitle?.trim() || '',
     playlistId,
     newPlaylistName: newPlaylistName?.trim(),
     videoPositionInPlaylist,

--- a/packages/ui/src/watch/dialogs/upload/utils.ts
+++ b/packages/ui/src/watch/dialogs/upload/utils.ts
@@ -10,7 +10,7 @@ const CREATE_NEW_PLAYLIST = '__create-new';
 const MATCH_URL_YOUTUBE =
   /(?:youtu\.be\/|youtube(?:-nocookie|education)?\.com\/(?:embed\/|v\/|watch\/|watch\?v=|watch\?.+&v=|shorts\/|live\/))((\w|-){11})|youtube\.com\/playlist\?list=|youtube\.com\/user\//;
 const HLS_EXTENSIONS = /\.(m3u8)($|\?)/i;
-const VIDEO_EXTENSIONS = /\.(mp4|mov|m4v|ts|webm|mkv)($|\?)/i;  // Added more video formats
+const VIDEO_EXTENSIONS = /\.(mp4|mov|m4v|ts|webm|mkv)($|\?)/i; // Added more video formats
 
 const canPlay = (url: string) => {
   const isYouTube = MATCH_URL_YOUTUBE.test(url);
@@ -27,17 +27,18 @@ const canPlayUrls = (urls: string[]): ValidationResult[] => {
     .filter(Boolean)
     .map(url => ({
       url,
-      isValid: canPlay(url)
+      isValid: canPlay(url),
     }));
 };
 
 const formalizeState = (dialogState: DialogState) => {
-  const { title, description, url, playlistId, newPlaylistName, videoPositionInPlaylist } = dialogState;
+  const { title, description, url, subtitle, playlistId, newPlaylistName, videoPositionInPlaylist } = dialogState;
 
   return {
     title: title?.trim(),
     description: description?.trim() || '',
     url: url?.trim(),
+    subtitle: subtitle?.trim(),
     playlistId,
     newPlaylistName: newPlaylistName?.trim(),
     videoPositionInPlaylist,
@@ -49,6 +50,7 @@ const buildVariables = (dialogState: DialogState) => {
     title,
     description = '',
     url,
+    subtitle = '',
     playlistId,
     newPlaylistName,
     videoPositionInPlaylist = 0,
@@ -83,6 +85,18 @@ const buildVariables = (dialogState: DialogState) => {
 
     variables.objects[0].playlist_videos = {
       data: [playlistVideoData],
+    };
+  }
+
+  if (subtitle) {
+    variables.objects[0].subtitles = {
+      data: [
+        {
+          url: subtitle,
+          lang: 'vi',
+          isDefault: true,
+        },
+      ],
     };
   }
 

--- a/packages/ui/src/watch/dialogs/upload/validate.test.ts
+++ b/packages/ui/src/watch/dialogs/upload/validate.test.ts
@@ -22,6 +22,7 @@ vi.mock('./texts', () => ({
       emptyTitle: 'Title is required',
       emptyNewPlaylistName: 'Playlist name is required',
       invalidUrl: 'Invalid URL',
+      invalidSubtitleFormat: 'Subtitle must be a .vtt file',
     },
   },
 }));
@@ -137,6 +138,87 @@ describe('validateForm', () => {
       title: 'Test Video',
       url: 'https://youtube.com/watch?v=123',
       newPlaylistName: 'My New Playlist',
+    } as ReturnType<typeof formalizeState>);
+
+    vi.mocked(canPlayUrls).mockReturnValueOnce([{ url: 'https://youtube.com/watch?v=123', isValid: true }]);
+
+    const result = validateForm(state);
+    expect(result).toBeNull();
+  });
+
+  // Add new tests for subtitle validation
+  it('should return error when subtitle is not a .vtt file', async () => {
+    const state: DialogState = {
+      title: 'Test Video',
+      url: 'https://youtube.com/watch?v=123',
+      subtitle: 'https://example.com/subtitle.srt',
+    } as DialogState;
+
+    vi.mocked(formalizeState).mockReturnValueOnce({
+      ...state,
+      title: 'Test Video',
+      url: 'https://youtube.com/watch?v=123',
+      subtitle: 'https://example.com/subtitle.srt',
+    } as ReturnType<typeof formalizeState>);
+
+    vi.mocked(canPlayUrls).mockReturnValueOnce([{ url: 'https://youtube.com/watch?v=123', isValid: true }]);
+
+    const result = validateForm(state);
+    expect(result).toBe(texts.errors.invalidSubtitleFormat);
+  });
+
+  it('should return null when subtitle has valid .vtt extension', async () => {
+    const state: DialogState = {
+      title: 'Test Video',
+      url: 'https://youtube.com/watch?v=123',
+      subtitle: 'https://example.com/subtitle.vtt',
+    } as DialogState;
+
+    vi.mocked(formalizeState).mockReturnValueOnce({
+      ...state,
+      title: 'Test Video',
+      url: 'https://youtube.com/watch?v=123',
+      subtitle: 'https://example.com/subtitle.vtt',
+    } as ReturnType<typeof formalizeState>);
+
+    vi.mocked(canPlayUrls).mockReturnValueOnce([{ url: 'https://youtube.com/watch?v=123', isValid: true }]);
+
+    const result = validateForm(state);
+    expect(result).toBeNull();
+  });
+
+  it('should return null when subtitle has valid .VTT extension (case insensitive)', async () => {
+    const state: DialogState = {
+      title: 'Test Video',
+      url: 'https://youtube.com/watch?v=123',
+      subtitle: 'https://example.com/subtitle.VTT',
+    } as DialogState;
+
+    vi.mocked(formalizeState).mockReturnValueOnce({
+      ...state,
+      title: 'Test Video',
+      url: 'https://youtube.com/watch?v=123',
+      subtitle: 'https://example.com/subtitle.VTT',
+    } as ReturnType<typeof formalizeState>);
+
+    vi.mocked(canPlayUrls).mockReturnValueOnce([{ url: 'https://youtube.com/watch?v=123', isValid: true }]);
+
+    const result = validateForm(state);
+    expect(result).toBeNull();
+  });
+
+  it('should ignore subtitle validation when subtitle is empty', async () => {
+    const state: DialogState = {
+      title: 'Test Video',
+      url: 'https://youtube.com/watch?v=123',
+      subtitle: '',
+    } as DialogState;
+
+    vi.mocked(formalizeState).mockReturnValueOnce({
+      ...state,
+      title: 'Test Video',
+      url: 'https://youtube.com/watch?v=123',
+      subtitle: '',
     } as ReturnType<typeof formalizeState>);
 
     vi.mocked(canPlayUrls).mockReturnValueOnce([{ url: 'https://youtube.com/watch?v=123', isValid: true }]);

--- a/packages/ui/src/watch/dialogs/upload/validate.ts
+++ b/packages/ui/src/watch/dialogs/upload/validate.ts
@@ -3,7 +3,7 @@ import { DialogState } from './types';
 import { canPlayUrls, CREATE_NEW_PLAYLIST, formalizeState } from './utils';
 
 const validateForm = (state: DialogState) => {
-  const { title, url, playlistId, newPlaylistName } = formalizeState(state);
+  const { title, url, subtitle, playlistId, newPlaylistName } = formalizeState(state);
 
   if (!title.trim()) {
     return texts.errors.emptyTitle;
@@ -18,6 +18,14 @@ const validateForm = (state: DialogState) => {
 
   if (!isValid) {
     return texts.errors.invalidUrl;
+  }
+
+  // Validate subtitle URL if provided
+  if (subtitle?.trim()) {
+    const isValidSubtitle = subtitle.trim().toLowerCase().endsWith('.vtt');
+    if (!isValidSubtitle) {
+      return texts.errors.invalidSubtitleFormat;
+    }
   }
 
   return null;


### PR DESCRIPTION
Add a new subtitle field to the video upload dialog to support subtitle URL input. This includes updates to the dialog state, form configuration, and validation logic to handle subtitle URLs. The subtitle field is optional and accepts valid vtt files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a subtitle input field in the video upload dialog, allowing users to enter a subtitle URL with guidance text for valid `.vtt` files.
  - Added validation for subtitle format, ensuring it meets specific criteria.

- **Bug Fixes**
  - Improved error handling for invalid subtitle formats, providing clear feedback to users.

- **Tests**
  - Enhanced test coverage to ensure the subtitle field renders correctly and is handled appropriately in various scenarios within the upload dialog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->