### PR TITLE
fix: only invalidate playlist-detail cache when a valid playlist is s…

### DIFF
--- a/packages/ui/src/watch/dialogs/upload/index.test.tsx
+++ b/packages/ui/src/watch/dialogs/upload/index.test.tsx
@@ -448,12 +448,12 @@ describe('VideoUploadDialog', () => {
     expect(mockInvalidateQuery).toHaveBeenCalledWith(['videos']);
   });
 
-  it('should invalidate playlist-detail cache when a playlist is selected', async () => {
+  it('should invalidate playlist-detail cache when a valid playlist is selected', async () => {
     renderWithAct(<VideoUploadDialog open={true} onOpenChange={mockOnOpenChange} />);
 
     await fillForm();
 
-    // Select a playlist
+    // Select a valid playlist (not CREATE_NEW_PLAYLIST)
     await act(async () => {
       fireEvent.change(screen.getByTestId('playlist-select'), {
         target: { value: 'playlist-1' },
@@ -470,9 +470,34 @@ describe('VideoUploadDialog', () => {
       expect(mockBulkConvert).toHaveBeenCalled();
     });
 
-    // Now check if both invalidateQuery calls were made with the right arguments
+    // Check if both invalidateQuery calls were made with the right arguments
     expect(mockInvalidateQuery).toHaveBeenCalledWith(['videos']);
     expect(mockInvalidateQuery).toHaveBeenCalledWith(['playlist-detail', 'playlist-1']);
+  });
+
+  it('should not invalidate playlist-detail cache when CREATE_NEW_PLAYLIST is selected', async () => {
+    renderWithAct(<VideoUploadDialog open={true} onOpenChange={mockOnOpenChange} />);
+
+    await fillForm();
+
+    // Select CREATE_NEW_PLAYLIST
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('playlist-select'), {
+        target: { value: 'tmp-id' },
+      });
+    });
+
+    await act(async () => {
+      fireEvent.submit(screen.getByTestId('submit-button'));
+    });
+
+    await waitFor(() => {
+      expect(mockBulkConvert).toHaveBeenCalled();
+    });
+
+    // Should only invalidate videos cache
+    expect(mockInvalidateQuery).toHaveBeenCalledWith(['videos']);
+    expect(mockInvalidateQuery).not.toHaveBeenCalledWith(['playlist-detail', 'tmp-id']);
   });
 
   it('should not invalidate playlist-detail cache when no playlist is selected', async () => {

--- a/packages/ui/src/watch/dialogs/upload/index.tsx
+++ b/packages/ui/src/watch/dialogs/upload/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { buildVariables, CLOSE_DELAY_MS } from './utils';
+import { buildVariables, CLOSE_DELAY_MS, CREATE_NEW_PLAYLIST } from './utils';
 import { DialogState } from './types';
 import { DialogComponent } from './dialog';
 import { texts } from './texts';
@@ -50,7 +50,7 @@ const VideoUploadDialog = ({ open, onOpenChange }: VideoUploadDialogProps) => {
       const firstPlaylistVideo = playlistVideos?.data?.[0];
       const playlistId = firstPlaylistVideo?.playlist_id;
 
-      if (typeof playlistId === 'string') {
+      if (typeof playlistId === 'string' && playlistId !== CREATE_NEW_PLAYLIST) {
         invalidateQuery(['playlist-detail', playlistId]);
       }
     },


### PR DESCRIPTION
…elected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cache management to ensure the playlist-detail cache is only invalidated for valid playlists, not when creating a new playlist or when no playlist is selected.
- **Tests**
  - Added and updated tests to verify correct cache invalidation behavior for different playlist selection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->