### PR TITLE
fix(til): add Box import and blockquote styling to markdown

### DIFF
--- a/apps/til/src/components/markdown/index.tsx
+++ b/apps/til/src/components/markdown/index.tsx
@@ -4,6 +4,7 @@ import React, { useMemo } from 'react';
  * TODO
  * Dynamic loading or using RSC in the future
  */
+import Box from '@mui/material/Box';
 import Markdown from 'react-markdown';
 import { CodeBlock } from './code-block';
 
@@ -31,6 +32,25 @@ const MarkdownContent = React.memo((props: MarkdownContentProps) => {
   return (
     <Markdown
       components={{
+        blockquote({ children }) {
+          return (
+            <Box
+              component="blockquote"
+              sx={{
+                borderLeft: 4,
+                borderColor: 'primary.main',
+                pl: 2,
+                py: 1,
+                my: 2,
+                mx: 0,
+                bgcolor: 'action.hover',
+                '& p': { m: 0 },
+              }}
+            >
+              {children}
+            </Box>
+          );
+        },
         code({ node, inline, className, children, ...props }) {
           const match = /language-(\w+)/.exec(className || '');
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Blockquote styling has been significantly enhanced throughout the application. Markdown blockquotes now display with a distinctive left border accent, refined padding and margins for improved spacing, and interactive hover effects that highlight quoted content, together improving readability and visual hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->