### PR TITLE
[WIP] fix(auth): use a host-only cookie on localhost so local login works

### DIFF
--- a/apps/watch/src/config.ts
+++ b/apps/watch/src/config.ts
@@ -1,10 +1,17 @@
 const hasuraGraphqlUrl = `${import.meta.env.VITE_HASURA_DOMAIN}/v1/graphql`;
 
+// On localhost there are no sibling subdomains to share a session with, and a
+// `.localhost` cookie domain is rejected by browsers — which breaks the Auth0
+// login handshake. Omit cookieDomain locally so a host-only cookie is used.
+const isLocalhost = window.location.hostname === 'localhost';
+
 const auth0Config = {
   domain: import.meta.env.VITE_AUTH0_DOMAIN,
   clientId: import.meta.env.VITE_AUTH0_CLIENT_ID,
   audience: hasuraGraphqlUrl,
-  cookieDomain: `.${import.meta.env.VITE_MAIN_SITE_URL}`,
+  cookieDomain: isLocalhost
+    ? undefined
+    : `.${import.meta.env.VITE_MAIN_SITE_URL}`,
   redirectUri: window.location.origin,
 };
 const queryConfig = {

--- a/packages/core/src/providers/auth/index.tsx
+++ b/packages/core/src/providers/auth/index.tsx
@@ -27,7 +27,7 @@ interface Auth0Config {
   clientId: string;
   audience: string;
   redirectUri: string;
-  cookieDomain: string;
+  cookieDomain?: string;
 }
 
 interface Props {


### PR DESCRIPTION
## Summary

No user-facing changes (local development only). On localhost the Auth0 cookie domain was being built as `.localhost`, which browsers reject, so the login handshake never completed and you couldn't sign in to a locally-running app. This omits the cookie domain on localhost so a normal host-only cookie is used. Production behaviour is unchanged — it still scopes the cookie to the shared parent domain for cross-subdomain single sign-on.

## Test plan

- [ ] Run an app locally (e.g. `pnpm dev:watch`) against a dev tenant that allows the localhost callback, and sign in. Login completes instead of looping back to the login screen.
- [ ] Production/deployed builds still sign in as before.
- [ ] CI green