### PR TITLE
[WIP] feat(watch): friendly empty state on the home page (SWO-267)

### DIFF
--- a/packages/ui/src/watch/home-page/container/index.test.tsx
+++ b/packages/ui/src/watch/home-page/container/index.test.tsx
@@ -1,9 +1,14 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { VideoCard } from '../../videos/video-card';
 import { VideoSkeleton } from '../../videos/video-card/skeleton';
 import { ContinueWatchingSection } from '../continue-watching';
+import { WatchEmptyState } from '../empty-state';
 import { HomeContainer } from './index';
+
+vi.mock('../empty-state', () => ({
+  WatchEmptyState: vi.fn(() => <div>WatchEmptyState</div>),
+}));
 
 vi.mock('../../videos/video-card/skeleton', () => ({
   VideoSkeleton: vi.fn(() => <div>VideoSkeleton</div>),
@@ -77,7 +82,7 @@ describe('HomeContainer', () => {
     );
   });
 
-  it('should handle empty videos array', () => {
+  it('should render the empty state when there are no videos', () => {
     render(
       <HomeContainer
         queryRs={{
@@ -89,7 +94,24 @@ describe('HomeContainer', () => {
       />,
     );
 
+    expect(WatchEmptyState).toHaveBeenCalled();
+    expect(screen.queryByText('Videos')).not.toBeInTheDocument();
     expect(VideoCard).not.toHaveBeenCalled();
+  });
+
+  it('should not render the empty state while loading', () => {
+    render(
+      <HomeContainer
+        queryRs={{
+          isLoading: true,
+          videos: [],
+          continueWatching: [],
+        }}
+        LinkComponent={MockLink}
+      />,
+    );
+
+    expect(WatchEmptyState).not.toHaveBeenCalled();
   });
 
   it('should pass continue-watching videos to ContinueWatchingSection', () => {

--- a/packages/ui/src/watch/home-page/container/index.tsx
+++ b/packages/ui/src/watch/home-page/container/index.tsx
@@ -8,6 +8,7 @@ import { VideoCard } from '../../videos/video-card';
 import { VideoSkeleton } from '../../videos/video-card/skeleton';
 import { GRID_COLUMN_PROPS } from '../columns';
 import { ContinueWatchingSection } from '../continue-watching';
+import { WatchEmptyState } from '../empty-state';
 import { genlinkProps } from '../utils';
 
 const SKELETON_KEYS = Array.from({ length: 12 }, (_, i) => `skeleton-${i}`);
@@ -32,6 +33,7 @@ interface HomeContainerProps extends Omit<RequiredLinkComponent, 'linkProps'> {
 const HomeContainer = (props: HomeContainerProps) => {
   const { queryRs, LinkComponent } = props;
   const { videos, continueWatching, isLoading } = queryRs;
+  const isEmpty = !isLoading && videos.length === 0;
 
   return (
     <Container
@@ -43,25 +45,31 @@ const HomeContainer = (props: HomeContainerProps) => {
         videos={continueWatching}
         LinkComponent={LinkComponent}
       />
-      <Box sx={{ mb: 2 }}>
-        <Typography variant="h6" component="h2">
-          Videos
-        </Typography>
-      </Box>
-      <Grid container spacing={3}>
-        {isLoading && <Loading />}
-        {!isLoading &&
-          videos.map((video) => (
-            <Grid item {...GRID_COLUMN_PROPS} key={video.id}>
-              <VideoCard
-                video={video}
-                asLink={true}
-                LinkComponent={LinkComponent}
-                linkProps={genlinkProps(video)}
-              />
-            </Grid>
-          ))}
-      </Grid>
+      {isEmpty ? (
+        <WatchEmptyState />
+      ) : (
+        <>
+          <Box sx={{ mb: 2 }}>
+            <Typography variant="h6" component="h2">
+              Videos
+            </Typography>
+          </Box>
+          <Grid container spacing={3}>
+            {isLoading && <Loading />}
+            {!isLoading &&
+              videos.map((video) => (
+                <Grid item {...GRID_COLUMN_PROPS} key={video.id}>
+                  <VideoCard
+                    video={video}
+                    asLink={true}
+                    LinkComponent={LinkComponent}
+                    linkProps={genlinkProps(video)}
+                  />
+                </Grid>
+              ))}
+          </Grid>
+        </>
+      )}
     </Container>
   );
 };

--- a/packages/ui/src/watch/home-page/empty-state/index.test.tsx
+++ b/packages/ui/src/watch/home-page/empty-state/index.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { WatchEmptyState } from './index';
+
+const mockUseQueryContext = vi.fn();
+
+vi.mock('core', () => ({
+  Query: {
+    useQueryContext: () => mockUseQueryContext(),
+  },
+}));
+
+vi.mock('../../dialogs/upload', () => ({
+  VideoUploadDialog: vi.fn(() => <div>VideoUploadDialog</div>),
+}));
+
+describe('WatchEmptyState', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the message and an upload CTA when the upload flag is on', () => {
+    mockUseQueryContext.mockReturnValue({
+      featureFlags: { data: { upload: true }, isLoading: false },
+    });
+
+    render(<WatchEmptyState />);
+
+    expect(screen.getByText('No videos yet')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /upload a video/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('hides the upload CTA when the upload flag is off', () => {
+    mockUseQueryContext.mockReturnValue({
+      featureFlags: { data: { upload: false }, isLoading: false },
+    });
+
+    render(<WatchEmptyState />);
+
+    expect(screen.getByText('No videos yet')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /upload a video/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/watch/home-page/empty-state/index.tsx
+++ b/packages/ui/src/watch/home-page/empty-state/index.tsx
@@ -1,0 +1,60 @@
+import { CloudUpload } from '@mui/icons-material';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import { Query } from 'core';
+import { lazy, Suspense, useState } from 'react';
+
+const VideoUploadDialog = lazy(() =>
+  import('../../dialogs/upload').then((module) => ({
+    default: module.VideoUploadDialog,
+  })),
+);
+
+// Shown on the home page when the library is empty (loaded, zero videos +
+// playlists). The upload call-to-action mirrors the settings UploadButton: it's
+// gated by the `upload` feature flag and opens the same VideoUploadDialog.
+const WatchEmptyState = () => {
+  const [open, setOpen] = useState(false);
+  const { featureFlags } = Query.useQueryContext();
+  const uploadEnabled = Boolean(featureFlags.data?.['upload']);
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        textAlign: 'center',
+        gap: 2,
+        py: { xs: 6, sm: 10 },
+        color: 'text.secondary',
+      }}
+    >
+      <CloudUpload sx={{ fontSize: 64, opacity: 0.4 }} />
+      <Typography variant="h6" component="p" color="text.primary">
+        No videos yet
+      </Typography>
+      <Typography variant="body2" sx={{ maxWidth: 360 }}>
+        Upload your first video to start building your library.
+      </Typography>
+      {uploadEnabled && (
+        <Button
+          variant="contained"
+          startIcon={<CloudUpload />}
+          onClick={() => setOpen(true)}
+        >
+          Upload a video
+        </Button>
+      )}
+
+      {open && uploadEnabled && (
+        <Suspense fallback={null}>
+          <VideoUploadDialog open={open} onOpenChange={setOpen} />
+        </Suspense>
+      )}
+    </Box>
+  );
+};
+
+export { WatchEmptyState };


### PR DESCRIPTION
## Summary

A user with no videos saw a bare "Videos" heading over an empty grid (the Continue-watching section already self-hides). Now, when the home page is loaded and has no videos/playlists, it renders a `WatchEmptyState`:

- icon + "No videos yet" message + guidance;
- an "Upload a video" CTA that reuses the existing settings upload flow — gated by the `upload` feature flag, opening the same lazy `VideoUploadDialog`.

Loading still shows skeletons; a non-empty home page is unchanged.

Part of SWO-261. Closes SWO-267.

## Test plan

- `WatchEmptyState`: shows the message + upload CTA when the `upload` flag is on; hides the CTA when off.
- `HomeContainer`: renders the empty state (and not the "Videos" grid) when loaded with zero videos; does not render it while loading; non-empty + continue-watching paths unchanged.
- Full `packages/ui/src/watch` suite green (236 tests).
- Manual (`pnpm dev:watch`): empty library shows the state + CTA; uploading from it works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clearer empty state on the Watch home page when no videos are available.
  * Users may now see an “Upload a video” button in the empty state when uploads are enabled.

* **Bug Fixes**
  * Prevented the Videos section from showing an empty grid when the library is empty.
  * Kept the loading view separate so the empty state only appears after loading finishes.

* **Tests**
  * Added coverage for empty-state and loading behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->