### PR TITLE
[WIP] feat(watch): set video thumbnail from a paused frame

### DIFF
--- a/apps/watch/src/routes/playlist.$slug.$playlistId.$videoId.lazy.tsx
+++ b/apps/watch/src/routes/playlist.$slug.$playlistId.$videoId.lazy.tsx
@@ -1,5 +1,6 @@
 import { createLazyFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import { Auth } from 'core';
+import { useQueryContext } from 'core/providers/query';
 import {
   buildVariables,
   formalize,
@@ -25,6 +26,7 @@ function VideoDetails(): JSX.Element {
   const { playlistId, videoId } = Route.useParams();
   const navigate = useNavigate();
   const authContext = Auth.useAuthContext();
+  const { invalidateQuery } = useQueryContext();
   const videoResult = useLoadPlaylistDetail({
     getAccessToken: authContext.getAccessToken,
     id: playlistId,
@@ -87,6 +89,10 @@ function VideoDetails(): JSX.Element {
         LinkComponent={Link}
         onVideoEnded={handleVideoEnded}
         onShare={handleShare}
+        onNotify={setNotification}
+        onThumbnailUpdated={() =>
+          invalidateQuery(['playlist-detail', playlistId])
+        }
       />
     </Layout>
   );

--- a/apps/watch/src/routes/video.$slug.$id.lazy.tsx
+++ b/apps/watch/src/routes/video.$slug.$id.lazy.tsx
@@ -1,5 +1,6 @@
 import { createLazyFileRoute, Link } from '@tanstack/react-router';
 import { useAuthContext } from 'core/providers/auth';
+import { useQueryContext } from 'core/providers/query';
 import {
   buildVariables,
   formalize,
@@ -25,6 +26,7 @@ function VideoDetails() {
   const { id: videoId } = Route.useParams();
   const navigate = Route.useNavigate();
   const authContext = useAuthContext();
+  const { invalidateQuery } = useQueryContext();
   const videoResult = useLoadVideoDetail({
     getAccessToken: authContext.getAccessToken,
     id: videoId,
@@ -79,6 +81,8 @@ function VideoDetails() {
         LinkComponent={Link}
         onVideoEnded={handleVideoEnded}
         onShare={handleShare}
+        onNotify={setNotification}
+        onThumbnailUpdated={() => invalidateQuery(['video-detail', videoId])}
       />
     </Layout>
   );

--- a/packages/core/src/graphql/gql.ts
+++ b/packages/core/src/graphql/gql.ts
@@ -40,6 +40,7 @@ type Documents = {
   '\n  subscription Notifications {\n    notifications(order_by: { createdAt: desc }) {\n      id\n      entityId\n      entityType\n      type\n      readAt\n      link\n      metadata\n      video {\n        id\n        title\n      }\n    }\n  }\n': typeof types.NotificationsDocument;
   '\n  mutation InsertVideos($objects: [videos_insert_input!]!) {\n    insert_videos(objects: $objects) {\n      returning {\n        id\n        title\n        description\n      }\n    }\n  }\n': typeof types.InsertVideosDocument;
   '\n  mutation SaveSubtitle($id: uuid!, $object: subtitles_set_input!) {\n    update_subtitles_by_pk(pk_columns: { id: $id }, _set: $object) {\n      id\n    }\n  }\n': typeof types.SaveSubtitleDocument;
+  '\n  mutation SetVideoThumbnailAtTime($input: SetVideoThumbnailAtTimeInput!) {\n    setVideoThumbnailAtTime(input: $input) {\n      success\n      message\n      dataObject {\n        thumbnailUrl\n      }\n    }\n  }\n': typeof types.SetVideoThumbnailAtTimeDocument;
   '\n  mutation sharePlaylist($id: uuid!, $emails: jsonb) {\n    update_playlist_by_pk(pk_columns: { id: $id }, _set: { sharedRecipientsInput: $emails }) {\n      id\n    }\n  }\n': typeof types.SharePlaylistDocument;
   '\n  mutation shareVideo($id: uuid!, $emails: jsonb) {\n    update_videos_by_pk(pk_columns: { id: $id }, _set: { sharedRecipientsInput: $emails }) {\n      id\n    }\n  }\n': typeof types.ShareVideoDocument;
   '\n  mutation UpdateVideoProgress($videoId: uuid!, $progressSeconds: Int!, $lastWatchedAt: timestamptz!) {\n    insert_user_video_history_one(\n      object: { video_id: $videoId, progress_seconds: $progressSeconds, last_watched_at: $lastWatchedAt }\n      on_conflict: {\n        constraint: user_video_history_user_id_video_id_key\n        update_columns: [progress_seconds, last_watched_at]\n      }\n    ) {\n      id\n      progress_seconds\n      last_watched_at\n    }\n  }\n': typeof types.UpdateVideoProgressDocument;
@@ -108,6 +109,8 @@ const documents: Documents = {
     types.InsertVideosDocument,
   '\n  mutation SaveSubtitle($id: uuid!, $object: subtitles_set_input!) {\n    update_subtitles_by_pk(pk_columns: { id: $id }, _set: $object) {\n      id\n    }\n  }\n':
     types.SaveSubtitleDocument,
+  '\n  mutation SetVideoThumbnailAtTime($input: SetVideoThumbnailAtTimeInput!) {\n    setVideoThumbnailAtTime(input: $input) {\n      success\n      message\n      dataObject {\n        thumbnailUrl\n      }\n    }\n  }\n':
+    types.SetVideoThumbnailAtTimeDocument,
   '\n  mutation sharePlaylist($id: uuid!, $emails: jsonb) {\n    update_playlist_by_pk(pk_columns: { id: $id }, _set: { sharedRecipientsInput: $emails }) {\n      id\n    }\n  }\n':
     types.SharePlaylistDocument,
   '\n  mutation shareVideo($id: uuid!, $emails: jsonb) {\n    update_videos_by_pk(pk_columns: { id: $id }, _set: { sharedRecipientsInput: $emails }) {\n      id\n    }\n  }\n':
@@ -296,6 +299,12 @@ export function graphql(
 export function graphql(
   source: '\n  mutation SaveSubtitle($id: uuid!, $object: subtitles_set_input!) {\n    update_subtitles_by_pk(pk_columns: { id: $id }, _set: $object) {\n      id\n    }\n  }\n',
 ): typeof import('./graphql').SaveSubtitleDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: '\n  mutation SetVideoThumbnailAtTime($input: SetVideoThumbnailAtTimeInput!) {\n    setVideoThumbnailAtTime(input: $input) {\n      success\n      message\n      dataObject {\n        thumbnailUrl\n      }\n    }\n  }\n',
+): typeof import('./graphql').SetVideoThumbnailAtTimeDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/packages/core/src/graphql/graphql.ts
+++ b/packages/core/src/graphql/graphql.ts
@@ -7092,6 +7092,23 @@ export type Reading_Progresses_Variance_Order_By = {
   totalPages?: InputMaybe<Order_By>;
 };
 
+export type SetVideoThumbnailAtTimeInput = {
+  atSeconds: Scalars['Float']['input'];
+  videoId: Scalars['String']['input'];
+};
+
+export type SetVideoThumbnailAtTimeOutput = {
+  __typename?: 'SetVideoThumbnailAtTimeOutput';
+  thumbnailUrl: Scalars['String']['output'];
+};
+
+export type SetVideoThumbnailAtTimeResponse = {
+  __typename?: 'SetVideoThumbnailAtTimeResponse';
+  dataObject?: Maybe<SetVideoThumbnailAtTimeOutput>;
+  message: Scalars['String']['output'];
+  success: Scalars['Boolean']['output'];
+};
+
 /** This table tell us what playlist is shared to whom. All videos in the playlist should be shared, not selective */
 export type Shared_Playlist_Recipients = {
   __typename?: 'shared_playlist_recipients';
@@ -12446,6 +12463,23 @@ export type SharePlaylistMutation = {
   update_playlist_by_pk?: { __typename?: 'playlist'; id: any } | null;
 };
 
+export type SetVideoThumbnailAtTimeMutationVariables = Exact<{
+  input: SetVideoThumbnailAtTimeInput;
+}>;
+
+export type SetVideoThumbnailAtTimeMutation = {
+  __typename?: 'mutation_root';
+  setVideoThumbnailAtTime: {
+    __typename?: 'SetVideoThumbnailAtTimeResponse';
+    success: boolean;
+    message: string;
+    dataObject?: {
+      __typename?: 'SetVideoThumbnailAtTimeOutput';
+      thumbnailUrl: string;
+    } | null;
+  };
+};
+
 export type ShareVideoMutationVariables = Exact<{
   id: Scalars['uuid']['input'];
   emails?: InputMaybe<Scalars['jsonb']['input']>;
@@ -13352,6 +13386,20 @@ export const SaveSubtitleDocument = new TypedDocumentString(`
     `) as unknown as TypedDocumentString<
   SaveSubtitleMutation,
   SaveSubtitleMutationVariables
+>;
+export const SetVideoThumbnailAtTimeDocument = new TypedDocumentString(`
+    mutation SetVideoThumbnailAtTime($input: SetVideoThumbnailAtTimeInput!) {
+  setVideoThumbnailAtTime(input: $input) {
+    success
+    message
+    dataObject {
+      thumbnailUrl
+    }
+  }
+}
+    `) as unknown as TypedDocumentString<
+  SetVideoThumbnailAtTimeMutation,
+  SetVideoThumbnailAtTimeMutationVariables
 >;
 export const SharePlaylistDocument = new TypedDocumentString(`
     mutation sharePlaylist($id: uuid!, $emails: jsonb) {

--- a/packages/core/src/watch/mutation-hooks/set-video-thumbnail/index.test.tsx
+++ b/packages/core/src/watch/mutation-hooks/set-video-thumbnail/index.test.tsx
@@ -1,0 +1,190 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+import type { FC, PropsWithChildren } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useMutationRequest } from '../../../universal/hooks/useMutation';
+import { useSetVideoThumbnail } from './';
+
+// Mock useMutationRequest
+vi.mock('../../../universal/hooks/useMutation', () => ({
+  useMutationRequest: vi.fn(),
+}));
+
+// Mock console.error
+const mockConsoleError = vi
+  .spyOn(console, 'error')
+  .mockImplementation(() => undefined);
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  const Wrapper: FC<PropsWithChildren> = ({ children }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  return Wrapper;
+};
+
+describe('useSetVideoThumbnail', () => {
+  const mockGetAccessToken = vi.fn().mockResolvedValue('test-token');
+  const mockVariables = {
+    input: {
+      videoId: 'test-video-id',
+      atSeconds: 87.5,
+    },
+  };
+
+  const mockSuccessResponse = {
+    setVideoThumbnailAtTime: {
+      success: true,
+      message: 'Thumbnail updated',
+      dataObject: {
+        thumbnailUrl: 'https://example.com/thumb.jpg',
+      },
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should successfully set the thumbnail and call onSuccess', async () => {
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+
+    vi.mocked(useMutationRequest).mockReturnValueOnce({
+      mutateAsync: vi.fn().mockImplementation(async (variables) => {
+        const result = mockSuccessResponse;
+        await Promise.resolve();
+        onSuccess(result, variables, undefined);
+        return result;
+      }),
+      mutate: vi.fn(),
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useSetVideoThumbnail({
+          getAccessToken: mockGetAccessToken,
+          onSuccess,
+          onError,
+        }),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    await result.current.mutateAsync(mockVariables);
+
+    expect(onSuccess).toHaveBeenCalledWith(
+      mockSuccessResponse,
+      mockVariables,
+      undefined,
+    );
+    expect(onError).not.toHaveBeenCalled();
+    expect(mockConsoleError).not.toHaveBeenCalled();
+  });
+
+  it('should handle errors and call onError', async () => {
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+    const mockError = new Error('Set thumbnail failed');
+
+    vi.mocked(useMutationRequest).mockReturnValueOnce({
+      mutateAsync: vi.fn().mockImplementation(async (variables) => {
+        await Promise.resolve();
+        onError(mockError, variables, undefined);
+        console.error('Set video thumbnail failed:', mockError);
+        throw mockError;
+      }),
+      mutate: vi.fn(),
+      isLoading: false,
+      isError: true,
+      error: mockError,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useSetVideoThumbnail({
+          getAccessToken: mockGetAccessToken,
+          onSuccess,
+          onError,
+        }),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    await expect(result.current.mutateAsync(mockVariables)).rejects.toThrow(
+      'Set thumbnail failed',
+    );
+
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledWith(mockError, mockVariables, undefined);
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      'Set video thumbnail failed:',
+      mockError,
+    );
+  });
+
+  it('should work without optional callbacks', async () => {
+    vi.mocked(useMutationRequest).mockReturnValueOnce({
+      mutateAsync: vi.fn().mockResolvedValue(mockSuccessResponse),
+      mutate: vi.fn(),
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useSetVideoThumbnail({
+          getAccessToken: mockGetAccessToken,
+        }),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    const response = await result.current.mutateAsync(mockVariables);
+    expect(response).toEqual(mockSuccessResponse);
+    expect(mockConsoleError).not.toHaveBeenCalled();
+  });
+
+  it('should pass the correct mutation document', () => {
+    vi.mocked(useMutationRequest).mockReturnValueOnce({
+      mutateAsync: vi.fn(),
+      mutate: vi.fn(),
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    renderHook(
+      () =>
+        useSetVideoThumbnail({
+          getAccessToken: mockGetAccessToken,
+        }),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    expect(useMutationRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        document: expect.stringContaining(
+          'mutation SetVideoThumbnailAtTime($input: SetVideoThumbnailAtTimeInput!)',
+        ),
+      }),
+    );
+  });
+});

--- a/packages/core/src/watch/mutation-hooks/set-video-thumbnail/index.ts
+++ b/packages/core/src/watch/mutation-hooks/set-video-thumbnail/index.ts
@@ -1,0 +1,53 @@
+import type { UseMutationOptions } from '@tanstack/react-query';
+import { graphql } from '../../../graphql';
+import type {
+  SetVideoThumbnailAtTimeMutation,
+  SetVideoThumbnailAtTimeMutationVariables,
+} from '../../../graphql/graphql';
+import { useMutationRequest } from '../../../universal/hooks/useMutation';
+
+const setVideoThumbnailAtTimeMutation = graphql(/* GraphQL */ `
+  mutation SetVideoThumbnailAtTime($input: SetVideoThumbnailAtTimeInput!) {
+    setVideoThumbnailAtTime(input: $input) {
+      success
+      message
+      dataObject {
+        thumbnailUrl
+      }
+    }
+  }
+`);
+
+type SetVideoThumbnailMutationOptions = UseMutationOptions<
+  SetVideoThumbnailAtTimeMutation,
+  unknown,
+  SetVideoThumbnailAtTimeMutationVariables,
+  unknown
+>;
+
+interface UseSetVideoThumbnailProps
+  extends Pick<SetVideoThumbnailMutationOptions, 'onSuccess' | 'onError'> {
+  getAccessToken: () => Promise<string>;
+}
+
+const useSetVideoThumbnail = (props: UseSetVideoThumbnailProps) => {
+  const { getAccessToken, onSuccess, onError } = props;
+
+  return useMutationRequest({
+    document: setVideoThumbnailAtTimeMutation,
+    getAccessToken,
+    options: {
+      onSuccess,
+      onError: (
+        error: unknown,
+        variables: SetVideoThumbnailAtTimeMutationVariables,
+        context: unknown,
+      ) => {
+        console.error('Set video thumbnail failed:', error);
+        onError?.(error, variables, context);
+      },
+    },
+  });
+};
+
+export { useSetVideoThumbnail };

--- a/packages/ui/src/watch/video-detail-page/containers/index.test.tsx
+++ b/packages/ui/src/watch/video-detail-page/containers/index.test.tsx
@@ -23,7 +23,7 @@ type MockVideo = {
   slug: string;
   duration: number;
   createdAt: string;
-  user: { username: string };
+  user: { id: string; username: string };
   lastWatchedAt: string | null;
   progressSeconds: number;
   subtitles: Array<{
@@ -73,12 +73,45 @@ vi.mock('@mui/material/Checkbox', () => ({
   ),
 }));
 
+// The mocked player exposes controls to drive paused state and the current
+// playback time (in seconds) from within tests.
+const mockCurrentTime = { value: 42 };
+
 // Create VideoContainer mock with a mock implementation
-const mockVideoContainer = vi.fn().mockImplementation(({ video, onEnded }) => (
-  <div data-testid="video-container" onClick={() => onEnded?.()}>
-    {video.title}
-  </div>
-));
+const mockVideoContainer = vi
+  .fn()
+  .mockImplementation(
+    ({ video, onEnded, onPausedChange, getCurrentTimeRef }) => {
+      if (getCurrentTimeRef) {
+        getCurrentTimeRef.current = () => mockCurrentTime.value;
+      }
+      return (
+        <div data-testid="video-container">
+          <button
+            type="button"
+            data-testid="video-container-ended"
+            onClick={() => onEnded?.()}
+          >
+            {video.title}
+          </button>
+          <button
+            type="button"
+            data-testid="video-container-pause"
+            onClick={() => onPausedChange?.(true)}
+          >
+            pause
+          </button>
+          <button
+            type="button"
+            data-testid="video-container-play"
+            onClick={() => onPausedChange?.(false)}
+          >
+            play
+          </button>
+        </div>
+      );
+    },
+  );
 
 // Mock the VideoContainer module
 vi.mock('../../videos/video-container', () => ({
@@ -86,7 +119,33 @@ vi.mock('../../videos/video-container', () => ({
     video: MockVideo;
     onEnded?: () => void;
     onError?: (error: unknown) => void;
+    onPausedChange?: (isPaused: boolean) => void;
+    getCurrentTimeRef?: {
+      current: (() => number | null) | null;
+    };
   }) => mockVideoContainer(props),
+}));
+
+// Mock the auth context so we can control the current user's id (owner check).
+const mockUseAuthContext = vi.fn();
+vi.mock('core/providers/auth', () => ({
+  useAuthContext: () => mockUseAuthContext(),
+}));
+
+// Mock the set-thumbnail mutation hook.
+const mockSetVideoThumbnail = vi.fn();
+let capturedThumbnailHandlers: {
+  onSuccess?: () => void;
+  onError?: () => void;
+} = {};
+vi.mock('core/watch/mutation-hooks/set-video-thumbnail', () => ({
+  useSetVideoThumbnail: (props: {
+    onSuccess?: () => void;
+    onError?: () => void;
+  }) => {
+    capturedThumbnailHandlers = props;
+    return { mutate: mockSetVideoThumbnail };
+  },
 }));
 
 vi.mock('../../dialogs/share', () => ({
@@ -197,7 +256,7 @@ const createMockVideo = (id: string, index: number) => ({
   slug: `video-${id}`,
   duration: 120 + index * 60,
   createdAt: `2023-01-${String(index + 1).padStart(2, '0')}`,
-  user: { username: 'testuser' },
+  user: { id: 'owner-1', username: 'testuser' },
   lastWatchedAt: null,
   progressSeconds: 0,
   subtitles: [
@@ -238,11 +297,45 @@ describe('VideoDetailContainer', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockVideoContainer.mockImplementation(({ video, onEnded }) => (
-      <div data-testid="video-container" onClick={() => onEnded?.()}>
-        {video.title}
-      </div>
-    ));
+    mockCurrentTime.value = 42;
+    capturedThumbnailHandlers = {};
+    // Default: current user is the video owner.
+    mockUseAuthContext.mockReturnValue({
+      getAccessToken: vi.fn(),
+      user: { id: 'owner-1' },
+    });
+    mockVideoContainer.mockImplementation(
+      ({ video, onEnded, onPausedChange, getCurrentTimeRef }) => {
+        if (getCurrentTimeRef) {
+          getCurrentTimeRef.current = () => mockCurrentTime.value;
+        }
+        return (
+          <div data-testid="video-container">
+            <button
+              type="button"
+              data-testid="video-container-ended"
+              onClick={() => onEnded?.()}
+            >
+              {video.title}
+            </button>
+            <button
+              type="button"
+              data-testid="video-container-pause"
+              onClick={() => onPausedChange?.(true)}
+            >
+              pause
+            </button>
+            <button
+              type="button"
+              data-testid="video-container-play"
+              onClick={() => onPausedChange?.(false)}
+            >
+              play
+            </button>
+          </div>
+        );
+      },
+    );
   });
 
   it('should render loading skeletons when isLoading is true', async () => {
@@ -377,7 +470,7 @@ describe('VideoDetailContainer', () => {
     renderWithTheme(<VideoDetailContainer {...props} />);
 
     // Simulate video end
-    fireEvent.click(screen.getByTestId('video-container'));
+    fireEvent.click(screen.getByTestId('video-container-ended'));
 
     // Should trigger onVideoEnded with next video
     expect(onVideoEnded).toHaveBeenCalledWith(
@@ -491,6 +584,97 @@ describe('VideoDetailContainer', () => {
       });
 
       expect(onShare).toHaveBeenCalledWith(['test@example.com']);
+    });
+  });
+
+  describe('set as thumbnail', () => {
+    const thumbnailLabel = 'Set as thumbnail';
+
+    it('shows the button only when the owner has paused the video', async () => {
+      await act(async () => {
+        renderWithTheme(<VideoDetailContainer {...createProps()} />);
+      });
+
+      // Hidden while playing.
+      expect(screen.queryByLabelText(thumbnailLabel)).not.toBeInTheDocument();
+
+      // Pause -> visible for the owner.
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('video-container-pause'));
+      });
+      expect(screen.getByLabelText(thumbnailLabel)).toBeInTheDocument();
+
+      // Resume -> hidden again.
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('video-container-play'));
+      });
+      expect(screen.queryByLabelText(thumbnailLabel)).not.toBeInTheDocument();
+    });
+
+    it('never shows the button for a non-owner, even when paused', async () => {
+      mockUseAuthContext.mockReturnValue({
+        getAccessToken: vi.fn(),
+        user: { id: 'someone-else' },
+      });
+
+      await act(async () => {
+        renderWithTheme(<VideoDetailContainer {...createProps()} />);
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('video-container-pause'));
+      });
+
+      expect(screen.queryByLabelText(thumbnailLabel)).not.toBeInTheDocument();
+    });
+
+    it('calls the mutation with the video id and current time on click', async () => {
+      mockCurrentTime.value = 87;
+
+      await act(async () => {
+        renderWithTheme(<VideoDetailContainer {...createProps()} />);
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('video-container-pause'));
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText(thumbnailLabel));
+      });
+
+      expect(mockSetVideoThumbnail).toHaveBeenCalledWith({
+        input: { videoId: 'video1', atSeconds: 87 },
+      });
+    });
+
+    it('notifies and refetches on success, notifies on error', async () => {
+      const onNotify = vi.fn();
+      const onThumbnailUpdated = vi.fn();
+
+      await act(async () => {
+        renderWithTheme(
+          <VideoDetailContainer
+            {...createProps({ onNotify, onThumbnailUpdated })}
+          />,
+        );
+      });
+
+      await act(async () => {
+        capturedThumbnailHandlers.onSuccess?.();
+      });
+      expect(onThumbnailUpdated).toHaveBeenCalledTimes(1);
+      expect(onNotify).toHaveBeenCalledWith({
+        message: 'Thumbnail updated',
+        severity: 'success',
+      });
+
+      await act(async () => {
+        capturedThumbnailHandlers.onError?.();
+      });
+      expect(onNotify).toHaveBeenCalledWith({
+        message: 'Failed to update thumbnail',
+        severity: 'error',
+      });
     });
   });
 

--- a/packages/ui/src/watch/video-detail-page/containers/index.tsx
+++ b/packages/ui/src/watch/video-detail-page/containers/index.tsx
@@ -1,4 +1,5 @@
 import EditIcon from '@mui/icons-material/Edit';
+import ImageIcon from '@mui/icons-material/Image';
 import PlaylistPlayIcon from '@mui/icons-material/PlaylistPlay';
 import ShareIcon from '@mui/icons-material/Share';
 import { Box, IconButton, Stack, Tooltip } from '@mui/material';
@@ -7,6 +8,7 @@ import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import { useAuthContext } from 'core/providers/auth';
 import { useSaveSubtitle } from 'core/watch/mutation-hooks/save-subtitle';
+import { useSetVideoThumbnail } from 'core/watch/mutation-hooks/set-video-thumbnail';
 import React, { Suspense } from 'react';
 import { getMediaDisplayName } from '../../utils';
 import { VideoContainer } from '../../videos/video-container';
@@ -45,21 +47,58 @@ const SubtitleDialog = React.lazy(() =>
 // long-lived event handlers.
 
 const MainContent = (props: VideoDetailContainerProps) => {
-  const { queryRs, activeVideoId, onVideoEnded, autoPlay, onShare } = props;
+  const {
+    queryRs,
+    activeVideoId,
+    onVideoEnded,
+    autoPlay,
+    onShare,
+    onNotify,
+    onThumbnailUpdated,
+  } = props;
   const { isLoading, videos, playlist } = queryRs;
   const isPlaylist = Boolean(playlist);
 
-  const { getAccessToken } = useAuthContext();
+  const { getAccessToken, user } = useAuthContext();
 
   // All hooks at the top
   const shouldPlayNextRef = React.useRef(autoPlay);
   const [shareDialogOpen, setShareDialogOpen] = React.useState(false);
   const [isSubtitleDialogOpen, setIsSubtitleDialogOpen] = React.useState(false);
+  const [isPaused, setIsPaused] = React.useState(false);
+  // Filled by the player with a getter for the current playback time (seconds).
+  const getCurrentTimeRef = React.useRef<(() => number | null) | null>(null);
 
   const videoDetail = React.useMemo(
     () => videos.find((video) => video.id === activeVideoId),
     [videos, activeVideoId],
   );
+
+  const isOwner = Boolean(user?.id) && videoDetail?.user.id === user?.id;
+
+  const { mutate: setVideoThumbnail } = useSetVideoThumbnail({
+    getAccessToken,
+    onSuccess: () => {
+      // Ask the route to refetch its own detail query so the new thumbnail is
+      // reflected without a hard reload (the route owns its query key).
+      onThumbnailUpdated?.();
+      onNotify?.({ message: 'Thumbnail updated', severity: 'success' });
+    },
+    onError: () => {
+      onNotify?.({ message: 'Failed to update thumbnail', severity: 'error' });
+    },
+  });
+
+  const handleSetThumbnail = React.useCallback(() => {
+    if (!videoDetail) return;
+
+    const atSeconds = getCurrentTimeRef.current?.() ?? null;
+    if (atSeconds === null) return;
+
+    setVideoThumbnail({
+      input: { videoId: videoDetail.id, atSeconds },
+    });
+  }, [videoDetail, setVideoThumbnail]);
 
   React.useEffect(() => {
     shouldPlayNextRef.current = autoPlay;
@@ -150,6 +189,8 @@ const MainContent = (props: VideoDetailContainerProps) => {
             console.log(err);
           }}
           onEnded={handleVideoEnd}
+          onPausedChange={setIsPaused}
+          getCurrentTimeRef={getCurrentTimeRef}
         />
       </Box>
       <Stack direction="row" alignItems="center" spacing={1} sx={{ mt: 2 }}>
@@ -175,6 +216,17 @@ const MainContent = (props: VideoDetailContainerProps) => {
             playlistName: playlist?.title,
           })}
         </Typography>
+        {isOwner && isPaused && (
+          <Tooltip title="Set as thumbnail">
+            <IconButton
+              onClick={handleSetThumbnail}
+              size="small"
+              aria-label="Set as thumbnail"
+            >
+              <ImageIcon />
+            </IconButton>
+          </Tooltip>
+        )}
         {onShare && (
           <Tooltip title="Share video">
             <IconButton onClick={() => setShareDialogOpen(true)} size="small">

--- a/packages/ui/src/watch/video-detail-page/containers/types.ts
+++ b/packages/ui/src/watch/video-detail-page/containers/types.ts
@@ -2,6 +2,11 @@ import type { useLoadPlaylistDetail } from 'core/watch/query-hooks/playlist-deta
 import type { useLoadVideoDetail } from 'core/watch/query-hooks/video-detail';
 import type { RequiredLinkComponent } from '../../videos/types';
 
+interface DetailNotification {
+  message: string;
+  severity: 'success' | 'error' | 'warning' | 'info';
+}
+
 interface VideoDetailContainerProps
   extends Omit<RequiredLinkComponent, 'linkProps'> {
   onVideoEnded?: (nextVideo: { id: string; slug: string }) => void;
@@ -11,6 +16,8 @@ interface VideoDetailContainerProps
   activeVideoId: string;
   autoPlay?: boolean;
   onShare?: (emails: string[]) => void;
+  onNotify?: (notification: DetailNotification) => void;
+  onThumbnailUpdated?: () => void;
 }
 
-export type { VideoDetailContainerProps };
+export type { DetailNotification, VideoDetailContainerProps };

--- a/packages/ui/src/watch/videos/video-container/index.tsx
+++ b/packages/ui/src/watch/videos/video-container/index.tsx
@@ -1,3 +1,4 @@
+import type { MutableRefObject } from 'react';
 import type { PlayableVideo } from '../types';
 import { VideoPlayer } from '../video-player';
 
@@ -5,12 +6,22 @@ interface VideoContainerInterface {
   video: PlayableVideo;
   onEnded?: () => void;
   onError?: (error: unknown) => void;
+  onPausedChange?: (isPaused: boolean) => void;
+  getCurrentTimeRef?: MutableRefObject<(() => number | null) | null>;
 }
 
 const VideoContainer = (props: VideoContainerInterface) => {
-  const { video, onEnded, onError } = props;
+  const { video, onEnded, onError, onPausedChange, getCurrentTimeRef } = props;
 
-  return <VideoPlayer video={video} onEnded={onEnded} onError={onError} />;
+  return (
+    <VideoPlayer
+      video={video}
+      onEnded={onEnded}
+      onError={onError}
+      onPausedChange={onPausedChange}
+      getCurrentTimeRef={getCurrentTimeRef}
+    />
+  );
 };
 
 export { VideoContainer };

--- a/packages/ui/src/watch/videos/video-player/index.tsx
+++ b/packages/ui/src/watch/videos/video-player/index.tsx
@@ -3,6 +3,7 @@ import { useAuthContext } from 'core/providers/auth';
 import { useVideoProgress } from 'core/watch/mutation-hooks/use-video-progress';
 import {
   lazy,
+  type MutableRefObject,
   Suspense,
   useCallback,
   useEffect,
@@ -31,6 +32,13 @@ interface VideoPlayerProps {
   video: PlayableVideo;
   onEnded?: () => void;
   onError?: (error: unknown) => void;
+  // Notifies the parent whenever the player is paused/resumed so owner-only
+  // controls (e.g. "Set as thumbnail") can react to the paused state.
+  onPausedChange?: (isPaused: boolean) => void;
+  // A ref the player fills with a getter for the current playback time in
+  // seconds, letting the parent read the paused frame without owning the
+  // player instance.
+  getCurrentTimeRef?: MutableRefObject<(() => number | null) | null>;
 }
 
 /**
@@ -56,7 +64,7 @@ interface VideoPlayerProps {
  */
 
 const VideoPlayer = (props: VideoPlayerProps) => {
-  const { video, onEnded, onError } = props;
+  const { video, onEnded, onError, onPausedChange, getCurrentTimeRef } = props;
   const { title, source, thumbnailUrl, subtitles } = video;
   const { isSignedIn, getAccessToken } = useAuthContext();
   const {
@@ -97,12 +105,34 @@ const VideoPlayer = (props: VideoPlayerProps) => {
     hasResumedRef.current = false;
   }, [video.id]);
 
-  // biome-ignore lint/suspicious/noExplicitAny: ReactPlayer passes an implementation-specific instance
-  const setPlayerRef = useCallback((player: any) => {
-    if (!player) return;
+  const setPlayerRef = useCallback(
+    // biome-ignore lint/suspicious/noExplicitAny: ReactPlayer passes an implementation-specific instance
+    (player: any) => {
+      if (!player) return;
 
-    playerRef.current = player;
-  }, []);
+      playerRef.current = player;
+
+      // Expose a current-time getter to the parent so it can read the paused
+      // frame's timestamp without holding the player instance itself.
+      if (getCurrentTimeRef) {
+        getCurrentTimeRef.current = () =>
+          playerRef.current?.getCurrentTime?.() ?? null;
+      }
+    },
+    [getCurrentTimeRef],
+  );
+
+  // Wrap the progress-tracking pause/play handlers so the parent also learns
+  // about the paused state (native controls fire onPause/onPlay directly).
+  const handlePauseWithNotify = useCallback(() => {
+    handlePause();
+    onPausedChange?.(true);
+  }, [handlePause, onPausedChange]);
+
+  const handlePlayWithNotify = useCallback(() => {
+    handlePlay();
+    onPausedChange?.(false);
+  }, [handlePlay, onPausedChange]);
 
   // Handle keyboard shortcuts on the wrapper element
   useEffect(() => {
@@ -377,11 +407,12 @@ const VideoPlayer = (props: VideoPlayerProps) => {
           playbackRate={playerState.playbackRate}
           onError={handleError}
           onProgress={handleProgress}
-          onPause={handlePause}
-          onPlay={handlePlay}
+          onPause={handlePauseWithNotify}
+          onPlay={handlePlayWithNotify}
           onSeek={handleSeek}
           onEnded={() => {
             handleEnded();
+            onPausedChange?.(false);
             onEnded?.();
           }}
           onReady={handleReady}


### PR DESCRIPTION
## Summary

Lets the owner of a video choose its thumbnail in the Watch app. Pause your own video on any frame and a **Set as thumbnail** button appears next to Share; clicking it makes that exact frame the video's thumbnail, and the picture updates in place without a page reload. Only the video's owner sees the button. Part of SWO-269 / SWO-274.

Depends on the `setVideoThumbnailAtTime` backend action + Hasura metadata being deployed (already merged) — until prod Hasura has it applied, the button will error.

## Test plan

- [ ] In the **Watch** app, open a video you own and pause it on a frame. A **Set as thumbnail** button appears near Share. Click it — after a moment the video's thumbnail becomes that frame, without reloading.
- [ ] Open a video you do **not** own and pause it — no **Set as thumbnail** button appears.
- [ ] While a video is playing (not paused), the button is not shown.
- [ ] CI green