### PR TITLE
Swo 172 bug report time reading in minutes

### DIFF
--- a/packages/ui/src/main/library-page/home-stats/index.test.tsx
+++ b/packages/ui/src/main/library-page/home-stats/index.test.tsx
@@ -39,7 +39,7 @@ describe('StatsGrid', () => {
     expect(screen.getByText('3')).toBeInTheDocument();
     expect(screen.getByText('Currently Reading')).toBeInTheDocument();
     // This Month (should include suffix 'h')
-    expect(screen.getByText('8m')).toBeInTheDocument();
+    expect(screen.getByText('0h')).toBeInTheDocument();
     expect(screen.getByText('This Month')).toBeInTheDocument();
     // Wishlist
     expect(screen.getByText('2')).toBeInTheDocument();
@@ -53,5 +53,58 @@ describe('StatsGrid', () => {
     expect(screen.getByText('Currently Reading')).toBeInTheDocument();
     expect(screen.getByText('This Month')).toBeInTheDocument();
     expect(screen.getByText('Wishlist')).toBeInTheDocument();
+  });
+
+  it('should show readingTimeThisMonth in hours (rounded)', () => {
+    render(
+      <StatsGrid
+        isLoading={false}
+        stats={{ completedBooks: 0, currentlyReading: 0, readingTimeThisMonth: 120, wishlist: 0 }}
+      />
+    );
+    expect(screen.getByText('2h')).toBeInTheDocument();
+  });
+
+  it('should round readingTimeThisMonth correctly (61 min → 1h)', () => {
+    render(
+      <StatsGrid
+        isLoading={false}
+        stats={{ completedBooks: 0, currentlyReading: 0, readingTimeThisMonth: 61, wishlist: 0 }}
+      />
+    );
+    expect(screen.getByText('1h')).toBeInTheDocument();
+  });
+
+  it('should round readingTimeThisMonth correctly (89 min → 1h)', () => {
+    render(
+      <StatsGrid
+        isLoading={false}
+        stats={{ completedBooks: 0, currentlyReading: 0, readingTimeThisMonth: 89, wishlist: 0 }}
+      />
+    );
+    expect(screen.getByText('1h')).toBeInTheDocument();
+  });
+
+  it('should show 0h for 0 minutes', () => {
+    render(
+      <StatsGrid
+        isLoading={false}
+        stats={{ completedBooks: 0, currentlyReading: 0, readingTimeThisMonth: 0, wishlist: 0 }}
+      />
+    );
+    // There may be multiple '0h', ensure at least one is present
+    const zeroHours = screen.getAllByText('0h');
+    expect(zeroHours.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should show 0h for negative minutes', () => {
+    render(
+      <StatsGrid
+        isLoading={false}
+        stats={{ completedBooks: 0, currentlyReading: 0, readingTimeThisMonth: -10, wishlist: 0 }}
+      />
+    );
+    const zeroHoursNeg = screen.getAllByText('0h');
+    expect(zeroHoursNeg.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/packages/ui/src/main/library-page/home-stats/index.test.tsx
+++ b/packages/ui/src/main/library-page/home-stats/index.test.tsx
@@ -39,7 +39,7 @@ describe('StatsGrid', () => {
     expect(screen.getByText('3')).toBeInTheDocument();
     expect(screen.getByText('Currently Reading')).toBeInTheDocument();
     // This Month (should include suffix 'h')
-    expect(screen.getByText('8h')).toBeInTheDocument();
+    expect(screen.getByText('8m')).toBeInTheDocument();
     expect(screen.getByText('This Month')).toBeInTheDocument();
     // Wishlist
     expect(screen.getByText('2')).toBeInTheDocument();

--- a/packages/ui/src/main/library-page/home-stats/index.tsx
+++ b/packages/ui/src/main/library-page/home-stats/index.tsx
@@ -43,7 +43,7 @@ const statItems = [
     icon: ScheduleIcon,
     color: '#9333ea',
     bgcolor: '#f3e8ff',
-    suffix: 'h',
+    suffix: 'm',
   },
   {
     key: 'wishlist',

--- a/packages/ui/src/main/library-page/home-stats/index.tsx
+++ b/packages/ui/src/main/library-page/home-stats/index.tsx
@@ -43,7 +43,7 @@ const statItems = [
     icon: ScheduleIcon,
     color: '#9333ea',
     bgcolor: '#f3e8ff',
-    suffix: 'm',
+    suffix: 'h',
   },
   {
     key: 'wishlist',
@@ -127,7 +127,11 @@ const StatsGrid: React.FC<StatsGridProps> = props => {
       <Grid container spacing={{ xs: 2, md: 3 }}>
         {statItems.map(item => {
           const IconComponent = item.icon;
-          const value = stats?.[item.key] ?? 0;
+          let value = stats?.[item.key] ?? 0;
+          // Convert minutes to hours for readingTimeThisMonth
+          if (item.key === 'readingTimeThisMonth') {
+            value = Math.round(value / 60);
+          }
 
           return (
             <Grid item xs={6} md={3} key={item.key}>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reading time for the month is now displayed in hours, rounded to the nearest hour.
* **Tests**
  * Added tests to verify correct rounding and display of monthly reading time in hours, including edge cases for zero and negative values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->