### PR TITLE
[WIP] feat(watch): add title search/filter to the home page (SWO-265)

### DIFF
--- a/packages/ui/src/watch/home-page/container/index.test.tsx
+++ b/packages/ui/src/watch/home-page/container/index.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { VideoCard } from '../../videos/video-card';
 import { VideoSkeleton } from '../../videos/video-card/skeleton';
@@ -17,15 +17,31 @@ vi.mock('../continue-watching', () => ({
   ContinueWatchingSection: vi.fn(() => <div>ContinueWatchingSection</div>),
 }));
 
-vi.mock('../utils', () => ({
-  genlinkProps: (video: { id: string; slug: string }) => ({
-    to: '/video/$slug-$id',
-    params: {
-      slug: video.slug,
-      id: video.id,
-    },
-  }),
+// Synchronous stand-in for the debounced search field so tests can drive the
+// query directly.
+vi.mock('../search', () => ({
+  HomeSearch: ({ onQueryChange }: { onQueryChange: (q: string) => void }) => (
+    <input
+      aria-label="Search videos"
+      onChange={(event) => onQueryChange(event.target.value)}
+    />
+  ),
 }));
+
+// Keep the real filterByTitle; only stub genlinkProps to avoid route generation.
+vi.mock('../utils', async () => {
+  const actual = await vi.importActual<typeof import('../utils')>('../utils');
+  return {
+    ...actual,
+    genlinkProps: (video: { id: string; slug: string }) => ({
+      to: '/video/$slug-$id',
+      params: {
+        slug: video.slug,
+        id: video.id,
+      },
+    }),
+  };
+});
 
 const MockLink = vi.fn();
 
@@ -113,5 +129,59 @@ describe('HomeContainer', () => {
       }),
       expect.anything(),
     );
+  });
+
+  it('filters the grid by the search query', () => {
+    const mockVideos = [
+      { id: '1', title: 'React Basics' },
+      { id: '2', title: 'Vue Intro' },
+    ];
+
+    render(
+      <HomeContainer
+        queryRs={{
+          isLoading: false,
+          videos: mockVideos,
+          continueWatching: [],
+        }}
+        LinkComponent={MockLink}
+      />,
+    );
+
+    expect(VideoCard).toHaveBeenCalledTimes(2);
+    vi.mocked(VideoCard).mockClear();
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search videos' }), {
+      target: { value: 'vue' },
+    });
+
+    expect(VideoCard).toHaveBeenCalledTimes(1);
+    expect(VideoCard).toHaveBeenCalledWith(
+      expect.objectContaining({ video: mockVideos[1] }),
+      expect.anything(),
+    );
+  });
+
+  it('shows a no-results message when the query matches nothing', () => {
+    render(
+      <HomeContainer
+        queryRs={{
+          isLoading: false,
+          videos: [{ id: '1', title: 'React Basics' }],
+          continueWatching: [],
+        }}
+        LinkComponent={MockLink}
+      />,
+    );
+
+    // Clear the initial (unfiltered) render before applying the query.
+    vi.mocked(VideoCard).mockClear();
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search videos' }), {
+      target: { value: 'svelte' },
+    });
+
+    expect(screen.getByText(/No videos match/)).toBeInTheDocument();
+    expect(VideoCard).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/watch/home-page/container/index.tsx
+++ b/packages/ui/src/watch/home-page/container/index.tsx
@@ -3,12 +3,14 @@ import Container from '@mui/material/Container';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import type { useLoadVideos } from 'core/watch/query-hooks/videos';
+import { useState } from 'react';
 import type { RequiredLinkComponent } from '../../videos/types';
 import { VideoCard } from '../../videos/video-card';
 import { VideoSkeleton } from '../../videos/video-card/skeleton';
 import { GRID_COLUMN_PROPS } from '../columns';
 import { ContinueWatchingSection } from '../continue-watching';
-import { genlinkProps } from '../utils';
+import { HomeSearch } from '../search';
+import { filterByTitle, genlinkProps } from '../utils';
 
 const SKELETON_KEYS = Array.from({ length: 12 }, (_, i) => `skeleton-${i}`);
 
@@ -32,6 +34,11 @@ interface HomeContainerProps extends Omit<RequiredLinkComponent, 'linkProps'> {
 const HomeContainer = (props: HomeContainerProps) => {
   const { queryRs, LinkComponent } = props;
   const { videos, continueWatching, isLoading } = queryRs;
+  const [query, setQuery] = useState('');
+
+  const filteredVideos = filterByTitle(videos, query);
+  const hasQuery = query.trim().length > 0;
+  const noResults = !isLoading && hasQuery && filteredVideos.length === 0;
 
   return (
     <Container
@@ -43,25 +50,41 @@ const HomeContainer = (props: HomeContainerProps) => {
         videos={continueWatching}
         LinkComponent={LinkComponent}
       />
-      <Box sx={{ mb: 2 }}>
+      <Box
+        sx={{
+          mb: 2,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 2,
+          flexWrap: 'wrap',
+        }}
+      >
         <Typography variant="h6" component="h2">
           Videos
         </Typography>
+        <HomeSearch onQueryChange={setQuery} />
       </Box>
-      <Grid container spacing={3}>
-        {isLoading && <Loading />}
-        {!isLoading &&
-          videos.map((video) => (
-            <Grid item {...GRID_COLUMN_PROPS} key={video.id}>
-              <VideoCard
-                video={video}
-                asLink={true}
-                LinkComponent={LinkComponent}
-                linkProps={genlinkProps(video)}
-              />
-            </Grid>
-          ))}
-      </Grid>
+      {noResults ? (
+        <Typography variant="body2" color="text.secondary" sx={{ py: 4 }}>
+          No videos match “{query.trim()}”.
+        </Typography>
+      ) : (
+        <Grid container spacing={3}>
+          {isLoading && <Loading />}
+          {!isLoading &&
+            filteredVideos.map((video) => (
+              <Grid item {...GRID_COLUMN_PROPS} key={video.id}>
+                <VideoCard
+                  video={video}
+                  asLink={true}
+                  LinkComponent={LinkComponent}
+                  linkProps={genlinkProps(video)}
+                />
+              </Grid>
+            ))}
+        </Grid>
+      )}
     </Container>
   );
 };

--- a/packages/ui/src/watch/home-page/search/index.test.tsx
+++ b/packages/ui/src/watch/home-page/search/index.test.tsx
@@ -1,0 +1,42 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { HomeSearch } from './index';
+
+describe('HomeSearch', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('debounces input before emitting the query', () => {
+    const onQueryChange = vi.fn();
+    render(<HomeSearch onQueryChange={onQueryChange} />);
+
+    const input = screen.getByRole('textbox', { name: 'Search videos' });
+    fireEvent.change(input, { target: { value: 'react' } });
+
+    // Not emitted synchronously.
+    expect(onQueryChange).not.toHaveBeenCalledWith('react');
+
+    vi.advanceTimersByTime(200);
+    expect(onQueryChange).toHaveBeenCalledWith('react');
+  });
+
+  it('emits only the latest value when typing quickly', () => {
+    const onQueryChange = vi.fn();
+    render(<HomeSearch onQueryChange={onQueryChange} />);
+
+    const input = screen.getByRole('textbox', { name: 'Search videos' });
+    fireEvent.change(input, { target: { value: 'r' } });
+    fireEvent.change(input, { target: { value: 're' } });
+    fireEvent.change(input, { target: { value: 'rea' } });
+
+    vi.advanceTimersByTime(200);
+    expect(onQueryChange).not.toHaveBeenCalledWith('r');
+    expect(onQueryChange).not.toHaveBeenCalledWith('re');
+    expect(onQueryChange).toHaveBeenCalledWith('rea');
+  });
+});

--- a/packages/ui/src/watch/home-page/search/index.tsx
+++ b/packages/ui/src/watch/home-page/search/index.tsx
@@ -1,0 +1,43 @@
+import SearchIcon from '@mui/icons-material/Search';
+import InputAdornment from '@mui/material/InputAdornment';
+import TextField from '@mui/material/TextField';
+import { useEffect, useState } from 'react';
+
+// The grid is filtered client-side over an in-memory list, so a short debounce
+// is plenty to avoid re-filtering on every keystroke.
+const DEBOUNCE_MS = 200;
+
+interface HomeSearchProps {
+  onQueryChange: (query: string) => void;
+}
+
+const HomeSearch = (props: HomeSearchProps) => {
+  const { onQueryChange } = props;
+  const [value, setValue] = useState('');
+
+  useEffect(() => {
+    const id = setTimeout(() => onQueryChange(value), DEBOUNCE_MS);
+    return () => clearTimeout(id);
+  }, [value, onQueryChange]);
+
+  return (
+    <TextField
+      value={value}
+      onChange={(event) => setValue(event.target.value)}
+      placeholder="Search videos"
+      size="small"
+      fullWidth
+      inputProps={{ 'aria-label': 'Search videos' }}
+      InputProps={{
+        startAdornment: (
+          <InputAdornment position="start">
+            <SearchIcon fontSize="small" />
+          </InputAdornment>
+        ),
+      }}
+      sx={{ maxWidth: 360 }}
+    />
+  );
+};
+
+export { HomeSearch };

--- a/packages/ui/src/watch/home-page/utils.test.ts
+++ b/packages/ui/src/watch/home-page/utils.test.ts
@@ -5,7 +5,7 @@ import {
   type TransformedVideo,
 } from 'core/watch/query-hooks';
 import { describe, expect, it, vi } from 'vitest';
-import { genlinkProps } from './utils';
+import { filterByTitle, genlinkProps } from './utils';
 
 // Mock the route generation functions
 vi.mock('core/watch/routes', () => ({
@@ -49,5 +49,34 @@ describe('genlinkProps', () => {
     expect(() => genlinkProps(invalidMedia)).toThrow(AppError);
     // @ts-expect-error
     expect(() => genlinkProps(invalidMedia)).toThrow('Invalid media type');
+  });
+});
+
+describe('filterByTitle', () => {
+  const items = [
+    { title: 'React Basics' },
+    { title: 'Advanced React' },
+    { title: 'Vue Intro' },
+  ];
+
+  it('matches titles case-insensitively as a substring', () => {
+    expect(filterByTitle(items, 'react')).toEqual([
+      { title: 'React Basics' },
+      { title: 'Advanced React' },
+    ]);
+    expect(filterByTitle(items, 'VUE')).toEqual([{ title: 'Vue Intro' }]);
+  });
+
+  it('returns the full list for an empty or whitespace-only query', () => {
+    expect(filterByTitle(items, '')).toBe(items);
+    expect(filterByTitle(items, '   ')).toBe(items);
+  });
+
+  it('returns an empty array when nothing matches', () => {
+    expect(filterByTitle(items, 'svelte')).toEqual([]);
+  });
+
+  it('trims surrounding whitespace in the query', () => {
+    expect(filterByTitle(items, '  vue  ')).toEqual([{ title: 'Vue Intro' }]);
   });
 });

--- a/packages/ui/src/watch/home-page/utils.ts
+++ b/packages/ui/src/watch/home-page/utils.ts
@@ -31,4 +31,20 @@ const genlinkProps = (video: ReturnType<typeof useLoadVideos>['videos'][0]) => {
   throw new AppError('Invalid media type', 'Invalid media type', false);
 };
 
-export { genlinkProps };
+/**
+ * Filters media items by a case-insensitive title substring match. An empty or
+ * whitespace-only query is treated as no filter and returns the list unchanged.
+ */
+const filterByTitle = <T extends { title: string }>(
+  items: T[],
+  query: string,
+): T[] => {
+  const trimmed = query.trim().toLowerCase();
+  if (!trimmed) {
+    return items;
+  }
+
+  return items.filter((item) => item.title.toLowerCase().includes(trimmed));
+};
+
+export { filterByTitle, genlinkProps };


### PR DESCRIPTION
## Summary

The home grid was a flat `createdAt desc` list of every video + playlist — no way to find a specific one. Adds a debounced title search above the grid.

- `filterByTitle(items, query)` — pure, generic, case-insensitive substring match; empty/whitespace query returns the list unchanged.
- `HomeSearch` — a debounced (200ms) MUI search field.
- `HomeContainer` — holds the query, filters the grid, and shows a "No videos match …" message when nothing matches.

Filtering is **client-side** over the already-loaded list (the home query loads everything today) — no backend change. A server-side `where: { title: { _ilike } }` follow-up can come if the library outgrows client filtering.

Part of SWO-261. Closes SWO-265.

## Test plan

- `filterByTitle`: case-insensitive substring, empty/whitespace = no filter, no-match = empty, trims query.
- `HomeSearch`: debounces input; emits only the latest value when typing quickly (fake timers).
- `HomeContainer`: filters the grid by query; shows the no-results message when nothing matches; unfiltered render unchanged.
- Full `packages/ui/src/watch` suite green (241 tests).
- Manual (`pnpm dev:watch`): typing filters the grid; clearing restores it; no match shows the message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)