### PR TITLE
[WIP] feat(watch): distinguish playlists and fix scroll + detail title

### DIFF
--- a/apps/watch/src/main.tsx
+++ b/apps/watch/src/main.tsx
@@ -19,6 +19,7 @@ const router = createRouter({
   routeTree,
   defaultViewTransition: true,
   defaultPreload: 'intent',
+  scrollRestoration: true,
   context: {
     auth: undefined!,
   },

--- a/packages/ui/src/watch/history-page/container/index.tsx
+++ b/packages/ui/src/watch/history-page/container/index.tsx
@@ -25,6 +25,7 @@ const HistoryContainer = (props: HistoryContainerProps) => {
   return (
     <Container
       maxWidth={false}
+      data-scroll-restoration-id="watch-history"
       sx={{ flex: 1, height: 0, py: 3, px: { xs: 2, sm: 3 }, overflow: 'auto' }}
     >
       <Grid container spacing={3}>

--- a/packages/ui/src/watch/home-page/container/index.tsx
+++ b/packages/ui/src/watch/home-page/container/index.tsx
@@ -32,6 +32,7 @@ const HomeContainer = (props: HomeContainerProps) => {
   return (
     <Container
       maxWidth={false}
+      data-scroll-restoration-id="watch-home"
       sx={{ flex: 1, height: 0, py: 3, px: { xs: 2, sm: 3 }, overflow: 'auto' }}
     >
       <Grid container spacing={3}>

--- a/packages/ui/src/watch/video-detail-page/containers/index.tsx
+++ b/packages/ui/src/watch/video-detail-page/containers/index.tsx
@@ -154,7 +154,7 @@ const MainContent = (props: VideoDetailContainerProps) => {
       <Stack direction="row" alignItems="center" spacing={1} sx={{ mt: 2 }}>
         {isPlaylist && (
           <Tooltip title="Playlist">
-            <PlaylistPlayIcon color="action" />
+            <PlaylistPlayIcon color="action" titleAccess="Playlist" />
           </Tooltip>
         )}
         <Typography

--- a/packages/ui/src/watch/video-detail-page/containers/index.tsx
+++ b/packages/ui/src/watch/video-detail-page/containers/index.tsx
@@ -1,6 +1,7 @@
 import EditIcon from '@mui/icons-material/Edit';
+import PlaylistPlayIcon from '@mui/icons-material/PlaylistPlay';
 import ShareIcon from '@mui/icons-material/Share';
-import { IconButton, Stack, Tooltip } from '@mui/material';
+import { Box, IconButton, Stack, Tooltip } from '@mui/material';
 import Chip from '@mui/material/Chip';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
@@ -44,7 +45,8 @@ const SubtitleDialog = React.lazy(() =>
 
 const MainContent = (props: VideoDetailContainerProps) => {
   const { queryRs, activeVideoId, onVideoEnded, autoPlay, onShare } = props;
-  const { isLoading, videos } = queryRs;
+  const { isLoading, videos, playlist } = queryRs;
+  const isPlaylist = Boolean(playlist);
 
   const { getAccessToken } = useAuthContext();
 
@@ -132,14 +134,29 @@ const MainContent = (props: VideoDetailContainerProps) => {
 
   return (
     <Grid item sx={{ width: '100%', px: 2 }}>
-      <VideoContainer
-        video={videoDetail}
-        onError={(err: unknown) => {
-          console.log(err);
+      <Box
+        sx={{
+          width: '100%',
+          // Cap the player so its 16:9 height never exceeds the viewport
+          // minus room for the header and the title/actions row below it.
+          maxWidth: 'calc((100vh - 220px) * 16 / 9)',
+          mx: 'auto',
         }}
-        onEnded={handleVideoEnd}
-      />
+      >
+        <VideoContainer
+          video={videoDetail}
+          onError={(err: unknown) => {
+            console.log(err);
+          }}
+          onEnded={handleVideoEnd}
+        />
+      </Box>
       <Stack direction="row" alignItems="center" spacing={1} sx={{ mt: 2 }}>
+        {isPlaylist && (
+          <Tooltip title="Playlist">
+            <PlaylistPlayIcon color="action" />
+          </Tooltip>
+        )}
         <Typography
           component="h1"
           variant="h4"
@@ -265,7 +282,7 @@ const VideoDetailContainer = (props: VideoDetailContainerProps) => {
 
   return (
     <Grid container spacing={2} sx={{ mt: 0 }}>
-      <Grid container item alignItems="center" xs={12} sm={6} md={8} lg={9}>
+      <Grid container item alignItems="flex-start" xs={12} sm={6} md={8} lg={9}>
         <MainContent
           {...props}
           onVideoEnded={handleVideoEnded}

--- a/packages/ui/src/watch/videos/video-card/index.tsx
+++ b/packages/ui/src/watch/videos/video-card/index.tsx
@@ -50,6 +50,7 @@ const VideoCardContent = (props: VideoCardContentProps) => {
 const PlaylistBadge = () => {
   return (
     <Box
+      role="img"
       aria-label="Playlist"
       sx={{
         position: 'absolute',

--- a/packages/ui/src/watch/videos/video-card/index.tsx
+++ b/packages/ui/src/watch/videos/video-card/index.tsx
@@ -1,3 +1,4 @@
+import PlaylistPlayIcon from '@mui/icons-material/PlaylistPlay';
 import Box from '@mui/material/Box';
 import CardContent from '@mui/material/CardContent';
 import Typography from '@mui/material/Typography';
@@ -43,6 +44,28 @@ const VideoCardContent = (props: VideoCardContentProps) => {
         {creator} • {createdTime}
       </Typography>
     </CardContent>
+  );
+};
+
+const PlaylistBadge = () => {
+  return (
+    <Box
+      aria-label="Playlist"
+      sx={{
+        position: 'absolute',
+        top: 8,
+        right: 8,
+        display: 'flex',
+        alignItems: 'center',
+        bgcolor: 'rgba(0, 0, 0, 0.75)',
+        color: 'common.white',
+        borderRadius: 1,
+        px: 0.5,
+        py: 0.25,
+      }}
+    >
+      <PlaylistPlayIcon sx={{ fontSize: 18 }} />
+    </Box>
   );
 };
 
@@ -94,6 +117,7 @@ const VideoContent = (props: VideoContentProps) => {
     return (
       <Box sx={{ position: 'relative' }}>
         <VideoThumbnail src={video.thumbnailUrl} title={video.title} />
+        {video.type === MEDIA_TYPES.PLAYLIST && <PlaylistBadge />}
         <VideoProgress video={video} />
       </Box>
     );
@@ -103,6 +127,7 @@ const VideoContent = (props: VideoContentProps) => {
     return (
       <Box sx={{ position: 'relative' }}>
         <VideoThumbnail src={video.thumbnailUrl} title={video.title} />
+        <PlaylistBadge />
       </Box>
     );
   }


### PR DESCRIPTION
## Summary

Three Watch fixes. Playlists and standalone videos now look the same in the grid and on the video page — this adds a small playlist icon so you can tell them apart. Returning from a video to the list used to jump back to the top; it now keeps your place. And on the video page the title and the share/edit buttons could be cut off below the player on wide screens — they're now always visible.

## Test plan

- [ ] Open the **Watch** home grid. Items that are playlists show a small playlist icon in the top-right of the thumbnail; single videos don't.
- [ ] Scroll down the grid, open a video, then press back. The list returns to the same scroll position, not the top.
- [ ] Open a video on a wide window. The title and the share/edit buttons sit fully visible right under the player, not clipped.
- [ ] Open a playlist video — a playlist icon appears next to the title.
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scroll restoration support in the watch area so pages can return to the previous scroll position.
  * Video cards and video detail pages now show a playlist indicator when content belongs to a playlist.
  * Improved video detail layout to better present playlist context and keep the player within view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->