### PR TITLE
[WIP] feat(main): add logout to home screen via settings drawer

### DIFF
--- a/apps/main/src/components/layout/index.tsx
+++ b/apps/main/src/components/layout/index.tsx
@@ -1,6 +1,8 @@
 import { useAuthContext } from 'core/providers/auth';
 import type React from 'react';
+import { useState } from 'react';
 import { Header } from 'ui/main/header';
+import { SettingsPanel } from 'ui/main/home-page/settings';
 import { FullWidthContainer } from 'ui/universal/containers/full-width';
 
 interface LayoutProps {
@@ -9,10 +11,12 @@ interface LayoutProps {
 
 const Layout = (props: LayoutProps) => {
   const { children } = props;
-  const { user, signIn } = useAuthContext();
+  const { user, signIn, signOut } = useAuthContext();
+  const [settingsOpen, toggleSettings] = useState<boolean>(false);
+
   const onProfileClick = () => {
     if (user) {
-      return;
+      toggleSettings(true);
     } else {
       signIn();
     }
@@ -21,6 +25,11 @@ const Layout = (props: LayoutProps) => {
   return (
     <FullWidthContainer>
       <Header user={user} onProfileClick={onProfileClick} />
+      <SettingsPanel
+        open={settingsOpen}
+        toggle={toggleSettings}
+        actions={{ logout: signOut }}
+      />
       {children}
     </FullWidthContainer>
   );

--- a/packages/ui/src/main/home-page/settings/index.test.tsx
+++ b/packages/ui/src/main/home-page/settings/index.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { SettingsPanel } from '.';
+import '@testing-library/jest-dom';
+
+describe('SettingsPanel', () => {
+  const defaultProps = {
+    open: true,
+    toggle: vi.fn(),
+    actions: {
+      logout: vi.fn(),
+    },
+  };
+
+  it('renders the logout option when open', () => {
+    render(<SettingsPanel {...defaultProps} />);
+
+    expect(screen.getByText('Logout')).toBeInTheDocument();
+    expect(screen.getByTestId('LogoutIcon')).toBeInTheDocument();
+  });
+
+  it('does not render when closed', () => {
+    render(<SettingsPanel {...defaultProps} open={false} />);
+
+    expect(screen.queryByText('Logout')).not.toBeInTheDocument();
+  });
+
+  it('calls logout when the logout option is clicked', () => {
+    render(<SettingsPanel {...defaultProps} />);
+
+    fireEvent.click(screen.getByText('Logout'));
+
+    expect(defaultProps.actions.logout).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls toggle with false when the drawer backdrop is clicked', () => {
+    render(<SettingsPanel {...defaultProps} />);
+
+    const backdrop = screen.getByRole('presentation').firstChild;
+    fireEvent.click(backdrop as Element);
+
+    expect(defaultProps.toggle).toHaveBeenCalledWith(false);
+  });
+});

--- a/packages/ui/src/main/home-page/settings/index.test.tsx
+++ b/packages/ui/src/main/home-page/settings/index.test.tsx
@@ -25,11 +25,12 @@ describe('SettingsPanel', () => {
     expect(screen.queryByText('Logout')).not.toBeInTheDocument();
   });
 
-  it('calls logout when the logout option is clicked', () => {
+  it('closes the drawer and calls logout when the logout option is clicked', () => {
     render(<SettingsPanel {...defaultProps} />);
 
     fireEvent.click(screen.getByText('Logout'));
 
+    expect(defaultProps.toggle).toHaveBeenCalledWith(false);
     expect(defaultProps.actions.logout).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/ui/src/main/home-page/settings/index.tsx
+++ b/packages/ui/src/main/home-page/settings/index.tsx
@@ -1,0 +1,41 @@
+import Logout from '@mui/icons-material/Logout';
+import Box from '@mui/material/Box';
+import Drawer from '@mui/material/Drawer';
+import List from '@mui/material/List';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+
+interface SettingsPanelProps {
+  open: boolean;
+  toggle: React.Dispatch<React.SetStateAction<boolean>>;
+  actions: {
+    logout: () => void;
+  };
+}
+
+const texts = {
+  logout: 'Logout',
+};
+
+const SettingsPanel = (props: SettingsPanelProps) => {
+  const { open, toggle, actions } = props;
+  const { logout } = actions;
+
+  return (
+    <Drawer anchor="right" open={open} onClose={() => toggle(false)}>
+      <Box sx={{ width: 250, height: '100%' }}>
+        <List>
+          <ListItemButton onClick={logout}>
+            <ListItemIcon>
+              <Logout />
+            </ListItemIcon>
+            <ListItemText primary={texts.logout} />
+          </ListItemButton>
+        </List>
+      </Box>
+    </Drawer>
+  );
+};
+
+export { SettingsPanel };

--- a/packages/ui/src/main/home-page/settings/index.tsx
+++ b/packages/ui/src/main/home-page/settings/index.tsx
@@ -26,7 +26,12 @@ const SettingsPanel = (props: SettingsPanelProps) => {
     <Drawer anchor="right" open={open} onClose={() => toggle(false)}>
       <Box sx={{ width: 250, height: '100%' }}>
         <List>
-          <ListItemButton onClick={logout}>
+          <ListItemButton
+            onClick={() => {
+              toggle(false);
+              logout();
+            }}
+          >
             <ListItemIcon>
               <Logout />
             </ListItemIcon>


### PR DESCRIPTION
## Summary

The main app home screen had no way for a signed-in user to log out — the header avatar click only called `signIn()` when logged out and did nothing when logged in. `signOut` already existed in the auth context (`packages/core/src/providers/auth`) but was never surfaced.

This adds a watch-style `SettingsPanel` drawer (right anchor) with a **Logout** item, opened from the header avatar when signed in. Logged-out behavior is unchanged (avatar click starts sign-in).

- `packages/ui/src/main/home-page/settings/` — new minimal drawer (mirrors the watch `SettingsPanel`, without the watch-only upload button) + unit test.
- `apps/main/src/components/layout/index.tsx` — opens the drawer on profile click when signed in; passes `signOut` as the drawer's logout action.

Linear: SWO-249

## Test plan

- [x] `vitest` — new `SettingsPanel` test (renders/opens/calls logout/closes) + existing header test pass.
- [x] `biome check` clean on changed files; `ui` builds and emits the new subpath entry.
- [ ] Manual: sign in on main → click avatar → drawer opens → **Logout** signs out and returns to origin. Signed-out → avatar click still starts sign-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a settings panel accessible from the profile area.
  * Users can now open a side drawer to find a logout option.
* **Bug Fixes**
  * Profile clicks now open settings for signed-in users instead of doing nothing.
  * Closing the settings drawer now properly dismisses it from the screen.
* **Tests**
  * Added coverage for settings panel visibility, logout behavior, and drawer closing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->