### PR TITLE
[WIP] docs(parallel-workflow): copy packages/core/.env for codegen (SWO-259)

### DIFF
--- a/.claude/skills/parallel-workflow/SKILL.md
+++ b/.claude/skills/parallel-workflow/SKILL.md
@@ -27,7 +27,7 @@ user-invocable: false
 
 5. `git fetch origin main` first, then create worktree inside `.claude/worktrees/` from `origin/main`.
 6. Name worktrees after the issue's slug — the kebab-case short form of its title, optionally prefixed with the identifier (e.g. `.claude/worktrees/swo-123-sticky-progress-bar`). This keeps worktrees self-contained, gitignored, and aligned with Claude Code's official default. Including the `SWO-NNN` identifier in the branch name lets the GitHub↔Linear integration auto-link the PR to the issue.
-7. Copy `.env` files from the main worktree into the matching `apps/<app>/` directories.
+7. Copy `.env` files from the main worktree into the matching `apps/<app>/` directories. **Also copy `packages/core/.env`** — `pnpm codegen` reads `HASURA_GRAPHQL_URL` / `HASURA_ADMIN_SECRET` from it; without it codegen aborts with `Unable to find any GraphQL type definitions ... - undefined`.
 8. Run `pnpm install` in each worktree.
 
 ## During work
@@ -42,7 +42,7 @@ user-invocable: false
 ## Codegen
 
 - ALWAYS `git fetch origin main && git merge origin/main` before running codegen.
-- Run `pnpm codegen` in `packages/core` to regenerate GraphQL types.
+- Run `pnpm codegen` in `packages/core` to regenerate GraphQL types. Needs `packages/core/.env` in the worktree (see step 7) — codegen introspects the live Hasura schema using the URL/secret from it.
 - See `architecture` skill for GraphQL conventions (generated files, `graphql()` usage).
 
 ## Resolving conflicts


### PR DESCRIPTION
## Summary

The `parallel-workflow` skill's worktree setup (step 7) only copied `.env` into `apps/<app>/`, omitting `packages/core/.env`. That file holds `HASURA_GRAPHQL_URL` / `HASURA_ADMIN_SECRET`, which `pnpm codegen` needs — without it codegen aborts with `Unable to find any GraphQL type definitions ... - undefined`. Hit during SWO-253.

- Step 7: also copy `packages/core/.env`, with the reason.
- Codegen section: pointer noting codegen needs it.

Docs-only change to `SKILL.md`. Resolves SWO-259.

## Test plan

- [x] Docs-only; no code paths affected. Reflects the exact step that unblocked codegen in the SWO-253 worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the parallel-workflow setup steps by adding a required environment-file copy before running code generation.
  * Expanded code generation guidance so it’s clear the command depends on the environment file being present in the worktree and uses live schema settings from it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->