### PR TITLE
[WIP] feat(til): add Pin/Unpin to post-detail menu (SWO-254)

### DIFF
--- a/apps/til/src/routes/posts.$slug.$id.tsx
+++ b/apps/til/src/routes/posts.$slug.$id.tsx
@@ -129,6 +129,17 @@ const RouteComponent = () => {
     refetch();
   };
 
+  const handleTogglePin = async () => {
+    await updatePost({
+      id: postId,
+      object: {
+        pinned: !post?.pinned,
+      },
+    });
+    handleMenuClose();
+    refetch();
+  };
+
   // Store original values for comparison
   const originalTitle = post?.title ?? '';
   const originalContent = post?.mContent ?? '';
@@ -341,6 +352,9 @@ const RouteComponent = () => {
                   {post?.visibility === POST_VISIBILITY.PUBLIC
                     ? 'Private'
                     : 'Public'}
+                </MenuItem>
+                <MenuItem onClick={handleTogglePin}>
+                  {post?.pinned ? 'Unpin' : 'Pin'}
                 </MenuItem>
               </Menu>
             </Box>


### PR DESCRIPTION
## Summary

Wave 3a of pinned posts (parent SWO-251). Adds a **Pin / Unpin** item to the post-detail 3-dot menu.

- `handleTogglePin` flips `post.pinned` via the existing `useUpdatePost` mutation, reusing its notification + `refetch` wiring (mirrors `handleToggleVisibility`).
- Menu item label is **"Pin"** when unpinned, **"Unpin"** when pinned.

Author-only by construction — the Hasura `update_permissions` filter (`author_id = X-Hasura-User-Id`, SWO-252) gates the mutation. Independent of SWO-255 (card badge).

Resolves SWO-254.

## Test plan

- [x] `pnpm build --filter=til` — green (typechecks the route against `post.pinned`).
- [x] `biome check` clean.
- [ ] Manual: open own post → menu shows "Pin" → click → toggles, label becomes "Unpin", success toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)