### PR TITLE
[WIP] fix(watch): resume playback from saved progress (SWO-262)

### DIFF
--- a/packages/ui/src/watch/videos/types.ts
+++ b/packages/ui/src/watch/videos/types.ts
@@ -12,6 +12,8 @@ interface PlayableVideo {
   source: string;
   thumbnailUrl: string;
   subtitles?: Subtitle[];
+  // Saved playback position in seconds; the player resumes from here on load.
+  progressSeconds?: number;
 }
 
 interface GenericLinkProps<T = Record<string, unknown>> {

--- a/packages/ui/src/watch/videos/video-player/index.test.tsx
+++ b/packages/ui/src/watch/videos/video-player/index.test.tsx
@@ -12,7 +12,7 @@ const mockSeekTo = vi.fn();
 
 vi.mock('react-player', () => ({
   __esModule: true,
-  default: React.forwardRef(({ url, onReady, ...props }, ref) => {
+  default: React.forwardRef(({ url, ...props }, ref) => {
     mockReactPlayerRef.mockImplementation(() => props);
 
     // Simulate ref callback
@@ -193,6 +193,64 @@ describe('VideoPlayer', () => {
     });
 
     expect(onError).toHaveBeenCalledWith(mockError);
+  });
+});
+
+describe('VideoPlayer resume from saved progress', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetDuration.mockReturnValue(100);
+  });
+
+  it('seeks to the saved position (minus a short rewind) on ready', async () => {
+    render(<VideoPlayer video={{ ...mockVideo, progressSeconds: 50 }} />);
+    await screen.findByTestId('mock-react-player');
+    const props = mockReactPlayerRef();
+
+    act(() => {
+      props.onReady();
+    });
+
+    // 50 saved - 5s rewind
+    expect(mockSeekTo).toHaveBeenCalledWith(45, 'seconds');
+  });
+
+  it('does not seek when there is no saved progress', async () => {
+    render(<VideoPlayer video={mockVideo} />);
+    await screen.findByTestId('mock-react-player');
+    const props = mockReactPlayerRef();
+
+    act(() => {
+      props.onReady();
+    });
+
+    expect(mockSeekTo).not.toHaveBeenCalled();
+  });
+
+  it('does not resume when the saved position is at/near the end', async () => {
+    // duration 100, threshold 10 → anything >= 90 is treated as finished
+    render(<VideoPlayer video={{ ...mockVideo, progressSeconds: 95 }} />);
+    await screen.findByTestId('mock-react-player');
+    const props = mockReactPlayerRef();
+
+    act(() => {
+      props.onReady();
+    });
+
+    expect(mockSeekTo).not.toHaveBeenCalled();
+  });
+
+  it('resumes only once even if ready fires repeatedly', async () => {
+    render(<VideoPlayer video={{ ...mockVideo, progressSeconds: 50 }} />);
+    await screen.findByTestId('mock-react-player');
+    const props = mockReactPlayerRef();
+
+    act(() => {
+      props.onReady();
+      props.onReady();
+    });
+
+    expect(mockSeekTo).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/ui/src/watch/videos/video-player/index.tsx
+++ b/packages/ui/src/watch/videos/video-player/index.tsx
@@ -15,6 +15,14 @@ import { VideoThumbnail } from '../video-thumbnail';
 
 const PROGRESS_INTERVAL = 1000;
 
+// Rewind a few seconds from the saved position so the viewer gets a moment of
+// context when resuming rather than landing mid-sentence.
+const RESUME_REWIND_SECONDS = 5;
+
+// If the saved position is within this many seconds of the end, treat the video
+// as finished and start from the beginning instead of resuming at the very end.
+const RESUME_END_THRESHOLD_SECONDS = 10;
+
 // Lazy load the VideoJS component that contains video.js
 // const VideoJS = lazy(() => import('./videojs'));
 const ReactPlayer = lazy(() => import('react-player'));
@@ -78,6 +86,16 @@ const VideoPlayer = (props: VideoPlayerProps) => {
   // biome-ignore lint/suspicious/noExplicitAny: ref type depends on ReactPlayer internals
   const playerRef = useRef<any | null>(null);
   const wrapperRef = useRef<HTMLDivElement | null>(null);
+  // Resume only once per video, and never override a position the viewer has
+  // since changed themselves.
+  const hasResumedRef = useRef(false);
+
+  // Reset the resume guard whenever the source video changes (e.g. advancing to
+  // the next video in a playlist reuses this same player instance).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: video.id is the intended reset trigger, not a value read in the body
+  useEffect(() => {
+    hasResumedRef.current = false;
+  }, [video.id]);
 
   // biome-ignore lint/suspicious/noExplicitAny: ReactPlayer passes an implementation-specific instance
   const setPlayerRef = useCallback((player: any) => {
@@ -293,6 +311,31 @@ const VideoPlayer = (props: VideoPlayerProps) => {
     [onError],
   );
 
+  // Resume from the saved position once the media is ready to seek.
+  const handleReady = useCallback(() => {
+    const player = playerRef.current;
+    if (!player || hasResumedRef.current) return;
+    hasResumedRef.current = true;
+
+    const progressSeconds = video.progressSeconds ?? 0;
+    if (progressSeconds <= 0) return;
+
+    // Skip resuming when the saved position is at/near the end — the viewer has
+    // effectively finished, so start over rather than land on the last frame.
+    const duration = player.getDuration?.() ?? 0;
+    if (
+      duration &&
+      progressSeconds >= duration - RESUME_END_THRESHOLD_SECONDS
+    ) {
+      return;
+    }
+
+    player.seekTo(
+      Math.max(0, progressSeconds - RESUME_REWIND_SECONDS),
+      'seconds',
+    );
+  }, [video.progressSeconds]);
+
   useEffect(() => {
     return () => {
       cleanup();
@@ -341,9 +384,7 @@ const VideoPlayer = (props: VideoPlayerProps) => {
             handleEnded();
             onEnded?.();
           }}
-          onReady={() => {
-            console.log('player ready');
-          }}
+          onReady={handleReady}
           progressInterval={PROGRESS_INTERVAL}
           config={{
             file: {


### PR DESCRIPTION
## Summary

Playback progress is saved (every 15s + on pause/seek/end/tab-close) and Continue-watching cards draw a progress bar — but the player never resumed from it: `onReady` just did `console.log('player ready')`, so opening a half-watched video **restarted at 0:00**, making the Continue-watching feature misleading.

Now, on player ready:
- seek to the saved `progressSeconds` minus a short rewind (5s) for context;
- skip resuming when the saved position is within 10s of the end (treat as finished → start over);
- resume only **once** per video, reset when `video.id` changes (the same player instance is reused when advancing through a playlist).

`progressSeconds` is threaded through `PlayableVideo`. No query change was needed — the active video the detail page renders (`videos.find(...)`, a `transformVideoFragment` result) already carries `progressSeconds` for both standalone and in-playlist videos.

Part of SWO-261. Closes SWO-262.

## Test plan

- New unit tests on `VideoPlayer`: seeks to `saved - 5s` on ready; no seek when no saved progress; no seek when near the end; resumes only once on repeated ready.
- Full `packages/ui/src/watch` suite green (225 tests).
- Manual (`pnpm dev:watch`): open a partly-watched video from Continue watching → resumes near where you left off; a fresh video → starts at 0:00; finishing one in a playlist and advancing → next starts correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)