### PR TITLE
[WIP] feat(watch): show playlist name in continue-watching + video detail (SWO-260)

### DIFF
--- a/packages/ui/src/watch/home-page/continue-watching/types.ts
+++ b/packages/ui/src/watch/home-page/continue-watching/types.ts
@@ -21,6 +21,7 @@ interface ContinueWatchingItem {
   playlist?: {
     id: string;
     slug: string;
+    title: string;
   };
 }
 

--- a/packages/ui/src/watch/utils.test.ts
+++ b/packages/ui/src/watch/utils.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { getMediaDisplayName } from './utils';
+
+describe('getMediaDisplayName', () => {
+  it('returns the video title alone for a standalone video', () => {
+    expect(getMediaDisplayName({ videoTitle: 'My Video' })).toBe('My Video');
+  });
+
+  it('prefixes the playlist name when the video belongs to a playlist', () => {
+    expect(
+      getMediaDisplayName({
+        videoTitle: 'Episode 1',
+        playlistName: 'My Playlist',
+      }),
+    ).toBe('My Playlist - Episode 1');
+  });
+
+  it('falls back to the video title when the playlist name is empty or null', () => {
+    expect(
+      getMediaDisplayName({ videoTitle: 'My Video', playlistName: '' }),
+    ).toBe('My Video');
+    expect(
+      getMediaDisplayName({ videoTitle: 'My Video', playlistName: null }),
+    ).toBe('My Video');
+  });
+});

--- a/packages/ui/src/watch/utils.ts
+++ b/packages/ui/src/watch/utils.ts
@@ -1,4 +1,4 @@
-export const formatCreatedDate = (
+const formatCreatedDate = (
   date: string | null | undefined,
   locale: string = 'en-CA',
 ): string => {
@@ -17,3 +17,20 @@ export const formatCreatedDate = (
     return '';
   }
 };
+
+interface MediaDisplayNameProps {
+  videoTitle: string;
+  playlistName?: string | null;
+}
+
+// Single source of truth for the name we show for a video everywhere in watch
+// (continue-watching cards, the detail page, …). A video watched inside a
+// playlist is prefixed with the playlist name — "Playlist - Video" — so the
+// context is never lost; a standalone video is just its own title.
+const getMediaDisplayName = (props: MediaDisplayNameProps): string => {
+  const { videoTitle, playlistName } = props;
+
+  return playlistName ? `${playlistName} - ${videoTitle}` : videoTitle;
+};
+
+export { formatCreatedDate, getMediaDisplayName };

--- a/packages/ui/src/watch/video-detail-page/containers/index.test.tsx
+++ b/packages/ui/src/watch/video-detail-page/containers/index.test.tsx
@@ -314,6 +314,10 @@ describe('VideoDetailContainer', () => {
     expect(screen.getByTestId('related-list-title')).toHaveTextContent(
       'Same playlist',
     );
+    // The heading prefixes the playlist name onto the video title.
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      'My Playlist - Video 1',
+    );
   });
 
   it('should return null in MainContent when video is not found', async () => {

--- a/packages/ui/src/watch/video-detail-page/containers/index.tsx
+++ b/packages/ui/src/watch/video-detail-page/containers/index.tsx
@@ -8,6 +8,7 @@ import Typography from '@mui/material/Typography';
 import { useAuthContext } from 'core/providers/auth';
 import { useSaveSubtitle } from 'core/watch/mutation-hooks/save-subtitle';
 import React, { Suspense } from 'react';
+import { getMediaDisplayName } from '../../utils';
 import { VideoContainer } from '../../videos/video-container';
 import { RelatedList } from '../related-list';
 import { MainContentSkeleton, RelatedContentSkeleton } from './skeleton';
@@ -169,7 +170,10 @@ const MainContent = (props: VideoDetailContainerProps) => {
             WebkitBoxOrient: 'vertical',
           }}
         >
-          {videoDetail.title}
+          {getMediaDisplayName({
+            videoTitle: videoDetail.title,
+            playlistName: playlist?.title,
+          })}
         </Typography>
         {onShare && (
           <Tooltip title="Share video">

--- a/packages/ui/src/watch/videos/video-card/index.test.tsx
+++ b/packages/ui/src/watch/videos/video-card/index.test.tsx
@@ -90,6 +90,25 @@ describe('VideoCard Component', () => {
     });
   });
 
+  it('prefixes the playlist name and shows a playlist badge for a video watched inside a playlist', async () => {
+    const playlistVideo = {
+      ...mockVideo,
+      playlist: { title: 'My Playlist' },
+    };
+
+    await renderWithAct(
+      <VideoCard
+        video={playlistVideo}
+        asLink={true}
+        LinkComponent={MockLink}
+        linkProps={{ to: '/x', params: { slug: 'test-video', id: '1' } }}
+      />,
+    );
+
+    expect(screen.getByText('My Playlist - Test Video')).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'Playlist' })).toBeInTheDocument();
+  });
+
   it('renders thumbnail only for playlist type when not asLink', async () => {
     const playlistVideo = {
       ...mockVideo,

--- a/packages/ui/src/watch/videos/video-card/index.tsx
+++ b/packages/ui/src/watch/videos/video-card/index.tsx
@@ -3,7 +3,7 @@ import Box from '@mui/material/Box';
 import CardContent from '@mui/material/CardContent';
 import Typography from '@mui/material/Typography';
 import { MEDIA_TYPES, type MediaType } from 'core/watch/query-hooks';
-import { formatCreatedDate } from '../../utils';
+import { formatCreatedDate, getMediaDisplayName } from '../../utils';
 import type { PlayableVideo, WithLinkComponent } from '../types';
 import { VideoContainer } from '../video-container';
 import { VideoThumbnail } from '../video-thumbnail';
@@ -19,6 +19,11 @@ interface Video extends Omit<PlayableVideo, 'source'> {
   };
   progressSeconds?: number;
   createdAt: string;
+  // Set when this card is a video watched inside a playlist (e.g. a
+  // continue-watching item) so we can show the playlist name + badge.
+  playlist?: {
+    title: string;
+  };
 }
 
 interface VideoCardProps extends WithLinkComponent {
@@ -118,13 +123,15 @@ const VideoContent = (props: VideoContentProps) => {
     return (
       <Box sx={{ position: 'relative' }}>
         <VideoThumbnail src={video.thumbnailUrl} title={video.title} />
-        {video.type === MEDIA_TYPES.PLAYLIST && <PlaylistBadge />}
+        {(video.type === MEDIA_TYPES.PLAYLIST || Boolean(video.playlist)) && (
+          <PlaylistBadge />
+        )}
         <VideoProgress video={video} />
       </Box>
     );
   }
 
-  if (video.type == MEDIA_TYPES.PLAYLIST) {
+  if (video.type === MEDIA_TYPES.PLAYLIST) {
     return (
       <Box sx={{ position: 'relative' }}>
         <VideoThumbnail src={video.thumbnailUrl} title={video.title} />
@@ -157,7 +164,10 @@ const VideoCard = (props: VideoCardProps) => {
         <VideoContent video={video} asLink={asLink} />
       </Box>
       <VideoCardContent
-        title={video.title}
+        title={getMediaDisplayName({
+          videoTitle: video.title,
+          playlistName: video.playlist?.title,
+        })}
         creator={video.user?.username || ''}
         createdTime={formatCreatedDate(video.createdAt)}
       />


### PR DESCRIPTION
## Summary

When a video belongs to a playlist, the UI didn't surface the playlist context — confusing on the home **Continue watching** row (just the video title, no playlist icon) and on the **video detail** heading (playlist name was in `queryRs.playlist` but never shown).

This adds a single centralized pure helper and wires it into both surfaces:

- `getMediaDisplayName({ videoTitle, playlistName })` in `packages/ui/src/watch/utils.ts` → `"${playlistName} - ${videoTitle}"` when in a playlist, otherwise just `videoTitle`.
- `VideoCard` uses it for the card title, and now shows the existing playlist badge for **any** video that carries a `playlist` (previously only `type === PLAYLIST` items).
- `ContinueWatchingItem.playlist` widened to include `title` (already fetched by the `AllVideos` query).
- Video detail heading uses the helper with `playlist?.title`.
- Drive-by: `==` → `===` in the same `VideoContent` function.

Home-grid **playlist-type** cards are intentionally unchanged — they represent a whole playlist, not a video-in-playlist.

Closes SWO-260.

## Test plan

- `getMediaDisplayName` unit tests: standalone / playlist / empty-or-null fallback.
- `VideoCard`: playlist video renders `"My Playlist - Test Video"` + playlist badge.
- Video detail: `<h1>` renders `"My Playlist - Video 1"` when inside a playlist.
- Full `packages/ui/src/watch` suite green (221 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Video titles now include the playlist name when available, both in video cards and the video detail page.
  * Continued-watching items can now carry playlist title information for richer display.

* **Bug Fixes**
  * Fixed title rendering so videos in playlists show a consistent “Playlist - Video” format.
  * Improved fallback behavior to show the plain video title when no playlist name is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->