### PR TITLE
[WIP] feat(watch): add signed-upload + set-thumbnail-url mutation hooks

### DIFF
--- a/packages/core/src/graphql/gql.ts
+++ b/packages/core/src/graphql/gql.ts
@@ -41,6 +41,8 @@ type Documents = {
   '\n  mutation InsertVideos($objects: [videos_insert_input!]!) {\n    insert_videos(objects: $objects) {\n      returning {\n        id\n        title\n        description\n      }\n    }\n  }\n': typeof types.InsertVideosDocument;
   '\n  mutation SaveSubtitle($id: uuid!, $object: subtitles_set_input!) {\n    update_subtitles_by_pk(pk_columns: { id: $id }, _set: $object) {\n      id\n    }\n  }\n': typeof types.SaveSubtitleDocument;
   '\n  mutation SetVideoThumbnailAtTime($input: SetVideoThumbnailAtTimeInput!) {\n    setVideoThumbnailAtTime(input: $input) {\n      success\n      message\n      dataObject {\n        thumbnailUrl\n      }\n    }\n  }\n': typeof types.SetVideoThumbnailAtTimeDocument;
+  '\n  mutation CreateSignedUploadUrl($input: SignedUploadUrlInput!) {\n    createSignedUploadUrl(input: $input) {\n      success\n      message\n      dataObject {\n        uploadUrl\n        publicUrl\n        objectPath\n        expiresAt\n      }\n    }\n  }\n': typeof types.CreateSignedUploadUrlDocument;
+  '\n  mutation SetVideoThumbnailUrl($input: SetVideoThumbnailUrlInput!) {\n    setVideoThumbnailUrl(input: $input) {\n      success\n      message\n      dataObject {\n        thumbnailUrl\n      }\n    }\n  }\n': typeof types.SetVideoThumbnailUrlDocument;
   '\n  mutation sharePlaylist($id: uuid!, $emails: jsonb) {\n    update_playlist_by_pk(pk_columns: { id: $id }, _set: { sharedRecipientsInput: $emails }) {\n      id\n    }\n  }\n': typeof types.SharePlaylistDocument;
   '\n  mutation shareVideo($id: uuid!, $emails: jsonb) {\n    update_videos_by_pk(pk_columns: { id: $id }, _set: { sharedRecipientsInput: $emails }) {\n      id\n    }\n  }\n': typeof types.ShareVideoDocument;
   '\n  mutation UpdateVideoProgress($videoId: uuid!, $progressSeconds: Int!, $lastWatchedAt: timestamptz!) {\n    insert_user_video_history_one(\n      object: { video_id: $videoId, progress_seconds: $progressSeconds, last_watched_at: $lastWatchedAt }\n      on_conflict: {\n        constraint: user_video_history_user_id_video_id_key\n        update_columns: [progress_seconds, last_watched_at]\n      }\n    ) {\n      id\n      progress_seconds\n      last_watched_at\n    }\n  }\n': typeof types.UpdateVideoProgressDocument;
@@ -111,6 +113,10 @@ const documents: Documents = {
     types.SaveSubtitleDocument,
   '\n  mutation SetVideoThumbnailAtTime($input: SetVideoThumbnailAtTimeInput!) {\n    setVideoThumbnailAtTime(input: $input) {\n      success\n      message\n      dataObject {\n        thumbnailUrl\n      }\n    }\n  }\n':
     types.SetVideoThumbnailAtTimeDocument,
+  '\n  mutation CreateSignedUploadUrl($input: SignedUploadUrlInput!) {\n    createSignedUploadUrl(input: $input) {\n      success\n      message\n      dataObject {\n        uploadUrl\n        publicUrl\n        objectPath\n        expiresAt\n      }\n    }\n  }\n':
+    types.CreateSignedUploadUrlDocument,
+  '\n  mutation SetVideoThumbnailUrl($input: SetVideoThumbnailUrlInput!) {\n    setVideoThumbnailUrl(input: $input) {\n      success\n      message\n      dataObject {\n        thumbnailUrl\n      }\n    }\n  }\n':
+    types.SetVideoThumbnailUrlDocument,
   '\n  mutation sharePlaylist($id: uuid!, $emails: jsonb) {\n    update_playlist_by_pk(pk_columns: { id: $id }, _set: { sharedRecipientsInput: $emails }) {\n      id\n    }\n  }\n':
     types.SharePlaylistDocument,
   '\n  mutation shareVideo($id: uuid!, $emails: jsonb) {\n    update_videos_by_pk(pk_columns: { id: $id }, _set: { sharedRecipientsInput: $emails }) {\n      id\n    }\n  }\n':
@@ -305,6 +311,18 @@ export function graphql(
 export function graphql(
   source: '\n  mutation SetVideoThumbnailAtTime($input: SetVideoThumbnailAtTimeInput!) {\n    setVideoThumbnailAtTime(input: $input) {\n      success\n      message\n      dataObject {\n        thumbnailUrl\n      }\n    }\n  }\n',
 ): typeof import('./graphql').SetVideoThumbnailAtTimeDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: '\n  mutation CreateSignedUploadUrl($input: SignedUploadUrlInput!) {\n    createSignedUploadUrl(input: $input) {\n      success\n      message\n      dataObject {\n        uploadUrl\n        publicUrl\n        objectPath\n        expiresAt\n      }\n    }\n  }\n',
+): typeof import('./graphql').CreateSignedUploadUrlDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: '\n  mutation SetVideoThumbnailUrl($input: SetVideoThumbnailUrlInput!) {\n    setVideoThumbnailUrl(input: $input) {\n      success\n      message\n      dataObject {\n        thumbnailUrl\n      }\n    }\n  }\n',
+): typeof import('./graphql').SetVideoThumbnailUrlDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/packages/core/src/graphql/graphql.ts
+++ b/packages/core/src/graphql/graphql.ts
@@ -88,6 +88,23 @@ export type Int_Comparison_Exp = {
   _nin?: InputMaybe<Array<Scalars['Int']['input']>>;
 };
 
+export type SetVideoThumbnailUrlInput = {
+  objectPath: Scalars['String']['input'];
+  videoId: Scalars['String']['input'];
+};
+
+export type SetVideoThumbnailUrlOutput = {
+  __typename?: 'SetVideoThumbnailUrlOutput';
+  thumbnailUrl: Scalars['String']['output'];
+};
+
+export type SetVideoThumbnailUrlResponse = {
+  __typename?: 'SetVideoThumbnailUrlResponse';
+  dataObject?: Maybe<SetVideoThumbnailUrlOutput>;
+  message: Scalars['String']['output'];
+  success: Scalars['Boolean']['output'];
+};
+
 export type SignedUploadUrlInput = {
   action: Scalars['String']['input'];
   contentType: Scalars['String']['input'];
@@ -12480,6 +12497,43 @@ export type SetVideoThumbnailAtTimeMutation = {
   };
 };
 
+export type CreateSignedUploadUrlMutationVariables = Exact<{
+  input: SignedUploadUrlInput;
+}>;
+
+export type CreateSignedUploadUrlMutation = {
+  __typename?: 'mutation_root';
+  createSignedUploadUrl: {
+    __typename?: 'SignedUploadUrlResponse';
+    success: boolean;
+    message: string;
+    dataObject?: {
+      __typename?: 'SignedUploadUrlOutput';
+      uploadUrl: string;
+      publicUrl: string;
+      objectPath: string;
+      expiresAt: string;
+    } | null;
+  };
+};
+
+export type SetVideoThumbnailUrlMutationVariables = Exact<{
+  input: SetVideoThumbnailUrlInput;
+}>;
+
+export type SetVideoThumbnailUrlMutation = {
+  __typename?: 'mutation_root';
+  setVideoThumbnailUrl: {
+    __typename?: 'SetVideoThumbnailUrlResponse';
+    success: boolean;
+    message: string;
+    dataObject?: {
+      __typename?: 'SetVideoThumbnailUrlOutput';
+      thumbnailUrl: string;
+    } | null;
+  };
+};
+
 export type ShareVideoMutationVariables = Exact<{
   id: Scalars['uuid']['input'];
   emails?: InputMaybe<Scalars['jsonb']['input']>;
@@ -13399,6 +13453,37 @@ export const SetVideoThumbnailAtTimeDocument = new TypedDocumentString(`
     `) as unknown as TypedDocumentString<
   SetVideoThumbnailAtTimeMutation,
   SetVideoThumbnailAtTimeMutationVariables
+>;
+export const CreateSignedUploadUrlDocument = new TypedDocumentString(`
+    mutation CreateSignedUploadUrl($input: SignedUploadUrlInput!) {
+  createSignedUploadUrl(input: $input) {
+    success
+    message
+    dataObject {
+      uploadUrl
+      publicUrl
+      objectPath
+      expiresAt
+    }
+  }
+}
+    `) as unknown as TypedDocumentString<
+  CreateSignedUploadUrlMutation,
+  CreateSignedUploadUrlMutationVariables
+>;
+export const SetVideoThumbnailUrlDocument = new TypedDocumentString(`
+    mutation SetVideoThumbnailUrl($input: SetVideoThumbnailUrlInput!) {
+  setVideoThumbnailUrl(input: $input) {
+    success
+    message
+    dataObject {
+      thumbnailUrl
+    }
+  }
+}
+    `) as unknown as TypedDocumentString<
+  SetVideoThumbnailUrlMutation,
+  SetVideoThumbnailUrlMutationVariables
 >;
 export const SharePlaylistDocument = new TypedDocumentString(`
     mutation sharePlaylist($id: uuid!, $emails: jsonb) {

--- a/packages/core/src/watch/mutation-hooks/create-signed-upload-url/index.test.tsx
+++ b/packages/core/src/watch/mutation-hooks/create-signed-upload-url/index.test.tsx
@@ -1,0 +1,195 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+import type { FC, PropsWithChildren } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useMutationRequest } from '../../../universal/hooks/useMutation';
+import { useCreateSignedUploadUrl } from './';
+
+// Mock useMutationRequest
+vi.mock('../../../universal/hooks/useMutation', () => ({
+  useMutationRequest: vi.fn(),
+}));
+
+// Mock console.error
+const mockConsoleError = vi
+  .spyOn(console, 'error')
+  .mockImplementation(() => undefined);
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  const Wrapper: FC<PropsWithChildren> = ({ children }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  return Wrapper;
+};
+
+describe('useCreateSignedUploadUrl', () => {
+  const mockGetAccessToken = vi.fn().mockResolvedValue('test-token');
+  const mockVariables = {
+    input: {
+      site: 'watch',
+      action: 'thumbnail',
+      id: 'test-video-id',
+      contentType: 'image/png',
+    },
+  };
+
+  const mockSuccessResponse = {
+    createSignedUploadUrl: {
+      success: true,
+      message: 'ok',
+      dataObject: {
+        uploadUrl: 'https://example.com/upload',
+        publicUrl: 'https://example.com/public',
+        objectPath: 'watch/thumbnail/test.png',
+        expiresAt: '2026-01-01T00:00:00Z',
+      },
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should successfully create signed upload URL and call onSuccess', async () => {
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+
+    vi.mocked(useMutationRequest).mockReturnValueOnce({
+      mutateAsync: vi.fn().mockImplementation(async (variables) => {
+        const result = mockSuccessResponse;
+        await Promise.resolve();
+        onSuccess(result, variables, undefined);
+        return result;
+      }),
+      mutate: vi.fn(),
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useCreateSignedUploadUrl({
+          getAccessToken: mockGetAccessToken,
+          onSuccess,
+          onError,
+        }),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    await result.current.mutateAsync(mockVariables);
+
+    expect(onSuccess).toHaveBeenCalledWith(
+      mockSuccessResponse,
+      mockVariables,
+      undefined,
+    );
+    expect(onError).not.toHaveBeenCalled();
+    expect(mockConsoleError).not.toHaveBeenCalled();
+  });
+
+  it('should handle errors and call onError', async () => {
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+    const mockError = new Error('Create signed URL failed');
+
+    vi.mocked(useMutationRequest).mockReturnValueOnce({
+      mutateAsync: vi.fn().mockImplementation(async (variables) => {
+        await Promise.resolve();
+        onError(mockError, variables, undefined);
+        console.error('Create signed upload URL failed:', mockError);
+        throw mockError;
+      }),
+      mutate: vi.fn(),
+      isLoading: false,
+      isError: true,
+      error: mockError,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useCreateSignedUploadUrl({
+          getAccessToken: mockGetAccessToken,
+          onSuccess,
+          onError,
+        }),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    await expect(result.current.mutateAsync(mockVariables)).rejects.toThrow(
+      'Create signed URL failed',
+    );
+
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledWith(mockError, mockVariables, undefined);
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      'Create signed upload URL failed:',
+      mockError,
+    );
+  });
+
+  it('should work without optional callbacks', async () => {
+    vi.mocked(useMutationRequest).mockReturnValueOnce({
+      mutateAsync: vi.fn().mockResolvedValue(mockSuccessResponse),
+      mutate: vi.fn(),
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useCreateSignedUploadUrl({
+          getAccessToken: mockGetAccessToken,
+        }),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    const response = await result.current.mutateAsync(mockVariables);
+    expect(response).toEqual(mockSuccessResponse);
+    expect(mockConsoleError).not.toHaveBeenCalled();
+  });
+
+  it('should pass the correct mutation document', () => {
+    vi.mocked(useMutationRequest).mockReturnValueOnce({
+      mutateAsync: vi.fn(),
+      mutate: vi.fn(),
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    renderHook(
+      () =>
+        useCreateSignedUploadUrl({
+          getAccessToken: mockGetAccessToken,
+        }),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    expect(useMutationRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        document: expect.stringContaining(
+          'mutation CreateSignedUploadUrl($input: SignedUploadUrlInput!)',
+        ),
+      }),
+    );
+  });
+});

--- a/packages/core/src/watch/mutation-hooks/create-signed-upload-url/index.ts
+++ b/packages/core/src/watch/mutation-hooks/create-signed-upload-url/index.ts
@@ -1,0 +1,56 @@
+import type { UseMutationOptions } from '@tanstack/react-query';
+import { graphql } from '../../../graphql';
+import type {
+  CreateSignedUploadUrlMutation,
+  CreateSignedUploadUrlMutationVariables,
+} from '../../../graphql/graphql';
+import { useMutationRequest } from '../../../universal/hooks/useMutation';
+
+const createSignedUploadUrlMutation = graphql(/* GraphQL */ `
+  mutation CreateSignedUploadUrl($input: SignedUploadUrlInput!) {
+    createSignedUploadUrl(input: $input) {
+      success
+      message
+      dataObject {
+        uploadUrl
+        publicUrl
+        objectPath
+        expiresAt
+      }
+    }
+  }
+`);
+
+type CreateSignedUploadUrlMutationOptions = UseMutationOptions<
+  CreateSignedUploadUrlMutation,
+  unknown,
+  CreateSignedUploadUrlMutationVariables,
+  unknown
+>;
+
+interface UseCreateSignedUploadUrlProps
+  extends Pick<CreateSignedUploadUrlMutationOptions, 'onSuccess' | 'onError'> {
+  getAccessToken: () => Promise<string>;
+}
+
+const useCreateSignedUploadUrl = (props: UseCreateSignedUploadUrlProps) => {
+  const { getAccessToken, onSuccess, onError } = props;
+
+  return useMutationRequest({
+    document: createSignedUploadUrlMutation,
+    getAccessToken,
+    options: {
+      onSuccess,
+      onError: (
+        error: unknown,
+        variables: CreateSignedUploadUrlMutationVariables,
+        context: unknown,
+      ) => {
+        console.error('Create signed upload URL failed:', error);
+        onError?.(error, variables, context);
+      },
+    },
+  });
+};
+
+export { useCreateSignedUploadUrl };

--- a/packages/core/src/watch/mutation-hooks/set-video-thumbnail-url/index.test.tsx
+++ b/packages/core/src/watch/mutation-hooks/set-video-thumbnail-url/index.test.tsx
@@ -1,0 +1,190 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+import type { FC, PropsWithChildren } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useMutationRequest } from '../../../universal/hooks/useMutation';
+import { useSetVideoThumbnailUrl } from './';
+
+// Mock useMutationRequest
+vi.mock('../../../universal/hooks/useMutation', () => ({
+  useMutationRequest: vi.fn(),
+}));
+
+// Mock console.error
+const mockConsoleError = vi
+  .spyOn(console, 'error')
+  .mockImplementation(() => undefined);
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  const Wrapper: FC<PropsWithChildren> = ({ children }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  return Wrapper;
+};
+
+describe('useSetVideoThumbnailUrl', () => {
+  const mockGetAccessToken = vi.fn().mockResolvedValue('test-token');
+  const mockVariables = {
+    input: {
+      videoId: 'test-video-id',
+      objectPath: 'watch/thumbnail/test.png',
+    },
+  };
+
+  const mockSuccessResponse = {
+    setVideoThumbnailUrl: {
+      success: true,
+      message: 'ok',
+      dataObject: {
+        thumbnailUrl: 'https://example.com/thumbnail.png',
+      },
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should successfully set video thumbnail URL and call onSuccess', async () => {
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+
+    vi.mocked(useMutationRequest).mockReturnValueOnce({
+      mutateAsync: vi.fn().mockImplementation(async (variables) => {
+        const result = mockSuccessResponse;
+        await Promise.resolve();
+        onSuccess(result, variables, undefined);
+        return result;
+      }),
+      mutate: vi.fn(),
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useSetVideoThumbnailUrl({
+          getAccessToken: mockGetAccessToken,
+          onSuccess,
+          onError,
+        }),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    await result.current.mutateAsync(mockVariables);
+
+    expect(onSuccess).toHaveBeenCalledWith(
+      mockSuccessResponse,
+      mockVariables,
+      undefined,
+    );
+    expect(onError).not.toHaveBeenCalled();
+    expect(mockConsoleError).not.toHaveBeenCalled();
+  });
+
+  it('should handle errors and call onError', async () => {
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+    const mockError = new Error('Set thumbnail URL failed');
+
+    vi.mocked(useMutationRequest).mockReturnValueOnce({
+      mutateAsync: vi.fn().mockImplementation(async (variables) => {
+        await Promise.resolve();
+        onError(mockError, variables, undefined);
+        console.error('Set video thumbnail URL failed:', mockError);
+        throw mockError;
+      }),
+      mutate: vi.fn(),
+      isLoading: false,
+      isError: true,
+      error: mockError,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useSetVideoThumbnailUrl({
+          getAccessToken: mockGetAccessToken,
+          onSuccess,
+          onError,
+        }),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    await expect(result.current.mutateAsync(mockVariables)).rejects.toThrow(
+      'Set thumbnail URL failed',
+    );
+
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledWith(mockError, mockVariables, undefined);
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      'Set video thumbnail URL failed:',
+      mockError,
+    );
+  });
+
+  it('should work without optional callbacks', async () => {
+    vi.mocked(useMutationRequest).mockReturnValueOnce({
+      mutateAsync: vi.fn().mockResolvedValue(mockSuccessResponse),
+      mutate: vi.fn(),
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useSetVideoThumbnailUrl({
+          getAccessToken: mockGetAccessToken,
+        }),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    const response = await result.current.mutateAsync(mockVariables);
+    expect(response).toEqual(mockSuccessResponse);
+    expect(mockConsoleError).not.toHaveBeenCalled();
+  });
+
+  it('should pass the correct mutation document', () => {
+    vi.mocked(useMutationRequest).mockReturnValueOnce({
+      mutateAsync: vi.fn(),
+      mutate: vi.fn(),
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    renderHook(
+      () =>
+        useSetVideoThumbnailUrl({
+          getAccessToken: mockGetAccessToken,
+        }),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    expect(useMutationRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        document: expect.stringContaining(
+          'mutation SetVideoThumbnailUrl($input: SetVideoThumbnailUrlInput!)',
+        ),
+      }),
+    );
+  });
+});

--- a/packages/core/src/watch/mutation-hooks/set-video-thumbnail-url/index.ts
+++ b/packages/core/src/watch/mutation-hooks/set-video-thumbnail-url/index.ts
@@ -1,0 +1,53 @@
+import type { UseMutationOptions } from '@tanstack/react-query';
+import { graphql } from '../../../graphql';
+import type {
+  SetVideoThumbnailUrlMutation,
+  SetVideoThumbnailUrlMutationVariables,
+} from '../../../graphql/graphql';
+import { useMutationRequest } from '../../../universal/hooks/useMutation';
+
+const setVideoThumbnailUrlMutation = graphql(/* GraphQL */ `
+  mutation SetVideoThumbnailUrl($input: SetVideoThumbnailUrlInput!) {
+    setVideoThumbnailUrl(input: $input) {
+      success
+      message
+      dataObject {
+        thumbnailUrl
+      }
+    }
+  }
+`);
+
+type SetVideoThumbnailUrlMutationOptions = UseMutationOptions<
+  SetVideoThumbnailUrlMutation,
+  unknown,
+  SetVideoThumbnailUrlMutationVariables,
+  unknown
+>;
+
+interface UseSetVideoThumbnailUrlProps
+  extends Pick<SetVideoThumbnailUrlMutationOptions, 'onSuccess' | 'onError'> {
+  getAccessToken: () => Promise<string>;
+}
+
+const useSetVideoThumbnailUrl = (props: UseSetVideoThumbnailUrlProps) => {
+  const { getAccessToken, onSuccess, onError } = props;
+
+  return useMutationRequest({
+    document: setVideoThumbnailUrlMutation,
+    getAccessToken,
+    options: {
+      onSuccess,
+      onError: (
+        error: unknown,
+        variables: SetVideoThumbnailUrlMutationVariables,
+        context: unknown,
+      ) => {
+        console.error('Set video thumbnail URL failed:', error);
+        onError?.(error, variables, context);
+      },
+    },
+  });
+};
+
+export { useSetVideoThumbnailUrl };


### PR DESCRIPTION
## Summary

No user-facing changes. Adds two data hooks the Watch app will use to set a video thumbnail from a browser-captured frame: `useCreateSignedUploadUrl` (gets a signed GCS upload URL) and `useSetVideoThumbnailUrl` (persists the uploaded image as the thumbnail). Plumbing only — no UI yet. Part of SWO-278 / SWO-281.

## Test plan

- [ ] Type checks pass; the hooks compile against the generated types
- [ ] Tests pass (8 new)
- [ ] CI green