### PR TITLE
[WIP] feat(watch): add duration badge to video thumbnails (SWO-263)

### DIFF
--- a/packages/ui/src/watch/utils.test.ts
+++ b/packages/ui/src/watch/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getMediaDisplayName } from './utils';
+import { formatDuration, getMediaDisplayName } from './utils';
 
 describe('getMediaDisplayName', () => {
   it('returns the video title alone for a standalone video', () => {
@@ -22,5 +22,35 @@ describe('getMediaDisplayName', () => {
     expect(
       getMediaDisplayName({ videoTitle: 'My Video', playlistName: null }),
     ).toBe('My Video');
+  });
+});
+
+describe('formatDuration', () => {
+  it('formats sub-minute durations as 0:ss', () => {
+    expect(formatDuration(5)).toBe('0:05');
+    expect(formatDuration(45)).toBe('0:45');
+  });
+
+  it('formats minutes as m:ss', () => {
+    expect(formatDuration(90)).toBe('1:30');
+    expect(formatDuration(600)).toBe('10:00');
+  });
+
+  it('widens to h:mm:ss past an hour', () => {
+    expect(formatDuration(3661)).toBe('1:01:01');
+    expect(formatDuration(7200)).toBe('2:00:00');
+  });
+
+  it('floors fractional seconds', () => {
+    expect(formatDuration(90.9)).toBe('1:30');
+  });
+
+  it('returns an empty string for missing / non-positive / non-finite values', () => {
+    expect(formatDuration(0)).toBe('');
+    expect(formatDuration(-10)).toBe('');
+    expect(formatDuration(undefined)).toBe('');
+    expect(formatDuration(null)).toBe('');
+    expect(formatDuration(Number.POSITIVE_INFINITY)).toBe('');
+    expect(formatDuration(Number.NaN)).toBe('');
   });
 });

--- a/packages/ui/src/watch/utils.ts
+++ b/packages/ui/src/watch/utils.ts
@@ -33,4 +33,23 @@ const getMediaDisplayName = (props: MediaDisplayNameProps): string => {
   return playlistName ? `${playlistName} - ${videoTitle}` : videoTitle;
 };
 
-export { formatCreatedDate, getMediaDisplayName };
+// Formats a duration in seconds as `m:ss`, widening to `h:mm:ss` past an hour.
+// Returns '' for missing / non-positive / non-finite values so callers can
+// simply skip rendering the badge.
+const formatDuration = (seconds: number | null | undefined): string => {
+  if (!seconds || seconds <= 0 || !Number.isFinite(seconds)) {
+    return '';
+  }
+
+  const total = Math.floor(seconds);
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  const secs = total % 60;
+  const pad = (value: number) => String(value).padStart(2, '0');
+
+  return hours > 0
+    ? `${hours}:${pad(minutes)}:${pad(secs)}`
+    : `${minutes}:${pad(secs)}`;
+};
+
+export { formatCreatedDate, formatDuration, getMediaDisplayName };

--- a/packages/ui/src/watch/videos/video-card/index.test.tsx
+++ b/packages/ui/src/watch/videos/video-card/index.test.tsx
@@ -109,6 +109,56 @@ describe('VideoCard Component', () => {
     expect(screen.getByRole('img', { name: 'Playlist' })).toBeInTheDocument();
   });
 
+  it('shows a duration badge on a video card', async () => {
+    await renderWithAct(
+      <VideoCard
+        video={mockVideo}
+        asLink={true}
+        LinkComponent={MockLink}
+        linkProps={{ to: '/x', params: { slug: 'test-video', id: '1' } }}
+      />,
+    );
+
+    // mockVideo.duration === 300 → 5:00
+    expect(screen.getByText('5:00')).toBeInTheDocument();
+  });
+
+  it('does not show a duration badge for a playlist card', async () => {
+    const playlistVideo = {
+      ...mockVideo,
+      type: MEDIA_TYPES.PLAYLIST,
+    } as TransformedMediaItem;
+
+    await renderWithAct(
+      <VideoCard
+        video={playlistVideo}
+        asLink={true}
+        LinkComponent={MockLink}
+        linkProps={{ to: '/x', params: { slug: 'test-video', id: '1' } }}
+      />,
+    );
+
+    expect(screen.queryByText('5:00')).not.toBeInTheDocument();
+  });
+
+  it('does not show a duration badge when duration is missing', async () => {
+    const videoWithoutDuration = {
+      ...mockVideo,
+      duration: undefined,
+    } as unknown as TransformedMediaItem;
+
+    await renderWithAct(
+      <VideoCard
+        video={videoWithoutDuration}
+        asLink={true}
+        LinkComponent={MockLink}
+        linkProps={{ to: '/x', params: { slug: 'test-video', id: '1' } }}
+      />,
+    );
+
+    expect(screen.queryByText('5:00')).not.toBeInTheDocument();
+  });
+
   it('renders thumbnail only for playlist type when not asLink', async () => {
     const playlistVideo = {
       ...mockVideo,

--- a/packages/ui/src/watch/videos/video-card/index.tsx
+++ b/packages/ui/src/watch/videos/video-card/index.tsx
@@ -3,7 +3,11 @@ import Box from '@mui/material/Box';
 import CardContent from '@mui/material/CardContent';
 import Typography from '@mui/material/Typography';
 import { MEDIA_TYPES, type MediaType } from 'core/watch/query-hooks';
-import { formatCreatedDate, getMediaDisplayName } from '../../utils';
+import {
+  formatCreatedDate,
+  formatDuration,
+  getMediaDisplayName,
+} from '../../utils';
 import type { PlayableVideo, WithLinkComponent } from '../types';
 import { VideoContainer } from '../video-container';
 import { VideoThumbnail } from '../video-thumbnail';
@@ -75,6 +79,38 @@ const PlaylistBadge = () => {
   );
 };
 
+interface DurationBadgeProps {
+  duration?: number;
+}
+
+const DurationBadge = (props: DurationBadgeProps) => {
+  const label = formatDuration(props.duration);
+  if (!label) {
+    return null;
+  }
+
+  return (
+    <Box
+      aria-label={`Duration ${label}`}
+      sx={{
+        position: 'absolute',
+        bottom: 8,
+        right: 8,
+        bgcolor: 'rgba(0, 0, 0, 0.75)',
+        color: 'common.white',
+        borderRadius: 1,
+        px: 0.75,
+        py: 0.25,
+        fontSize: 12,
+        fontWeight: 500,
+        lineHeight: 1.4,
+      }}
+    >
+      {label}
+    </Box>
+  );
+};
+
 interface VideoProgressProps {
   video: Video;
 }
@@ -125,6 +161,9 @@ const VideoContent = (props: VideoContentProps) => {
         <VideoThumbnail src={video.thumbnailUrl} title={video.title} />
         {(video.type === MEDIA_TYPES.PLAYLIST || Boolean(video.playlist)) && (
           <PlaylistBadge />
+        )}
+        {video.type !== MEDIA_TYPES.PLAYLIST && (
+          <DurationBadge duration={video.duration} />
         )}
         <VideoProgress video={video} />
       </Box>


### PR DESCRIPTION
## Summary

`duration` is fetched for every video but only fed the progress bar — there was no length indicator on thumbnails. Adds the standard `m:ss` badge.

- New pure helper `formatDuration(seconds)` in `packages/ui/src/watch/utils.ts` — `m:ss`, widening to `h:mm:ss` past an hour; returns `''` for missing / non-positive / non-finite input so callers just skip the badge.
- `VideoCard` renders a bottom-right duration badge on video thumbnails (mirrors the existing top-right playlist badge styling). Hidden for playlist cards and when duration is missing/0.

Part of SWO-261. Closes SWO-263.

## Test plan

- `formatDuration` unit tests: sub-minute, minutes, hours, fractional flooring, and empty for 0/negative/undefined/null/Infinity/NaN.
- `VideoCard`: badge shows on a video card (`5:00`), hidden for a playlist card, hidden when duration is missing.
- Full `packages/ui/src/watch` suite green (233 tests).
- Manual (`pnpm dev:watch`): video cards show length bottom-right; playlist cards don't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)