### PR TITLE
[WIP] feat(til): show pin badge on pinned PostCard (SWO-255)

### DIFF
--- a/packages/ui/src/til/posts/post-card/index.test.tsx
+++ b/packages/ui/src/til/posts/post-card/index.test.tsx
@@ -47,4 +47,26 @@ describe('PostCard', () => {
       expect.anything(),
     );
   });
+
+  it('does not render the pin marker for an unpinned post', () => {
+    render(
+      <PostCard
+        post={mockPost}
+        LinkComponent={({ children }) => <div>{children}</div>}
+      />,
+    );
+
+    expect(screen.queryByTestId('PushPinIcon')).not.toBeInTheDocument();
+  });
+
+  it('renders the pin marker for a pinned post', () => {
+    render(
+      <PostCard
+        post={{ ...mockPost, pinned: true }}
+        LinkComponent={({ children }) => <div>{children}</div>}
+      />,
+    );
+
+    expect(screen.getByTestId('PushPinIcon')).toBeInTheDocument();
+  });
 });

--- a/packages/ui/src/til/posts/post-card/index.tsx
+++ b/packages/ui/src/til/posts/post-card/index.tsx
@@ -1,3 +1,4 @@
+import PushPinIcon from '@mui/icons-material/PushPin';
 import CardContent from '@mui/material/CardContent';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
@@ -13,15 +14,29 @@ interface PostCardProps extends Omit<RequiredLinkComponent, 'linkProps'> {
 
 export const PostCard = (props: PostCardProps) => {
   const { post, LinkComponent } = props;
-  const { title, brief, readTimeInMinutes, createdAt } = post;
+  const { title, brief, readTimeInMinutes, createdAt, pinned } = post;
 
   return (
     <LinkComponent {...genlinkProps(post)} style={{ textDecoration: 'none' }}>
       <StyledCard>
         <CardContent>
-          <Typography variant="h6" gutterBottom>
-            {title}
-          </Typography>
+          <Stack
+            direction="row"
+            alignItems="flex-start"
+            justifyContent="space-between"
+            spacing={1}
+          >
+            <Typography variant="h6" gutterBottom>
+              {title}
+            </Typography>
+            {pinned && (
+              <PushPinIcon
+                fontSize="small"
+                color="action"
+                aria-label="Pinned"
+              />
+            )}
+          </Stack>
           <StyledDescription variant="body2" color="text.secondary">
             {brief}
           </StyledDescription>


### PR DESCRIPTION
## Summary

Wave 3b of pinned posts (parent SWO-251). Shows a small pin marker on pinned cards in the home grid.

- `PostCard` renders a `PushPinIcon` (subtle, `color="action"`) beside the title when `post.pinned` is true; nothing when unpinned.
- Pinned-first ordering already comes from the `AllPosts` query (SWO-253) — no list/layout change here.

Independent of SWO-254 (menu toggle).

Resolves SWO-255.

## Test plan

- [x] `vitest run` post-card — added pinned/unpinned cases; 7/7 pass.
- [x] `pnpm build --filter=til` — green.
- [x] `biome check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)