### PR TITLE
[WIP] feat(watch): add ContinueWatchingSection component (SWO-257)

### DIFF
--- a/packages/ui/src/watch/home-page/columns.ts
+++ b/packages/ui/src/watch/home-page/columns.ts
@@ -1,0 +1,8 @@
+// Single source of truth for the watch home-page grid responsive layout.
+// GRID_COLUMN_PROPS feeds the MUI <Grid item> size props; COLUMNS_PER_ROW is
+// the matching number of cards that fit one row at each breakpoint — used to
+// slice the "Continue watching" row so it never wraps. Keep the two in sync.
+const GRID_COLUMN_PROPS = { xs: 12, sm: 6, md: 4, lg: 3, xl: 2.4 } as const;
+const COLUMNS_PER_ROW = { xs: 1, sm: 2, md: 3, lg: 4, xl: 5 } as const;
+
+export { COLUMNS_PER_ROW, GRID_COLUMN_PROPS };

--- a/packages/ui/src/watch/home-page/continue-watching/index.stories.tsx
+++ b/packages/ui/src/watch/home-page/continue-watching/index.stories.tsx
@@ -1,0 +1,80 @@
+import Box from '@mui/material/Box';
+import type { Meta, StoryObj } from '@storybook/react';
+import type { LinkComponentType } from '../../videos/types';
+import { ContinueWatchingSection } from '.';
+import type { ContinueWatchingItem } from './types';
+
+const MockLink: LinkComponentType = ({ to, children, style }) => (
+  <a href={to} style={style}>
+    {children}
+  </a>
+);
+
+const makeItem = (
+  index: number,
+  overrides: Partial<ContinueWatchingItem> = {},
+): ContinueWatchingItem => ({
+  id: `video-${index}`,
+  type: 'video',
+  title: `Continue watching video ${index}`,
+  thumbnailUrl: `https://picsum.photos/seed/${index}/536/354`,
+  source:
+    'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
+  slug: `video-${index}`,
+  duration: 600,
+  createdAt: '2024-12-15T04:32:47.424952+00:00',
+  user: { username: 'shinabr2' },
+  progressSeconds: 120 + index * 40,
+  lastWatchedAt: '2026-06-29T10:00:00.000000+00:00',
+  ...overrides,
+});
+
+const meta: Meta<typeof ContinueWatchingSection> = {
+  title: 'Watch/ContinueWatchingSection',
+  component: ContinueWatchingSection,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    (Story) => (
+      <Box sx={{ p: 3 }}>
+        <Story />
+      </Box>
+    ),
+  ],
+  args: {
+    LinkComponent: MockLink,
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof ContinueWatchingSection>;
+
+// More items than a single row holds — the component slices to the breakpoint.
+export const Populated: Story = {
+  args: {
+    videos: Array.from({ length: 8 }, (_, i) => makeItem(i + 1)),
+  },
+};
+
+// Fewer items than a full row.
+export const FewItems: Story = {
+  args: {
+    videos: [makeItem(1), makeItem(2)],
+  },
+};
+
+// A video watched inside a playlist (links to the in-playlist route).
+export const WithPlaylistItem: Story = {
+  args: {
+    videos: [
+      makeItem(1, {
+        title: 'Episode 3 — inside a playlist',
+        playlist: { id: 'playlist-1', slug: 'my-playlist' },
+      }),
+      makeItem(2),
+      makeItem(3),
+    ],
+  },
+};

--- a/packages/ui/src/watch/home-page/continue-watching/index.test.tsx
+++ b/packages/ui/src/watch/home-page/continue-watching/index.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { VideoCard } from '../../videos/video-card';
+import { ContinueWatchingSection } from './index';
+import type { ContinueWatchingItem } from './types';
+
+// Controls the breakpoint: when true every breakpoints.up() matches → xl (5
+// columns); when false none match → xs (1 column).
+let matchesBreakpoints = false;
+vi.mock('@mui/material/useMediaQuery', () => ({
+  default: () => matchesBreakpoints,
+}));
+
+vi.mock('../../videos/video-card', () => ({
+  VideoCard: vi.fn(() => <div>VideoCard</div>),
+}));
+
+vi.mock('./utils', () => ({
+  genlinkProps: (item: { id: string; slug: string }) => ({
+    to: '/video/$slug/$id',
+    params: { slug: item.slug, id: item.id },
+  }),
+}));
+
+const MockLink = vi.fn(({ to, children }) => <a href={to}>{children}</a>);
+
+const makeItem = (index: number): ContinueWatchingItem => ({
+  id: `video-${index}`,
+  type: 'video',
+  title: `Video ${index}`,
+  thumbnailUrl: '',
+  source: '',
+  slug: `video-${index}`,
+  duration: 600,
+  createdAt: '2024-12-15T04:32:47.424952+00:00',
+  user: { username: 'shinabr2' },
+  progressSeconds: 120,
+  lastWatchedAt: '2026-06-29T10:00:00.000000+00:00',
+});
+
+describe('ContinueWatchingSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    matchesBreakpoints = false;
+  });
+
+  it('renders the heading and a "Show all" link to history', () => {
+    render(
+      <ContinueWatchingSection
+        videos={[makeItem(1)]}
+        LinkComponent={MockLink}
+      />,
+    );
+
+    expect(screen.getByText('Continue watching')).toBeInTheDocument();
+    expect(screen.getByText('Show all')).toBeInTheDocument();
+    expect(MockLink).toHaveBeenCalledWith(
+      expect.objectContaining({ to: '/history' }),
+      expect.anything(),
+    );
+  });
+
+  it('slices to one card at the smallest breakpoint', () => {
+    matchesBreakpoints = false;
+
+    render(
+      <ContinueWatchingSection
+        videos={Array.from({ length: 8 }, (_, i) => makeItem(i + 1))}
+        LinkComponent={MockLink}
+      />,
+    );
+
+    expect(VideoCard).toHaveBeenCalledTimes(1);
+  });
+
+  it('slices to five cards at the largest breakpoint', () => {
+    matchesBreakpoints = true;
+
+    render(
+      <ContinueWatchingSection
+        videos={Array.from({ length: 8 }, (_, i) => makeItem(i + 1))}
+        LinkComponent={MockLink}
+      />,
+    );
+
+    expect(VideoCard).toHaveBeenCalledTimes(5);
+  });
+
+  it('renders nothing when there are no videos', () => {
+    const { container } = render(
+      <ContinueWatchingSection videos={[]} LinkComponent={MockLink} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+    expect(VideoCard).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/watch/home-page/continue-watching/index.tsx
+++ b/packages/ui/src/watch/home-page/continue-watching/index.tsx
@@ -1,0 +1,77 @@
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Grid from '@mui/material/Grid';
+import { useTheme } from '@mui/material/styles';
+import Typography from '@mui/material/Typography';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import type { RequiredLinkComponentWithoutLinkProps } from '../../videos/types';
+import { VideoCard } from '../../videos/video-card';
+import { COLUMNS_PER_ROW, GRID_COLUMN_PROPS } from '../columns';
+import type { ContinueWatchingItem } from './types';
+import { genlinkProps } from './utils';
+
+const HISTORY_ROUTE = '/history';
+
+interface ContinueWatchingSectionProps
+  extends RequiredLinkComponentWithoutLinkProps {
+  videos: ContinueWatchingItem[];
+}
+
+const ContinueWatchingSection = (props: ContinueWatchingSectionProps) => {
+  const { videos, LinkComponent } = props;
+  const theme = useTheme();
+  const isXl = useMediaQuery(theme.breakpoints.up('xl'));
+  const isLg = useMediaQuery(theme.breakpoints.up('lg'));
+  const isMd = useMediaQuery(theme.breakpoints.up('md'));
+  const isSm = useMediaQuery(theme.breakpoints.up('sm'));
+
+  if (videos.length === 0) {
+    return null;
+  }
+
+  const columns = isXl
+    ? COLUMNS_PER_ROW.xl
+    : isLg
+      ? COLUMNS_PER_ROW.lg
+      : isMd
+        ? COLUMNS_PER_ROW.md
+        : isSm
+          ? COLUMNS_PER_ROW.sm
+          : COLUMNS_PER_ROW.xs;
+
+  const visibleVideos = videos.slice(0, columns);
+
+  return (
+    <Box sx={{ mb: 4 }}>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          mb: 2,
+        }}
+      >
+        <Typography variant="h6" component="h2">
+          Continue watching
+        </Typography>
+        <LinkComponent to={HISTORY_ROUTE} style={{ textDecoration: 'none' }}>
+          <Button size="small">Show all</Button>
+        </LinkComponent>
+      </Box>
+      <Grid container spacing={3}>
+        {visibleVideos.map((video) => (
+          <Grid item {...GRID_COLUMN_PROPS} key={video.id}>
+            <VideoCard
+              video={video}
+              asLink={true}
+              LinkComponent={LinkComponent}
+              linkProps={genlinkProps(video)}
+            />
+          </Grid>
+        ))}
+      </Grid>
+    </Box>
+  );
+};
+
+export { ContinueWatchingSection };

--- a/packages/ui/src/watch/home-page/continue-watching/types.ts
+++ b/packages/ui/src/watch/home-page/continue-watching/types.ts
@@ -1,0 +1,27 @@
+import type { MediaType } from 'core/watch/query-hooks';
+
+// The continue-watching row declares its OWN item contract — the fields the
+// card + link need — rather than importing a type derived from a data hook.
+// Any source that produces this shape (e.g. useLoadVideos' continueWatching)
+// satisfies it structurally, with no cross-hook coupling.
+interface ContinueWatchingItem {
+  id: string;
+  type: MediaType;
+  title: string;
+  thumbnailUrl: string;
+  source: string;
+  slug: string;
+  duration: number;
+  createdAt: string;
+  user: {
+    username: string;
+  };
+  progressSeconds: number;
+  lastWatchedAt: string | null;
+  playlist?: {
+    id: string;
+    slug: string;
+  };
+}
+
+export type { ContinueWatchingItem };

--- a/packages/ui/src/watch/home-page/continue-watching/utils.test.ts
+++ b/packages/ui/src/watch/home-page/continue-watching/utils.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ContinueWatchingItem } from './types';
+import { genlinkProps } from './utils';
+
+vi.mock('core/watch/routes', () => ({
+  generateVideoDetailRoute: vi.fn().mockReturnValue({ to: '/video/123' }),
+  generateVideoInPlaylistRoute: vi
+    .fn()
+    .mockReturnValue({ to: '/playlist/456' }),
+}));
+
+describe('continue-watching genlinkProps', () => {
+  it('links a standalone video to the video detail route', () => {
+    const item = {
+      id: '123',
+      slug: 'test-video',
+    } as ContinueWatchingItem;
+
+    const result = genlinkProps(item);
+    expect(result).toEqual({ to: '/video/123' });
+  });
+
+  it('links a video watched inside a playlist to the in-playlist route', () => {
+    const item = {
+      id: '123',
+      slug: 'test-video',
+      playlist: {
+        id: 'abc',
+        slug: 'test-playlist',
+      },
+    } as ContinueWatchingItem;
+
+    const result = genlinkProps(item);
+    expect(result).toEqual({ to: '/playlist/456' });
+  });
+});

--- a/packages/ui/src/watch/home-page/continue-watching/utils.ts
+++ b/packages/ui/src/watch/home-page/continue-watching/utils.ts
@@ -1,0 +1,31 @@
+import {
+  generateVideoDetailRoute,
+  generateVideoInPlaylistRoute,
+} from 'core/watch/routes';
+import type { ContinueWatchingItem } from './types';
+
+/**
+ * Generates link props for a continue-watching item. A video watched inside a
+ * playlist links to the in-playlist route so it resumes in context; a
+ * standalone video links to the video detail route.
+ * @param item - A continue-watching item
+ * @returns Link props for either the in-playlist or video detail route
+ */
+const genlinkProps = (item: ContinueWatchingItem) => {
+  const { playlist } = item;
+
+  if (playlist) {
+    return generateVideoInPlaylistRoute({
+      playlistId: playlist.id,
+      playlistSlug: playlist.slug,
+      videoId: item.id,
+    });
+  }
+
+  return generateVideoDetailRoute({
+    id: item.id,
+    slug: item.slug,
+  });
+};
+
+export { genlinkProps };


### PR DESCRIPTION
## Summary

PR 1 of 2 for **SWO-256** (a "Continue watching" section on the Watch home page). This adds the presentational component only — it is **not yet wired into the route** (that's SWO-258), so there is no user-visible change on `main` from this PR alone.

`ContinueWatchingSection` renders:
- a header (`Continue watching`) with a **Show all** link to `/history`
- a single `<Grid>` row of `VideoCard`s, **sliced to the number of columns that fit at the current breakpoint** (1/2/3/4/5 for xs/sm/md/lg/xl) so it never wraps. `VideoCard`'s `asLink` mode already draws the resume progress bar.

Design notes:
- `columns.ts` holds one source-of-truth matrix (`GRID_COLUMN_PROPS` + `COLUMNS_PER_ROW`) shared with the existing home grid in PR2.
- The component declares its **own** `ContinueWatchingItem` contract and its **own** `genlinkProps` (standalone → video route, playlist-internal → in-playlist route). No coupling to `useLoadHistory`/history-page; the PR2 hook output will satisfy the contract structurally.
- Returns `null` when given an empty list.

## Test plan

- `cd packages/ui && pnpm vitest run src/watch/home-page/continue-watching` → 6 tests pass:
  - heading + "Show all" link to `/history`
  - slices to 1 card at the smallest breakpoint, 5 at the largest
  - renders nothing when empty
  - `genlinkProps` routes standalone vs playlist-internal items
- `pnpm build` (tsup) succeeds; new files pass `biome check`.
- Storybook: `Watch/ContinueWatchingSection` — Populated / FewItems / WithPlaylistItem.

Part of SWO-256. Blocks SWO-258.