### PR TITLE
[WIP] chore(watch): trigger deploy to verify Cloudflare Pages pipeline

### DIFF
--- a/apps/watch/src/main.tsx
+++ b/apps/watch/src/main.tsx
@@ -12,6 +12,7 @@ import {
 } from './config';
 import { routeTree } from './routeTree.gen';
 
+// Trigger a production build to verify the Cloudflare Pages deploy pipeline.
 validateEnvVars();
 
 // @ts-expect-error


### PR DESCRIPTION
## Summary

No user-facing changes. Adds a single comment in the Watch app entry file so a production build is triggered. Purpose: verify the Cloudflare Pages deploy pipeline picks up changes under `apps/watch/` after the build-watch-paths fix (`/**` → `/*`). Safe to revert once the deploy is confirmed.

## Test plan

- [ ] Merging this triggers a Cloudflare Pages production build for the Watch project.
- [ ] After it deploys, `https://watch.shinabr2.com` serves a new `index.lazy-*` bundle (containing the earlier watch changes), not the old one.
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a build-check note to help validate the deployment pipeline during production releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->