### PR TITLE
[WIP] feat(til): thread pinned through post queries (SWO-253)

### DIFF
--- a/packages/core/schema.graphql
+++ b/packages/core/schema.graphql
@@ -72,6 +72,26 @@ input Int_comparison_exp {
   _nin: [Int!]
 }
 
+input SignedUploadUrlInput {
+  action: String!
+  contentType: String!
+  id: String
+  site: String!
+}
+
+type SignedUploadUrlOutput {
+  expiresAt: String!
+  objectPath: String!
+  publicUrl: String!
+  uploadUrl: String!
+}
+
+type SignedUploadUrlResponse {
+  dataObject: SignedUploadUrlOutput
+  message: String!
+  success: Boolean!
+}
+
 """
 Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'.
 """
@@ -4057,6 +4077,10 @@ type mutation_root {
     input: CreateDeviceRequestInput!
   ): CreateDeviceRequestResponse!
   """
+  Generate a V4 signed PUT URL for a direct browser-to-GCS upload (app-agnostic).
+  """
+  createSignedUploadUrl(input: SignedUploadUrlInput!): SignedUploadUrlResponse!
+  """
   delete data from the table: "audio_tags"
   """
   delete_audio_tags(
@@ -7792,6 +7816,7 @@ type posts {
   hId: String
   id: uuid!
   markdownContent: String!
+  pinned: Boolean!
   readTimeInMinutes: Int!
   slug: String!
   status: String!
@@ -7845,6 +7870,7 @@ input posts_bool_exp {
   hId: String_comparison_exp
   id: uuid_comparison_exp
   markdownContent: String_comparison_exp
+  pinned: Boolean_comparison_exp
   readTimeInMinutes: Int_comparison_exp
   slug: String_comparison_exp
   status: String_comparison_exp
@@ -7887,6 +7913,7 @@ input posts_insert_input {
   hId: String
   id: uuid
   markdownContent: String
+  pinned: Boolean
   readTimeInMinutes: Int
   slug: String
   status: String
@@ -7970,6 +7997,7 @@ input posts_order_by {
   hId: order_by
   id: order_by
   markdownContent: order_by
+  pinned: order_by
   readTimeInMinutes: order_by
   slug: order_by
   status: order_by
@@ -8016,6 +8044,10 @@ enum posts_select_column {
   """
   column name
   """
+  pinned
+  """
+  column name
+  """
   readTimeInMinutes
   """
   column name
@@ -8052,6 +8084,7 @@ input posts_set_input {
   hId: String
   id: uuid
   markdownContent: String
+  pinned: Boolean
   readTimeInMinutes: Int
   slug: String
   status: String
@@ -8108,6 +8141,7 @@ input posts_stream_cursor_value_input {
   hId: String
   id: uuid
   markdownContent: String
+  pinned: Boolean
   readTimeInMinutes: Int
   slug: String
   status: String
@@ -8151,6 +8185,10 @@ enum posts_update_column {
   column name
   """
   markdownContent
+  """
+  column name
+  """
+  pinned
   """
   column name
   """
@@ -16334,6 +16372,15 @@ type videos {
   """
   keepOriginalSource: Boolean
   """
+  Processing hints (input: customRequestHeaders) and failure record (output: lastError) for the reliability flow
+  """
+  metadata(
+    """
+    JSON select path
+    """
+    path: String
+  ): jsonb
+  """
   An array relationship
   """
   playlist_videos(
@@ -16384,6 +16431,10 @@ type videos {
     where: playlist_videos_bool_exp
   ): playlist_videos_aggregate!
   public: Boolean!
+  """
+  Bump to request a reprocess; an update-event on this column re-enqueues processing
+  """
+  retry_count: Int!
   """
   short id like Youtube video id
   """
@@ -16749,6 +16800,10 @@ append existing jsonb value of filtered columns with new jsonb value
 """
 input videos_append_input {
   """
+  Processing hints (input: customRequestHeaders) and failure record (output: lastError) for the reliability flow
+  """
+  metadata: jsonb
+  """
   List of shared recipient emails after validated by the system, should use this field to show for end users. Only system can update this field. End user should NOT know the real shared user ids.
   """
   sharedRecipients: jsonb
@@ -16774,6 +16829,10 @@ aggregate avg on columns
 """
 type videos_avg_fields {
   duration: Float
+  """
+  Bump to request a reprocess; an update-event on this column re-enqueues processing
+  """
+  retry_count: Float
   view_count: Float
 }
 
@@ -16782,6 +16841,10 @@ order by avg() on columns of table "videos"
 """
 input videos_avg_order_by {
   duration: order_by
+  """
+  Bump to request a reprocess; an update-event on this column re-enqueues processing
+  """
+  retry_count: order_by
   view_count: order_by
 }
 
@@ -16797,9 +16860,11 @@ input videos_bool_exp {
   duration: Int_comparison_exp
   id: uuid_comparison_exp
   keepOriginalSource: Boolean_comparison_exp
+  metadata: jsonb_comparison_exp
   playlist_videos: playlist_videos_bool_exp
   playlist_videos_aggregate: playlist_videos_aggregate_bool_exp
   public: Boolean_comparison_exp
+  retry_count: Int_comparison_exp
   sId: String_comparison_exp
   sharedRecipients: jsonb_comparison_exp
   sharedRecipientsInput: jsonb_comparison_exp
@@ -16849,6 +16914,10 @@ delete the field or element with specified path (for JSON arrays, negative integ
 """
 input videos_delete_at_path_input {
   """
+  Processing hints (input: customRequestHeaders) and failure record (output: lastError) for the reliability flow
+  """
+  metadata: [String!]
+  """
   List of shared recipient emails after validated by the system, should use this field to show for end users. Only system can update this field. End user should NOT know the real shared user ids.
   """
   sharedRecipients: [String!]
@@ -16862,6 +16931,10 @@ input videos_delete_at_path_input {
 delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array
 """
 input videos_delete_elem_input {
+  """
+  Processing hints (input: customRequestHeaders) and failure record (output: lastError) for the reliability flow
+  """
+  metadata: Int
   """
   List of shared recipient emails after validated by the system, should use this field to show for end users. Only system can update this field. End user should NOT know the real shared user ids.
   """
@@ -16877,6 +16950,10 @@ delete key/value pair or string element. key/value pairs are matched based on th
 """
 input videos_delete_key_input {
   """
+  Processing hints (input: customRequestHeaders) and failure record (output: lastError) for the reliability flow
+  """
+  metadata: String
+  """
   List of shared recipient emails after validated by the system, should use this field to show for end users. Only system can update this field. End user should NOT know the real shared user ids.
   """
   sharedRecipients: String
@@ -16891,6 +16968,10 @@ input type for incrementing numeric columns in table "videos"
 """
 input videos_inc_input {
   duration: Int
+  """
+  Bump to request a reprocess; an update-event on this column re-enqueues processing
+  """
+  retry_count: Int
   view_count: Int
 }
 
@@ -16906,8 +16987,16 @@ input videos_insert_input {
   When this field is true, keep the source field as video_url without any video processing
   """
   keepOriginalSource: Boolean
+  """
+  Processing hints (input: customRequestHeaders) and failure record (output: lastError) for the reliability flow
+  """
+  metadata: jsonb
   playlist_videos: playlist_videos_arr_rel_insert_input
   public: Boolean
+  """
+  Bump to request a reprocess; an update-event on this column re-enqueues processing
+  """
+  retry_count: Int
   """
   short id like Youtube video id
   """
@@ -16950,6 +17039,10 @@ type videos_max_fields {
   duration: Int
   id: uuid
   """
+  Bump to request a reprocess; an update-event on this column re-enqueues processing
+  """
+  retry_count: Int
+  """
   short id like Youtube video id
   """
   sId: String
@@ -16972,6 +17065,10 @@ input videos_max_order_by {
   description: order_by
   duration: order_by
   id: order_by
+  """
+  Bump to request a reprocess; an update-event on this column re-enqueues processing
+  """
+  retry_count: order_by
   """
   short id like Youtube video id
   """
@@ -16996,6 +17093,10 @@ type videos_min_fields {
   duration: Int
   id: uuid
   """
+  Bump to request a reprocess; an update-event on this column re-enqueues processing
+  """
+  retry_count: Int
+  """
   short id like Youtube video id
   """
   sId: String
@@ -17018,6 +17119,10 @@ input videos_min_order_by {
   description: order_by
   duration: order_by
   id: order_by
+  """
+  Bump to request a reprocess; an update-event on this column re-enqueues processing
+  """
+  retry_count: order_by
   """
   short id like Youtube video id
   """
@@ -17076,8 +17181,10 @@ input videos_order_by {
   duration: order_by
   id: order_by
   keepOriginalSource: order_by
+  metadata: order_by
   playlist_videos_aggregate: playlist_videos_aggregate_order_by
   public: order_by
+  retry_count: order_by
   sId: order_by
   sharedRecipients: order_by
   sharedRecipientsInput: order_by
@@ -17110,6 +17217,10 @@ input videos_pk_columns_input {
 prepend existing jsonb value of filtered columns with new jsonb value
 """
 input videos_prepend_input {
+  """
+  Processing hints (input: customRequestHeaders) and failure record (output: lastError) for the reliability flow
+  """
+  metadata: jsonb
   """
   List of shared recipient emails after validated by the system, should use this field to show for end users. Only system can update this field. End user should NOT know the real shared user ids.
   """
@@ -17147,7 +17258,15 @@ enum videos_select_column {
   """
   column name
   """
+  metadata
+  """
+  column name
+  """
   public
+  """
+  column name
+  """
+  retry_count
   """
   column name
   """
@@ -17250,7 +17369,15 @@ input videos_set_input {
   When this field is true, keep the source field as video_url without any video processing
   """
   keepOriginalSource: Boolean
+  """
+  Processing hints (input: customRequestHeaders) and failure record (output: lastError) for the reliability flow
+  """
+  metadata: jsonb
   public: Boolean
+  """
+  Bump to request a reprocess; an update-event on this column re-enqueues processing
+  """
+  retry_count: Int
   """
   short id like Youtube video id
   """
@@ -17283,6 +17410,10 @@ aggregate stddev on columns
 """
 type videos_stddev_fields {
   duration: Float
+  """
+  Bump to request a reprocess; an update-event on this column re-enqueues processing
+  """
+  retry_count: Float
   view_count: Float
 }
 
@@ -17291,6 +17422,10 @@ order by stddev() on columns of table "videos"
 """
 input videos_stddev_order_by {
   duration: order_by
+  """
+  Bump to request a reprocess; an update-event on this column re-enqueues processing
+  """
+  retry_count: order_by
   view_count: order_by
 }
 
@@ -17299,6 +17434,10 @@ aggregate stddev_pop on columns
 """
 type videos_stddev_pop_fields {
   duration: Float
+  """
+  Bump to request a reprocess; an update-event on this column re-enqueues processing
+  """
+  retry_count: Float
   view_count: Float
 }
 
@@ -17307,6 +17446,10 @@ order by stddev_pop() on columns of table "videos"
 """
 input videos_stddev_pop_order_by {
   duration: order_by
+  """
+  Bump to request a reprocess; an update-event on this column re-enqueues processing
+  """
+  retry_count: order_by
   view_count: order_by
 }
 
@@ -17315,6 +17458,10 @@ aggregate stddev_samp on columns
 """
 type videos_stddev_samp_fields {
   duration: Float
+  """
+  Bump to request a reprocess; an update-event on this column re-enqueues processing
+  """
+  retry_count: Float
   view_count: Float
 }
 
@@ -17323,6 +17470,10 @@ order by stddev_samp() on columns of table "videos"
 """
 input videos_stddev_samp_order_by {
   duration: order_by
+  """
+  Bump to request a reprocess; an update-event on this column re-enqueues processing
+  """
+  retry_count: order_by
   view_count: order_by
 }
 
@@ -17352,7 +17503,15 @@ input videos_stream_cursor_value_input {
   When this field is true, keep the source field as video_url without any video processing
   """
   keepOriginalSource: Boolean
+  """
+  Processing hints (input: customRequestHeaders) and failure record (output: lastError) for the reliability flow
+  """
+  metadata: jsonb
   public: Boolean
+  """
+  Bump to request a reprocess; an update-event on this column re-enqueues processing
+  """
+  retry_count: Int
   """
   short id like Youtube video id
   """
@@ -17385,6 +17544,10 @@ aggregate sum on columns
 """
 type videos_sum_fields {
   duration: Int
+  """
+  Bump to request a reprocess; an update-event on this column re-enqueues processing
+  """
+  retry_count: Int
   view_count: Int
 }
 
@@ -17393,6 +17556,10 @@ order by sum() on columns of table "videos"
 """
 input videos_sum_order_by {
   duration: order_by
+  """
+  Bump to request a reprocess; an update-event on this column re-enqueues processing
+  """
+  retry_count: order_by
   view_count: order_by
 }
 
@@ -17423,7 +17590,15 @@ enum videos_update_column {
   """
   column name
   """
+  metadata
+  """
+  column name
+  """
   public
+  """
+  column name
+  """
+  retry_count
   """
   column name
   """
@@ -17518,6 +17693,10 @@ aggregate var_pop on columns
 """
 type videos_var_pop_fields {
   duration: Float
+  """
+  Bump to request a reprocess; an update-event on this column re-enqueues processing
+  """
+  retry_count: Float
   view_count: Float
 }
 
@@ -17526,6 +17705,10 @@ order by var_pop() on columns of table "videos"
 """
 input videos_var_pop_order_by {
   duration: order_by
+  """
+  Bump to request a reprocess; an update-event on this column re-enqueues processing
+  """
+  retry_count: order_by
   view_count: order_by
 }
 
@@ -17534,6 +17717,10 @@ aggregate var_samp on columns
 """
 type videos_var_samp_fields {
   duration: Float
+  """
+  Bump to request a reprocess; an update-event on this column re-enqueues processing
+  """
+  retry_count: Float
   view_count: Float
 }
 
@@ -17542,6 +17729,10 @@ order by var_samp() on columns of table "videos"
 """
 input videos_var_samp_order_by {
   duration: order_by
+  """
+  Bump to request a reprocess; an update-event on this column re-enqueues processing
+  """
+  retry_count: order_by
   view_count: order_by
 }
 
@@ -17550,6 +17741,10 @@ aggregate variance on columns
 """
 type videos_variance_fields {
   duration: Float
+  """
+  Bump to request a reprocess; an update-event on this column re-enqueues processing
+  """
+  retry_count: Float
   view_count: Float
 }
 
@@ -17558,5 +17753,9 @@ order by variance() on columns of table "videos"
 """
 input videos_variance_order_by {
   duration: order_by
+  """
+  Bump to request a reprocess; an update-event on this column re-enqueues processing
+  """
+  retry_count: order_by
   view_count: order_by
 }

--- a/packages/core/src/graphql/gql.ts
+++ b/packages/core/src/graphql/gql.ts
@@ -32,8 +32,8 @@ type Documents = {
   '\n  query GetPublicAudiosAndFeelings @cached {\n    audios(where: { public: { _eq: true } }) {\n      id\n      name\n      source\n      thumbnailUrl\n      artistName\n      audio_tags {\n        tag_id\n      }\n    }\n    tags(where: { site: { _eq: "listen" }, audio_tags: { audio: { public: { _eq: true } } } }) {\n      id\n      name\n    }\n  }\n': typeof types.GetPublicAudiosAndFeelingsDocument;
   '\n  mutation InsertPost($object: posts_insert_input!) {\n    insert_posts_one(object: $object) {\n      id\n      title\n      slug\n      brief\n      markdownContent\n      readTimeInMinutes\n      created_at\n      updated_at\n    }\n  }\n': typeof types.InsertPostDocument;
   '\n  mutation UpdatePost($id: uuid!, $object: posts_set_input!) {\n    update_posts_by_pk(pk_columns: { id: $id }, _set: $object) {\n      id\n      title\n      slug\n      brief\n      markdownContent\n      readTimeInMinutes\n      created_at\n      updated_at\n      status\n    }\n  }\n': typeof types.UpdatePostDocument;
-  '\n  query Post($id: uuid!) {\n    posts_by_pk(id: $id) {\n      title\n      readTimeInMinutes\n      markdownContent\n      id\n      brief\n      slug\n      created_at\n      status\n      visibility\n    }\n  }\n': typeof types.PostDocument;
-  '\n  query AllPosts {\n    posts(order_by: { created_at: desc }) {\n      brief\n      id\n      markdownContent\n      readTimeInMinutes\n      title\n      slug\n      created_at\n      status\n      visibility\n    }\n  }\n': typeof types.AllPostsDocument;
+  '\n  query Post($id: uuid!) {\n    posts_by_pk(id: $id) {\n      title\n      readTimeInMinutes\n      markdownContent\n      id\n      brief\n      slug\n      created_at\n      status\n      visibility\n      pinned\n    }\n  }\n': typeof types.PostDocument;
+  '\n  query AllPosts {\n    posts(order_by: [{ pinned: desc }, { created_at: desc }]) {\n      brief\n      id\n      markdownContent\n      readTimeInMinutes\n      title\n      slug\n      created_at\n      status\n      visibility\n      pinned\n    }\n  }\n': typeof types.AllPostsDocument;
   '\n  subscription FeatureFlags {\n    feature_flag {\n      id\n      name\n      conditions\n    }\n  }\n': typeof types.FeatureFlagsDocument;
   '\n  mutation MarkNotificationAsRead($notificationId: uuid!) {\n    update_notifications_by_pk(pk_columns: { id: $notificationId }, _set: { readAt: "now()" }) {\n      id\n      readAt\n    }\n  }\n': typeof types.MarkNotificationAsReadDocument;
   '\n  mutation MarkNotificationsAsRead($ids: [uuid!]!) {\n    update_notifications(where: { id: { _in: $ids }, readAt: { _is_null: true } }, _set: { readAt: "now()" }) {\n      affected_rows\n      returning {\n        id\n        readAt\n      }\n    }\n  }\n': typeof types.MarkNotificationsAsReadDocument;
@@ -92,9 +92,9 @@ const documents: Documents = {
     types.InsertPostDocument,
   '\n  mutation UpdatePost($id: uuid!, $object: posts_set_input!) {\n    update_posts_by_pk(pk_columns: { id: $id }, _set: $object) {\n      id\n      title\n      slug\n      brief\n      markdownContent\n      readTimeInMinutes\n      created_at\n      updated_at\n      status\n    }\n  }\n':
     types.UpdatePostDocument,
-  '\n  query Post($id: uuid!) {\n    posts_by_pk(id: $id) {\n      title\n      readTimeInMinutes\n      markdownContent\n      id\n      brief\n      slug\n      created_at\n      status\n      visibility\n    }\n  }\n':
+  '\n  query Post($id: uuid!) {\n    posts_by_pk(id: $id) {\n      title\n      readTimeInMinutes\n      markdownContent\n      id\n      brief\n      slug\n      created_at\n      status\n      visibility\n      pinned\n    }\n  }\n':
     types.PostDocument,
-  '\n  query AllPosts {\n    posts(order_by: { created_at: desc }) {\n      brief\n      id\n      markdownContent\n      readTimeInMinutes\n      title\n      slug\n      created_at\n      status\n      visibility\n    }\n  }\n':
+  '\n  query AllPosts {\n    posts(order_by: [{ pinned: desc }, { created_at: desc }]) {\n      brief\n      id\n      markdownContent\n      readTimeInMinutes\n      title\n      slug\n      created_at\n      status\n      visibility\n      pinned\n    }\n  }\n':
     types.AllPostsDocument,
   '\n  subscription FeatureFlags {\n    feature_flag {\n      id\n      name\n      conditions\n    }\n  }\n':
     types.FeatureFlagsDocument,
@@ -252,13 +252,13 @@ export function graphql(
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(
-  source: '\n  query Post($id: uuid!) {\n    posts_by_pk(id: $id) {\n      title\n      readTimeInMinutes\n      markdownContent\n      id\n      brief\n      slug\n      created_at\n      status\n      visibility\n    }\n  }\n',
+  source: '\n  query Post($id: uuid!) {\n    posts_by_pk(id: $id) {\n      title\n      readTimeInMinutes\n      markdownContent\n      id\n      brief\n      slug\n      created_at\n      status\n      visibility\n      pinned\n    }\n  }\n',
 ): typeof import('./graphql').PostDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(
-  source: '\n  query AllPosts {\n    posts(order_by: { created_at: desc }) {\n      brief\n      id\n      markdownContent\n      readTimeInMinutes\n      title\n      slug\n      created_at\n      status\n      visibility\n    }\n  }\n',
+  source: '\n  query AllPosts {\n    posts(order_by: [{ pinned: desc }, { created_at: desc }]) {\n      brief\n      id\n      markdownContent\n      readTimeInMinutes\n      title\n      slug\n      created_at\n      status\n      visibility\n      pinned\n    }\n  }\n',
 ): typeof import('./graphql').AllPostsDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.

--- a/packages/core/src/graphql/graphql.ts
+++ b/packages/core/src/graphql/graphql.ts
@@ -88,6 +88,28 @@ export type Int_Comparison_Exp = {
   _nin?: InputMaybe<Array<Scalars['Int']['input']>>;
 };
 
+export type SignedUploadUrlInput = {
+  action: Scalars['String']['input'];
+  contentType: Scalars['String']['input'];
+  id?: InputMaybe<Scalars['String']['input']>;
+  site: Scalars['String']['input'];
+};
+
+export type SignedUploadUrlOutput = {
+  __typename?: 'SignedUploadUrlOutput';
+  expiresAt: Scalars['String']['output'];
+  objectPath: Scalars['String']['output'];
+  publicUrl: Scalars['String']['output'];
+  uploadUrl: Scalars['String']['output'];
+};
+
+export type SignedUploadUrlResponse = {
+  __typename?: 'SignedUploadUrlResponse';
+  dataObject?: Maybe<SignedUploadUrlOutput>;
+  message: Scalars['String']['output'];
+  success: Scalars['Boolean']['output'];
+};
+
 /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
 export type String_Comparison_Exp = {
   _eq?: InputMaybe<Scalars['String']['input']>;
@@ -3025,6 +3047,8 @@ export type Mutation_Root = {
   __typename?: 'mutation_root';
   /** Request to generate code for next step authentication, called from other sources like smart tivi apps, extensions, etc. */
   createDeviceRequest: CreateDeviceRequestResponse;
+  /** Generate a V4 signed PUT URL for a direct browser-to-GCS upload (app-agnostic). */
+  createSignedUploadUrl: SignedUploadUrlResponse;
   /** delete data from the table: "audio_tags" */
   delete_audio_tags?: Maybe<Audio_Tags_Mutation_Response>;
   /** delete single row from the table: "audio_tags" */
@@ -3402,6 +3426,11 @@ export type Mutation_Root = {
 /** mutation root */
 export type Mutation_RootCreateDeviceRequestArgs = {
   input: CreateDeviceRequestInput;
+};
+
+/** mutation root */
+export type Mutation_RootCreateSignedUploadUrlArgs = {
+  input: SignedUploadUrlInput;
 };
 
 /** mutation root */
@@ -5633,6 +5662,7 @@ export type Posts = {
   hId?: Maybe<Scalars['String']['output']>;
   id: Scalars['uuid']['output'];
   markdownContent: Scalars['String']['output'];
+  pinned: Scalars['Boolean']['output'];
   readTimeInMinutes: Scalars['Int']['output'];
   slug: Scalars['String']['output'];
   status: Scalars['String']['output'];
@@ -5687,6 +5717,7 @@ export type Posts_Bool_Exp = {
   hId?: InputMaybe<String_Comparison_Exp>;
   id?: InputMaybe<Uuid_Comparison_Exp>;
   markdownContent?: InputMaybe<String_Comparison_Exp>;
+  pinned?: InputMaybe<Boolean_Comparison_Exp>;
   readTimeInMinutes?: InputMaybe<Int_Comparison_Exp>;
   slug?: InputMaybe<String_Comparison_Exp>;
   status?: InputMaybe<String_Comparison_Exp>;
@@ -5717,6 +5748,7 @@ export type Posts_Insert_Input = {
   hId?: InputMaybe<Scalars['String']['input']>;
   id?: InputMaybe<Scalars['uuid']['input']>;
   markdownContent?: InputMaybe<Scalars['String']['input']>;
+  pinned?: InputMaybe<Scalars['Boolean']['input']>;
   readTimeInMinutes?: InputMaybe<Scalars['Int']['input']>;
   slug?: InputMaybe<Scalars['String']['input']>;
   status?: InputMaybe<Scalars['String']['input']>;
@@ -5785,6 +5817,7 @@ export type Posts_Order_By = {
   hId?: InputMaybe<Order_By>;
   id?: InputMaybe<Order_By>;
   markdownContent?: InputMaybe<Order_By>;
+  pinned?: InputMaybe<Order_By>;
   readTimeInMinutes?: InputMaybe<Order_By>;
   slug?: InputMaybe<Order_By>;
   status?: InputMaybe<Order_By>;
@@ -5813,6 +5846,8 @@ export enum Posts_Select_Column {
   /** column name */
   MarkdownContent = 'markdownContent',
   /** column name */
+  Pinned = 'pinned',
+  /** column name */
   ReadTimeInMinutes = 'readTimeInMinutes',
   /** column name */
   Slug = 'slug',
@@ -5835,6 +5870,7 @@ export type Posts_Set_Input = {
   hId?: InputMaybe<Scalars['String']['input']>;
   id?: InputMaybe<Scalars['uuid']['input']>;
   markdownContent?: InputMaybe<Scalars['String']['input']>;
+  pinned?: InputMaybe<Scalars['Boolean']['input']>;
   readTimeInMinutes?: InputMaybe<Scalars['Int']['input']>;
   slug?: InputMaybe<Scalars['String']['input']>;
   status?: InputMaybe<Scalars['String']['input']>;
@@ -5878,6 +5914,7 @@ export type Posts_Stream_Cursor_Value_Input = {
   hId?: InputMaybe<Scalars['String']['input']>;
   id?: InputMaybe<Scalars['uuid']['input']>;
   markdownContent?: InputMaybe<Scalars['String']['input']>;
+  pinned?: InputMaybe<Scalars['Boolean']['input']>;
   readTimeInMinutes?: InputMaybe<Scalars['Int']['input']>;
   slug?: InputMaybe<Scalars['String']['input']>;
   status?: InputMaybe<Scalars['String']['input']>;
@@ -5906,6 +5943,8 @@ export enum Posts_Update_Column {
   Id = 'id',
   /** column name */
   MarkdownContent = 'markdownContent',
+  /** column name */
+  Pinned = 'pinned',
   /** column name */
   ReadTimeInMinutes = 'readTimeInMinutes',
   /** column name */
@@ -10941,11 +10980,15 @@ export type Videos = {
   id: Scalars['uuid']['output'];
   /** When this field is true, keep the source field as video_url without any video processing */
   keepOriginalSource?: Maybe<Scalars['Boolean']['output']>;
+  /** Processing hints (input: customRequestHeaders) and failure record (output: lastError) for the reliability flow */
+  metadata?: Maybe<Scalars['jsonb']['output']>;
   /** An array relationship */
   playlist_videos: Array<Playlist_Videos>;
   /** An aggregate relationship */
   playlist_videos_aggregate: Playlist_Videos_Aggregate;
   public: Scalars['Boolean']['output'];
+  /** Bump to request a reprocess; an update-event on this column re-enqueues processing */
+  retry_count: Scalars['Int']['output'];
   /** short id like Youtube video id */
   sId?: Maybe<Scalars['String']['output']>;
   /** List of shared recipient emails after validated by the system, should use this field to show for end users. Only system can update this field. End user should NOT know the real shared user ids. */
@@ -10985,6 +11028,11 @@ export type Videos = {
   /** An aggregate relationship */
   video_views_aggregate: Video_Views_Aggregate;
   view_count?: Maybe<Scalars['Int']['output']>;
+};
+
+/** columns and relationships of "videos" */
+export type VideosMetadataArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** columns and relationships of "videos" */
@@ -11178,6 +11226,8 @@ export type Videos_Aggregate_Order_By = {
 
 /** append existing jsonb value of filtered columns with new jsonb value */
 export type Videos_Append_Input = {
+  /** Processing hints (input: customRequestHeaders) and failure record (output: lastError) for the reliability flow */
+  metadata?: InputMaybe<Scalars['jsonb']['input']>;
   /** List of shared recipient emails after validated by the system, should use this field to show for end users. Only system can update this field. End user should NOT know the real shared user ids. */
   sharedRecipients?: InputMaybe<Scalars['jsonb']['input']>;
   /** List of recipient emails from user input, not validated yet. End user can update this. */
@@ -11195,12 +11245,16 @@ export type Videos_Arr_Rel_Insert_Input = {
 export type Videos_Avg_Fields = {
   __typename?: 'videos_avg_fields';
   duration?: Maybe<Scalars['Float']['output']>;
+  /** Bump to request a reprocess; an update-event on this column re-enqueues processing */
+  retry_count?: Maybe<Scalars['Float']['output']>;
   view_count?: Maybe<Scalars['Float']['output']>;
 };
 
 /** order by avg() on columns of table "videos" */
 export type Videos_Avg_Order_By = {
   duration?: InputMaybe<Order_By>;
+  /** Bump to request a reprocess; an update-event on this column re-enqueues processing */
+  retry_count?: InputMaybe<Order_By>;
   view_count?: InputMaybe<Order_By>;
 };
 
@@ -11214,9 +11268,11 @@ export type Videos_Bool_Exp = {
   duration?: InputMaybe<Int_Comparison_Exp>;
   id?: InputMaybe<Uuid_Comparison_Exp>;
   keepOriginalSource?: InputMaybe<Boolean_Comparison_Exp>;
+  metadata?: InputMaybe<Jsonb_Comparison_Exp>;
   playlist_videos?: InputMaybe<Playlist_Videos_Bool_Exp>;
   playlist_videos_aggregate?: InputMaybe<Playlist_Videos_Aggregate_Bool_Exp>;
   public?: InputMaybe<Boolean_Comparison_Exp>;
+  retry_count?: InputMaybe<Int_Comparison_Exp>;
   sId?: InputMaybe<String_Comparison_Exp>;
   sharedRecipients?: InputMaybe<Jsonb_Comparison_Exp>;
   sharedRecipientsInput?: InputMaybe<Jsonb_Comparison_Exp>;
@@ -11255,6 +11311,8 @@ export enum Videos_Constraint {
 
 /** delete the field or element with specified path (for JSON arrays, negative integers count from the end) */
 export type Videos_Delete_At_Path_Input = {
+  /** Processing hints (input: customRequestHeaders) and failure record (output: lastError) for the reliability flow */
+  metadata?: InputMaybe<Array<Scalars['String']['input']>>;
   /** List of shared recipient emails after validated by the system, should use this field to show for end users. Only system can update this field. End user should NOT know the real shared user ids. */
   sharedRecipients?: InputMaybe<Array<Scalars['String']['input']>>;
   /** List of recipient emails from user input, not validated yet. End user can update this. */
@@ -11263,6 +11321,8 @@ export type Videos_Delete_At_Path_Input = {
 
 /** delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array */
 export type Videos_Delete_Elem_Input = {
+  /** Processing hints (input: customRequestHeaders) and failure record (output: lastError) for the reliability flow */
+  metadata?: InputMaybe<Scalars['Int']['input']>;
   /** List of shared recipient emails after validated by the system, should use this field to show for end users. Only system can update this field. End user should NOT know the real shared user ids. */
   sharedRecipients?: InputMaybe<Scalars['Int']['input']>;
   /** List of recipient emails from user input, not validated yet. End user can update this. */
@@ -11271,6 +11331,8 @@ export type Videos_Delete_Elem_Input = {
 
 /** delete key/value pair or string element. key/value pairs are matched based on their key value */
 export type Videos_Delete_Key_Input = {
+  /** Processing hints (input: customRequestHeaders) and failure record (output: lastError) for the reliability flow */
+  metadata?: InputMaybe<Scalars['String']['input']>;
   /** List of shared recipient emails after validated by the system, should use this field to show for end users. Only system can update this field. End user should NOT know the real shared user ids. */
   sharedRecipients?: InputMaybe<Scalars['String']['input']>;
   /** List of recipient emails from user input, not validated yet. End user can update this. */
@@ -11280,6 +11342,8 @@ export type Videos_Delete_Key_Input = {
 /** input type for incrementing numeric columns in table "videos" */
 export type Videos_Inc_Input = {
   duration?: InputMaybe<Scalars['Int']['input']>;
+  /** Bump to request a reprocess; an update-event on this column re-enqueues processing */
+  retry_count?: InputMaybe<Scalars['Int']['input']>;
   view_count?: InputMaybe<Scalars['Int']['input']>;
 };
 
@@ -11291,8 +11355,12 @@ export type Videos_Insert_Input = {
   id?: InputMaybe<Scalars['uuid']['input']>;
   /** When this field is true, keep the source field as video_url without any video processing */
   keepOriginalSource?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Processing hints (input: customRequestHeaders) and failure record (output: lastError) for the reliability flow */
+  metadata?: InputMaybe<Scalars['jsonb']['input']>;
   playlist_videos?: InputMaybe<Playlist_Videos_Arr_Rel_Insert_Input>;
   public?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Bump to request a reprocess; an update-event on this column re-enqueues processing */
+  retry_count?: InputMaybe<Scalars['Int']['input']>;
   /** short id like Youtube video id */
   sId?: InputMaybe<Scalars['String']['input']>;
   /** List of shared recipient emails after validated by the system, should use this field to show for end users. Only system can update this field. End user should NOT know the real shared user ids. */
@@ -11325,6 +11393,8 @@ export type Videos_Max_Fields = {
   description?: Maybe<Scalars['String']['output']>;
   duration?: Maybe<Scalars['Int']['output']>;
   id?: Maybe<Scalars['uuid']['output']>;
+  /** Bump to request a reprocess; an update-event on this column re-enqueues processing */
+  retry_count?: Maybe<Scalars['Int']['output']>;
   /** short id like Youtube video id */
   sId?: Maybe<Scalars['String']['output']>;
   slug?: Maybe<Scalars['String']['output']>;
@@ -11344,6 +11414,8 @@ export type Videos_Max_Order_By = {
   description?: InputMaybe<Order_By>;
   duration?: InputMaybe<Order_By>;
   id?: InputMaybe<Order_By>;
+  /** Bump to request a reprocess; an update-event on this column re-enqueues processing */
+  retry_count?: InputMaybe<Order_By>;
   /** short id like Youtube video id */
   sId?: InputMaybe<Order_By>;
   slug?: InputMaybe<Order_By>;
@@ -11364,6 +11436,8 @@ export type Videos_Min_Fields = {
   description?: Maybe<Scalars['String']['output']>;
   duration?: Maybe<Scalars['Int']['output']>;
   id?: Maybe<Scalars['uuid']['output']>;
+  /** Bump to request a reprocess; an update-event on this column re-enqueues processing */
+  retry_count?: Maybe<Scalars['Int']['output']>;
   /** short id like Youtube video id */
   sId?: Maybe<Scalars['String']['output']>;
   slug?: Maybe<Scalars['String']['output']>;
@@ -11383,6 +11457,8 @@ export type Videos_Min_Order_By = {
   description?: InputMaybe<Order_By>;
   duration?: InputMaybe<Order_By>;
   id?: InputMaybe<Order_By>;
+  /** Bump to request a reprocess; an update-event on this column re-enqueues processing */
+  retry_count?: InputMaybe<Order_By>;
   /** short id like Youtube video id */
   sId?: InputMaybe<Order_By>;
   slug?: InputMaybe<Order_By>;
@@ -11426,8 +11502,10 @@ export type Videos_Order_By = {
   duration?: InputMaybe<Order_By>;
   id?: InputMaybe<Order_By>;
   keepOriginalSource?: InputMaybe<Order_By>;
+  metadata?: InputMaybe<Order_By>;
   playlist_videos_aggregate?: InputMaybe<Playlist_Videos_Aggregate_Order_By>;
   public?: InputMaybe<Order_By>;
+  retry_count?: InputMaybe<Order_By>;
   sId?: InputMaybe<Order_By>;
   sharedRecipients?: InputMaybe<Order_By>;
   sharedRecipientsInput?: InputMaybe<Order_By>;
@@ -11456,6 +11534,8 @@ export type Videos_Pk_Columns_Input = {
 
 /** prepend existing jsonb value of filtered columns with new jsonb value */
 export type Videos_Prepend_Input = {
+  /** Processing hints (input: customRequestHeaders) and failure record (output: lastError) for the reliability flow */
+  metadata?: InputMaybe<Scalars['jsonb']['input']>;
   /** List of shared recipient emails after validated by the system, should use this field to show for end users. Only system can update this field. End user should NOT know the real shared user ids. */
   sharedRecipients?: InputMaybe<Scalars['jsonb']['input']>;
   /** List of recipient emails from user input, not validated yet. End user can update this. */
@@ -11475,7 +11555,11 @@ export enum Videos_Select_Column {
   /** column name */
   KeepOriginalSource = 'keepOriginalSource',
   /** column name */
+  Metadata = 'metadata',
+  /** column name */
   Public = 'public',
+  /** column name */
+  RetryCount = 'retry_count',
   /** column name */
   SId = 'sId',
   /** column name */
@@ -11532,7 +11616,11 @@ export type Videos_Set_Input = {
   id?: InputMaybe<Scalars['uuid']['input']>;
   /** When this field is true, keep the source field as video_url without any video processing */
   keepOriginalSource?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Processing hints (input: customRequestHeaders) and failure record (output: lastError) for the reliability flow */
+  metadata?: InputMaybe<Scalars['jsonb']['input']>;
   public?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Bump to request a reprocess; an update-event on this column re-enqueues processing */
+  retry_count?: InputMaybe<Scalars['Int']['input']>;
   /** short id like Youtube video id */
   sId?: InputMaybe<Scalars['String']['input']>;
   /** List of shared recipient emails after validated by the system, should use this field to show for end users. Only system can update this field. End user should NOT know the real shared user ids. */
@@ -11556,12 +11644,16 @@ export type Videos_Set_Input = {
 export type Videos_Stddev_Fields = {
   __typename?: 'videos_stddev_fields';
   duration?: Maybe<Scalars['Float']['output']>;
+  /** Bump to request a reprocess; an update-event on this column re-enqueues processing */
+  retry_count?: Maybe<Scalars['Float']['output']>;
   view_count?: Maybe<Scalars['Float']['output']>;
 };
 
 /** order by stddev() on columns of table "videos" */
 export type Videos_Stddev_Order_By = {
   duration?: InputMaybe<Order_By>;
+  /** Bump to request a reprocess; an update-event on this column re-enqueues processing */
+  retry_count?: InputMaybe<Order_By>;
   view_count?: InputMaybe<Order_By>;
 };
 
@@ -11569,12 +11661,16 @@ export type Videos_Stddev_Order_By = {
 export type Videos_Stddev_Pop_Fields = {
   __typename?: 'videos_stddev_pop_fields';
   duration?: Maybe<Scalars['Float']['output']>;
+  /** Bump to request a reprocess; an update-event on this column re-enqueues processing */
+  retry_count?: Maybe<Scalars['Float']['output']>;
   view_count?: Maybe<Scalars['Float']['output']>;
 };
 
 /** order by stddev_pop() on columns of table "videos" */
 export type Videos_Stddev_Pop_Order_By = {
   duration?: InputMaybe<Order_By>;
+  /** Bump to request a reprocess; an update-event on this column re-enqueues processing */
+  retry_count?: InputMaybe<Order_By>;
   view_count?: InputMaybe<Order_By>;
 };
 
@@ -11582,12 +11678,16 @@ export type Videos_Stddev_Pop_Order_By = {
 export type Videos_Stddev_Samp_Fields = {
   __typename?: 'videos_stddev_samp_fields';
   duration?: Maybe<Scalars['Float']['output']>;
+  /** Bump to request a reprocess; an update-event on this column re-enqueues processing */
+  retry_count?: Maybe<Scalars['Float']['output']>;
   view_count?: Maybe<Scalars['Float']['output']>;
 };
 
 /** order by stddev_samp() on columns of table "videos" */
 export type Videos_Stddev_Samp_Order_By = {
   duration?: InputMaybe<Order_By>;
+  /** Bump to request a reprocess; an update-event on this column re-enqueues processing */
+  retry_count?: InputMaybe<Order_By>;
   view_count?: InputMaybe<Order_By>;
 };
 
@@ -11607,7 +11707,11 @@ export type Videos_Stream_Cursor_Value_Input = {
   id?: InputMaybe<Scalars['uuid']['input']>;
   /** When this field is true, keep the source field as video_url without any video processing */
   keepOriginalSource?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Processing hints (input: customRequestHeaders) and failure record (output: lastError) for the reliability flow */
+  metadata?: InputMaybe<Scalars['jsonb']['input']>;
   public?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Bump to request a reprocess; an update-event on this column re-enqueues processing */
+  retry_count?: InputMaybe<Scalars['Int']['input']>;
   /** short id like Youtube video id */
   sId?: InputMaybe<Scalars['String']['input']>;
   /** List of shared recipient emails after validated by the system, should use this field to show for end users. Only system can update this field. End user should NOT know the real shared user ids. */
@@ -11631,12 +11735,16 @@ export type Videos_Stream_Cursor_Value_Input = {
 export type Videos_Sum_Fields = {
   __typename?: 'videos_sum_fields';
   duration?: Maybe<Scalars['Int']['output']>;
+  /** Bump to request a reprocess; an update-event on this column re-enqueues processing */
+  retry_count?: Maybe<Scalars['Int']['output']>;
   view_count?: Maybe<Scalars['Int']['output']>;
 };
 
 /** order by sum() on columns of table "videos" */
 export type Videos_Sum_Order_By = {
   duration?: InputMaybe<Order_By>;
+  /** Bump to request a reprocess; an update-event on this column re-enqueues processing */
+  retry_count?: InputMaybe<Order_By>;
   view_count?: InputMaybe<Order_By>;
 };
 
@@ -11653,7 +11761,11 @@ export enum Videos_Update_Column {
   /** column name */
   KeepOriginalSource = 'keepOriginalSource',
   /** column name */
+  Metadata = 'metadata',
+  /** column name */
   Public = 'public',
+  /** column name */
+  RetryCount = 'retry_count',
   /** column name */
   SId = 'sId',
   /** column name */
@@ -11705,12 +11817,16 @@ export type Videos_Updates = {
 export type Videos_Var_Pop_Fields = {
   __typename?: 'videos_var_pop_fields';
   duration?: Maybe<Scalars['Float']['output']>;
+  /** Bump to request a reprocess; an update-event on this column re-enqueues processing */
+  retry_count?: Maybe<Scalars['Float']['output']>;
   view_count?: Maybe<Scalars['Float']['output']>;
 };
 
 /** order by var_pop() on columns of table "videos" */
 export type Videos_Var_Pop_Order_By = {
   duration?: InputMaybe<Order_By>;
+  /** Bump to request a reprocess; an update-event on this column re-enqueues processing */
+  retry_count?: InputMaybe<Order_By>;
   view_count?: InputMaybe<Order_By>;
 };
 
@@ -11718,12 +11834,16 @@ export type Videos_Var_Pop_Order_By = {
 export type Videos_Var_Samp_Fields = {
   __typename?: 'videos_var_samp_fields';
   duration?: Maybe<Scalars['Float']['output']>;
+  /** Bump to request a reprocess; an update-event on this column re-enqueues processing */
+  retry_count?: Maybe<Scalars['Float']['output']>;
   view_count?: Maybe<Scalars['Float']['output']>;
 };
 
 /** order by var_samp() on columns of table "videos" */
 export type Videos_Var_Samp_Order_By = {
   duration?: InputMaybe<Order_By>;
+  /** Bump to request a reprocess; an update-event on this column re-enqueues processing */
+  retry_count?: InputMaybe<Order_By>;
   view_count?: InputMaybe<Order_By>;
 };
 
@@ -11731,12 +11851,16 @@ export type Videos_Var_Samp_Order_By = {
 export type Videos_Variance_Fields = {
   __typename?: 'videos_variance_fields';
   duration?: Maybe<Scalars['Float']['output']>;
+  /** Bump to request a reprocess; an update-event on this column re-enqueues processing */
+  retry_count?: Maybe<Scalars['Float']['output']>;
   view_count?: Maybe<Scalars['Float']['output']>;
 };
 
 /** order by variance() on columns of table "videos" */
 export type Videos_Variance_Order_By = {
   duration?: InputMaybe<Order_By>;
+  /** Bump to request a reprocess; an update-event on this column re-enqueues processing */
+  retry_count?: InputMaybe<Order_By>;
   view_count?: InputMaybe<Order_By>;
 };
 
@@ -12201,6 +12325,7 @@ export type PostQuery = {
     created_at: any;
     status: string;
     visibility: string;
+    pinned: boolean;
   } | null;
 };
 
@@ -12219,6 +12344,7 @@ export type AllPostsQuery = {
     created_at: any;
     status: string;
     visibility: string;
+    pinned: boolean;
   }>;
 };
 
@@ -13086,12 +13212,13 @@ export const PostDocument = new TypedDocumentString(`
     created_at
     status
     visibility
+    pinned
   }
 }
     `) as unknown as TypedDocumentString<PostQuery, PostQueryVariables>;
 export const AllPostsDocument = new TypedDocumentString(`
     query AllPosts {
-  posts(order_by: {created_at: desc}) {
+  posts(order_by: [{pinned: desc}, {created_at: desc}]) {
     brief
     id
     markdownContent
@@ -13101,6 +13228,7 @@ export const AllPostsDocument = new TypedDocumentString(`
     created_at
     status
     visibility
+    pinned
   }
 }
     `) as unknown as TypedDocumentString<AllPostsQuery, AllPostsQueryVariables>;

--- a/packages/core/src/til/query-hooks/post-detail/index.ts
+++ b/packages/core/src/til/query-hooks/post-detail/index.ts
@@ -16,6 +16,7 @@ const postDetailQuery = graphql(/* GraphQL */ `
       created_at
       status
       visibility
+      pinned
     }
   }
 `);

--- a/packages/core/src/til/query-hooks/posts/index.test.ts
+++ b/packages/core/src/til/query-hooks/posts/index.test.ts
@@ -18,6 +18,7 @@ const mockPosts = [
     brief: 'Test brief',
     markdownContent: '# Content',
     readTimeInMinutes: 5,
+    pinned: true,
   },
 ];
 
@@ -60,6 +61,7 @@ describe('useLoadPosts', () => {
         brief: 'Test brief',
         mContent: '# Content',
         readTimeInMinutes: 5,
+        pinned: true,
       },
     ]);
   });

--- a/packages/core/src/til/query-hooks/posts/index.ts
+++ b/packages/core/src/til/query-hooks/posts/index.ts
@@ -6,7 +6,7 @@ import { transformPost } from '../transformers';
 
 const postsQuery = graphql(/* GraphQL */ `
   query AllPosts {
-    posts(order_by: { created_at: desc }) {
+    posts(order_by: [{ pinned: desc }, { created_at: desc }]) {
       brief
       id
       markdownContent
@@ -16,6 +16,7 @@ const postsQuery = graphql(/* GraphQL */ `
       created_at
       status
       visibility
+      pinned
     }
   }
 `);

--- a/packages/core/src/til/query-hooks/transformers.test.ts
+++ b/packages/core/src/til/query-hooks/transformers.test.ts
@@ -10,6 +10,7 @@ describe('transformPost', () => {
       brief: 'Sample brief description',
       markdownContent: '# Hello World\nTest content',
       readTimeInMinutes: 5,
+      pinned: true,
     } as NonNullable<PostQuery['posts_by_pk']>;
 
     const result = transformPost(mockData);
@@ -20,6 +21,7 @@ describe('transformPost', () => {
       brief: 'Sample brief description',
       mContent: '# Hello World\nTest content',
       readTimeInMinutes: 5,
+      pinned: true,
     });
   });
 });

--- a/packages/core/src/til/query-hooks/transformers.ts
+++ b/packages/core/src/til/query-hooks/transformers.ts
@@ -11,6 +11,7 @@ const transformPost = (data: NonNullable<PostQuery['posts_by_pk']>) => {
     created_at,
     status,
     visibility,
+    pinned,
   } = data;
 
   return {
@@ -23,6 +24,7 @@ const transformPost = (data: NonNullable<PostQuery['posts_by_pk']>) => {
     createdAt: created_at,
     status,
     visibility,
+    pinned,
   };
 };
 


### PR DESCRIPTION
## Summary

Wave 2 of pinned posts (parent SWO-251; data layer SWO-252 already merged). Threads the `pinned` column through the TIL data layer so the UI can read it and pinned posts sort first.

- `query-hooks/posts/index.ts` — select `pinned`; order `[{ pinned: desc }, { created_at: desc }]` (pinned-first, then newest-first).
- `query-hooks/post-detail/index.ts` — select `pinned`.
- `query-hooks/transformers.ts` — surface `pinned` from `transformPost`, so the `Post` UI type carries it automatically.
- Regenerated GraphQL types via `pnpm codegen`.

No UI yet — the menu toggle (SWO-254) and card badge (SWO-255) consume this.

### Note on the generated diff
`pnpm codegen` introspects the live Hasura schema, which had drifted ahead of main's committed types (`createSignedUploadUrl` action, `videos.metadata`/`retry_count`). Regenerating catches those up — that's the extra churn in `graphql.ts`/`schema.graphql`, not part of this feature. `pnpm build` is green across all 9 apps with the regenerated types.

Resolves SWO-253.

## Test plan

- [x] `vitest run` — `transformers.test.ts` + `posts/index.test.ts` updated for `pinned`; 9/9 til tests pass.
- [x] `pnpm build` — green across all apps (typechecks regenerated types).
- [x] `biome check` clean on edited files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for generating signed upload URLs from the app.
  * Posts can now be marked as pinned, and pinned posts are shown first in post lists.

* **Bug Fixes**
  * Post detail views now include pin status consistently.
  * Video records now expose retry and metadata information more reliably across browsing and filtering.

* **Tests**
  * Updated coverage to reflect the new pinned post data in post-related flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->