### PR TITLE
feat(til): move write button to sidebar

### DIFF
--- a/apps/til/src/components/layout/Header.tsx
+++ b/apps/til/src/components/layout/Header.tsx
@@ -1,7 +1,6 @@
 import AccountCircle from '@mui/icons-material/AccountCircle';
 import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
 import Toolbar from '@mui/material/Toolbar';
 import type { Auth } from 'core';
@@ -56,17 +55,6 @@ const Header = (props: HeaderProps) => {
             alignItems: 'center',
           }}
         >
-          {user && LinkComponent && (
-            <LinkComponent to="/write">
-              <Button
-                color="inherit"
-                sx={{ mr: 1, textTransform: 'none', fontWeight: 500 }}
-              >
-                Write
-              </Button>
-            </LinkComponent>
-          )}
-
           <IconButton onClick={!user ? login : toggleSidebar}>
             {avatarUrl ? (
               <ResponsiveAvatar

--- a/apps/til/src/components/layout/index.tsx
+++ b/apps/til/src/components/layout/index.tsx
@@ -34,6 +34,7 @@ const Layout = (props: LayoutProps) => {
       <SettingsPanel
         open={sidebarOpen}
         toggle={setSidebarOpen}
+        LinkComponent={Link}
         actions={{
           logout: signOut,
         }}

--- a/packages/ui/src/til/settings/index.tsx
+++ b/packages/ui/src/til/settings/index.tsx
@@ -1,3 +1,4 @@
+import EditIcon from '@mui/icons-material/Edit';
 import Logout from '@mui/icons-material/Logout';
 import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
@@ -6,6 +7,7 @@ import List from '@mui/material/List';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
+import type { ReactNode } from 'react';
 
 interface SettingsPanelProps {
   open: boolean;
@@ -13,14 +15,22 @@ interface SettingsPanelProps {
   actions: {
     logout: () => void;
   };
+  LinkComponent?: ({
+    to,
+    children,
+  }: {
+    to: string;
+    children: ReactNode;
+  }) => ReactNode;
 }
 
 const texts = {
   logout: 'Logout',
+  write: 'Write',
 };
 
 const SettingsPanel = (props: SettingsPanelProps) => {
-  const { open, toggle, actions } = props;
+  const { open, toggle, actions, LinkComponent } = props;
   const { logout } = actions;
 
   return (
@@ -33,7 +43,16 @@ const SettingsPanel = (props: SettingsPanelProps) => {
           flexDirection: 'column',
         }}
       >
-        <List sx={{ flex: 1 }} />
+        <List sx={{ flex: 1 }}>
+          {LinkComponent && (
+            <ListItemButton component={LinkComponent} to="/write">
+              <ListItemIcon>
+                <EditIcon />
+              </ListItemIcon>
+              <ListItemText primary={texts.write} />
+            </ListItemButton>
+          )}
+        </List>
         <Divider />
         <List>
           <ListItemButton onClick={logout}>


### PR DESCRIPTION
Moves the write button from the header to the sidebar (SettingsPanel) for better UI organization.

Changes:
- Removes the write button from the Header component
- Adds a write button with EditIcon to the SettingsPanel sidebar
- Passes LinkComponent to SettingsPanel to enable navigation
- Updates SettingsPanel interface to accept LinkComponent prop

This provides a cleaner header and groups navigation items in the sidebar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * "Write" navigation option relocated to the settings panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->