### PR TITLE
[WIP] feat(watch): capture video thumbnail in the browser and upload it

### DIFF
--- a/packages/ui/src/watch/video-detail-page/containers/capture-thumbnail.test.ts
+++ b/packages/ui/src/watch/video-detail-page/containers/capture-thumbnail.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  captureFrameBlob,
+  fitWithinBox,
+  TAINTED_CANVAS_MESSAGE,
+  TaintedCanvasError,
+  uploadBlob,
+} from './capture-thumbnail';
+
+describe('fitWithinBox', () => {
+  it('fits a 16:9 frame inside the 300x200 box preserving aspect ratio', () => {
+    expect(fitWithinBox({ sourceWidth: 1920, sourceHeight: 1080 })).toEqual({
+      width: 300,
+      height: 169,
+    });
+  });
+
+  it('fits a tall frame by height', () => {
+    expect(fitWithinBox({ sourceWidth: 1080, sourceHeight: 1920 })).toEqual({
+      width: 113,
+      height: 200,
+    });
+  });
+
+  it('never upscales a frame smaller than the box', () => {
+    expect(fitWithinBox({ sourceWidth: 100, sourceHeight: 50 })).toEqual({
+      width: 100,
+      height: 50,
+    });
+  });
+
+  it('falls back to the full box for a zero-sized frame', () => {
+    expect(fitWithinBox({ sourceWidth: 0, sourceHeight: 0 })).toEqual({
+      width: 300,
+      height: 200,
+    });
+  });
+});
+
+// Build a fake <video> element plus a canvas whose toBlob behaviour we control.
+const setupCanvas = (props: {
+  toBlob: HTMLCanvasElement['toBlob'];
+  drawImage?: () => void;
+}) => {
+  const { toBlob, drawImage } = props;
+  const ctx = {
+    drawImage: drawImage ?? vi.fn(),
+  } as unknown as CanvasRenderingContext2D;
+
+  const canvas = {
+    width: 0,
+    height: 0,
+    getContext: vi.fn(() => ctx),
+    toBlob,
+  } as unknown as HTMLCanvasElement;
+
+  vi.spyOn(document, 'createElement').mockReturnValue(canvas);
+  return { canvas, ctx };
+};
+
+const fakeVideo = { videoWidth: 1920, videoHeight: 1080 } as HTMLVideoElement;
+
+describe('captureFrameBlob', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('draws the frame downscaled and resolves with a JPEG blob', async () => {
+    const blob = new Blob(['x'], { type: 'image/jpeg' });
+    const drawImage = vi.fn();
+    const toBlob = vi.fn((cb: BlobCallback) =>
+      cb(blob),
+    ) as unknown as HTMLCanvasElement['toBlob'];
+
+    const { canvas } = setupCanvas({ toBlob, drawImage });
+
+    const result = await captureFrameBlob(fakeVideo);
+
+    expect(result).toBe(blob);
+    expect(canvas.width).toBe(300);
+    expect(canvas.height).toBe(169);
+    expect(drawImage).toHaveBeenCalledWith(fakeVideo, 0, 0, 300, 169);
+    expect(toBlob).toHaveBeenCalledWith(
+      expect.any(Function),
+      'image/jpeg',
+      0.85,
+    );
+  });
+
+  it('throws TaintedCanvasError when toBlob yields null (tainted canvas)', async () => {
+    const toBlob = vi.fn((cb: BlobCallback) =>
+      cb(null),
+    ) as unknown as HTMLCanvasElement['toBlob'];
+    setupCanvas({ toBlob });
+
+    await expect(captureFrameBlob(fakeVideo)).rejects.toBeInstanceOf(
+      TaintedCanvasError,
+    );
+  });
+
+  it('maps a SecurityError from drawImage/toBlob to TaintedCanvasError', async () => {
+    const toBlob = vi.fn(() => {
+      throw new DOMException('tainted', 'SecurityError');
+    }) as unknown as HTMLCanvasElement['toBlob'];
+    setupCanvas({ toBlob });
+
+    const error = await captureFrameBlob(fakeVideo).catch((e) => e);
+    expect(error).toBeInstanceOf(TaintedCanvasError);
+    expect(error.message).toBe(TAINTED_CANVAS_MESSAGE);
+  });
+});
+
+describe('uploadBlob', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('PUTs the blob to the signed URL with the JPEG content type', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, status: 200 } as Response);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const blob = new Blob(['x'], { type: 'image/jpeg' });
+    await uploadBlob({ uploadUrl: 'https://signed.example/put', blob });
+
+    expect(fetchMock).toHaveBeenCalledWith('https://signed.example/put', {
+      method: 'PUT',
+      body: blob,
+      headers: { 'Content-Type': 'image/jpeg' },
+    });
+    vi.unstubAllGlobals();
+  });
+
+  it('throws on a non-2xx response', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: false, status: 403 } as Response);
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      uploadBlob({
+        uploadUrl: 'https://signed.example/put',
+        blob: new Blob(['x']),
+      }),
+    ).rejects.toThrow('403');
+    vi.unstubAllGlobals();
+  });
+});

--- a/packages/ui/src/watch/video-detail-page/containers/capture-thumbnail.ts
+++ b/packages/ui/src/watch/video-detail-page/containers/capture-thumbnail.ts
@@ -1,0 +1,139 @@
+// Client-side thumbnail capture.
+//
+// Instead of asking the server to run ffmpeg against the source file (unreliable
+// on cold start and prone to Linux seek quirks), we grab the frame that's
+// already decoded in the user's <video> element, downscale it to a small JPEG on
+// a canvas, and upload that straight to the bucket via a signed URL.
+//
+// The one hard requirement for this to work is a *CORS-enabled* video: the
+// media element must be loaded with `crossOrigin="anonymous"` AND the bucket
+// must return permissive GET CORS headers. Without both, drawing the frame taints
+// the canvas and `toBlob`/`toDataURL` throw a `SecurityError`.
+
+// Target thumbnail box. We fit the frame inside this while preserving aspect
+// ratio, so a 16:9 frame becomes ~300x169 and never exceeds these bounds.
+const THUMBNAIL_MAX_WIDTH = 300;
+const THUMBNAIL_MAX_HEIGHT = 200;
+const THUMBNAIL_MIME = 'image/jpeg';
+const THUMBNAIL_QUALITY = 0.85;
+
+const TAINTED_CANVAS_MESSAGE =
+  "Couldn't capture the frame — the video isn't CORS-enabled";
+
+interface FittedSize {
+  width: number;
+  height: number;
+}
+
+// Fit a source size inside the max box, preserving aspect ratio. Never upscales.
+const fitWithinBox = (props: {
+  sourceWidth: number;
+  sourceHeight: number;
+}): FittedSize => {
+  const { sourceWidth, sourceHeight } = props;
+
+  if (sourceWidth <= 0 || sourceHeight <= 0) {
+    return { width: THUMBNAIL_MAX_WIDTH, height: THUMBNAIL_MAX_HEIGHT };
+  }
+
+  const scale = Math.min(
+    THUMBNAIL_MAX_WIDTH / sourceWidth,
+    THUMBNAIL_MAX_HEIGHT / sourceHeight,
+    1,
+  );
+
+  return {
+    width: Math.max(1, Math.round(sourceWidth * scale)),
+    height: Math.max(1, Math.round(sourceHeight * scale)),
+  };
+};
+
+// Raised for a tainted (cross-origin) canvas so callers can show a clear message
+// distinct from a generic capture failure.
+class TaintedCanvasError extends Error {
+  constructor() {
+    super(TAINTED_CANVAS_MESSAGE);
+    this.name = 'TaintedCanvasError';
+  }
+}
+
+// Draw the current frame of `video` onto a downscaled canvas and return it as a
+// JPEG blob. Throws `TaintedCanvasError` when the canvas is cross-origin tainted.
+const captureFrameBlob = async (video: HTMLVideoElement): Promise<Blob> => {
+  const { width, height } = fitWithinBox({
+    sourceWidth: video.videoWidth,
+    sourceHeight: video.videoHeight,
+  });
+
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    throw new Error("Couldn't capture the frame — canvas is unavailable");
+  }
+
+  try {
+    ctx.drawImage(video, 0, 0, width, height);
+
+    return await new Promise<Blob>((resolve, reject) => {
+      // toBlob throws synchronously for a tainted canvas in some engines, and
+      // yields null in others — handle both.
+      try {
+        canvas.toBlob(
+          (blob) => {
+            if (blob) {
+              resolve(blob);
+            } else {
+              reject(new TaintedCanvasError());
+            }
+          },
+          THUMBNAIL_MIME,
+          THUMBNAIL_QUALITY,
+        );
+      } catch (error) {
+        reject(toCaptureError(error));
+      }
+    });
+  } catch (error) {
+    throw toCaptureError(error);
+  }
+};
+
+// Normalise a thrown value into a TaintedCanvasError when it's a SecurityError,
+// otherwise pass it through.
+const toCaptureError = (error: unknown): Error => {
+  if (error instanceof TaintedCanvasError) return error;
+  if (error instanceof DOMException && error.name === 'SecurityError') {
+    return new TaintedCanvasError();
+  }
+  return error instanceof Error ? error : new Error(String(error));
+};
+
+// PUT the blob to the signed upload URL. Throws on a non-2xx response.
+const uploadBlob = async (props: {
+  uploadUrl: string;
+  blob: Blob;
+}): Promise<void> => {
+  const { uploadUrl, blob } = props;
+
+  const response = await fetch(uploadUrl, {
+    method: 'PUT',
+    body: blob,
+    headers: { 'Content-Type': THUMBNAIL_MIME },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Thumbnail upload failed (${response.status})`);
+  }
+};
+
+export {
+  captureFrameBlob,
+  fitWithinBox,
+  TaintedCanvasError,
+  TAINTED_CANVAS_MESSAGE,
+  THUMBNAIL_MIME,
+  uploadBlob,
+};

--- a/packages/ui/src/watch/video-detail-page/containers/index.test.tsx
+++ b/packages/ui/src/watch/video-detail-page/containers/index.test.tsx
@@ -10,6 +10,10 @@ import {
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  TAINTED_CANVAS_MESSAGE,
+  TaintedCanvasError,
+} from './capture-thumbnail';
 import { VideoDetailContainer } from './index';
 import type { VideoDetailContainerProps } from './types';
 
@@ -77,15 +81,41 @@ vi.mock('@mui/material/Checkbox', () => ({
 // The mocked player exposes controls to drive paused state and the current
 // playback time (in seconds) from within tests.
 const mockCurrentTime = { value: 42 };
+// A stand-in <video> element handed to the container via getVideoElementRef.
+// `null` simulates the player not being ready.
+const mockVideoElement: { value: HTMLVideoElement | null } = {
+  value: {} as HTMLVideoElement,
+};
+
+const wireRefs = ({
+  getCurrentTimeRef,
+  getVideoElementRef,
+}: {
+  getCurrentTimeRef?: { current: (() => number | null) | null };
+  getVideoElementRef?: {
+    current: (() => HTMLVideoElement | null) | null;
+  };
+}) => {
+  if (getCurrentTimeRef) {
+    getCurrentTimeRef.current = () => mockCurrentTime.value;
+  }
+  if (getVideoElementRef) {
+    getVideoElementRef.current = () => mockVideoElement.value;
+  }
+};
 
 // Create VideoContainer mock with a mock implementation
 const mockVideoContainer = vi
   .fn()
   .mockImplementation(
-    ({ video, onEnded, onPausedChange, getCurrentTimeRef }) => {
-      if (getCurrentTimeRef) {
-        getCurrentTimeRef.current = () => mockCurrentTime.value;
-      }
+    ({
+      video,
+      onEnded,
+      onPausedChange,
+      getCurrentTimeRef,
+      getVideoElementRef,
+    }) => {
+      wireRefs({ getCurrentTimeRef, getVideoElementRef });
       return (
         <div data-testid="video-container">
           <button
@@ -124,6 +154,9 @@ vi.mock('../../videos/video-container', () => ({
     getCurrentTimeRef?: {
       current: (() => number | null) | null;
     };
+    getVideoElementRef?: {
+      current: (() => HTMLVideoElement | null) | null;
+    };
   }) => mockVideoContainer(props),
 }));
 
@@ -133,21 +166,38 @@ vi.mock('core/providers/auth', () => ({
   useAuthContext: () => mockUseAuthContext(),
 }));
 
-// Mock the set-thumbnail mutation hook.
-const mockSetVideoThumbnail = vi.fn();
-let capturedThumbnailHandlers: {
-  onSuccess?: () => void;
-  onError?: () => void;
-} = {};
+// The server-side ffmpeg action is retained as a fallback but no longer called
+// on click — just mock it so the module resolves.
 vi.mock('core/watch/mutation-hooks/set-video-thumbnail', () => ({
-  useSetVideoThumbnail: (props: {
-    onSuccess?: () => void;
-    onError?: () => void;
-  }) => {
-    capturedThumbnailHandlers = props;
-    return { mutate: mockSetVideoThumbnail };
-  },
+  useSetVideoThumbnail: () => ({ mutate: vi.fn() }),
 }));
+
+// New client-upload hooks. mutateAsync is what the container awaits.
+const mockCreateSignedUploadUrl = vi.fn();
+const mockSetVideoThumbnailUrl = vi.fn();
+vi.mock('core/watch/mutation-hooks/create-signed-upload-url', () => ({
+  useCreateSignedUploadUrl: () => ({
+    mutateAsync: mockCreateSignedUploadUrl,
+  }),
+}));
+vi.mock('core/watch/mutation-hooks/set-video-thumbnail-url', () => ({
+  useSetVideoThumbnailUrl: () => ({ mutateAsync: mockSetVideoThumbnailUrl }),
+}));
+
+// Mock the capture util so the container test drives the orchestration without
+// touching a real canvas/fetch (those are unit-tested in capture-thumbnail.test).
+const mockCaptureFrameBlob = vi.fn();
+const mockUploadBlob = vi.fn();
+vi.mock('./capture-thumbnail', async () => {
+  const actual = await vi.importActual<typeof import('./capture-thumbnail')>(
+    './capture-thumbnail',
+  );
+  return {
+    ...actual,
+    captureFrameBlob: (...args: unknown[]) => mockCaptureFrameBlob(...args),
+    uploadBlob: (...args: unknown[]) => mockUploadBlob(...args),
+  };
+});
 
 vi.mock('../../dialogs/share', () => ({
   ShareDialog: ({
@@ -300,17 +350,40 @@ describe('VideoDetailContainer', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockCurrentTime.value = 42;
-    capturedThumbnailHandlers = {};
+    mockVideoElement.value = {} as HTMLVideoElement;
+    // Sensible defaults for the happy path; individual tests override.
+    mockCaptureFrameBlob.mockResolvedValue(
+      new Blob(['x'], { type: 'image/jpeg' }),
+    );
+    mockCreateSignedUploadUrl.mockResolvedValue({
+      createSignedUploadUrl: {
+        dataObject: {
+          uploadUrl: 'https://signed.example/put',
+          publicUrl: 'https://cdn.example/thumb.jpg',
+          objectPath: 'watch/video1/thumb.jpg',
+        },
+      },
+    });
+    mockUploadBlob.mockResolvedValue(undefined);
+    mockSetVideoThumbnailUrl.mockResolvedValue({
+      setVideoThumbnailUrl: {
+        dataObject: { thumbnailUrl: 'https://cdn.example/thumb.jpg' },
+      },
+    });
     // Default: current user is the video owner.
     mockUseAuthContext.mockReturnValue({
       getAccessToken: vi.fn(),
       user: { id: 'owner-1' },
     });
     mockVideoContainer.mockImplementation(
-      ({ video, onEnded, onPausedChange, getCurrentTimeRef }) => {
-        if (getCurrentTimeRef) {
-          getCurrentTimeRef.current = () => mockCurrentTime.value;
-        }
+      ({
+        video,
+        onEnded,
+        onPausedChange,
+        getCurrentTimeRef,
+        getVideoElementRef,
+      }) => {
+        wireRefs({ getCurrentTimeRef, getVideoElementRef });
         return (
           <div data-testid="video-container">
             <button
@@ -630,26 +703,16 @@ describe('VideoDetailContainer', () => {
       expect(screen.queryByLabelText(thumbnailLabel)).not.toBeInTheDocument();
     });
 
-    it('calls the mutation with the video id and current time on click', async () => {
-      mockCurrentTime.value = 87;
-
-      await act(async () => {
-        renderWithTheme(<VideoDetailContainer {...createProps()} />);
-      });
-
+    const pauseAndCapture = async () => {
       await act(async () => {
         fireEvent.click(screen.getByTestId('video-container-pause'));
       });
       await act(async () => {
         fireEvent.click(screen.getByLabelText(thumbnailLabel));
       });
+    };
 
-      expect(mockSetVideoThumbnail).toHaveBeenCalledWith({
-        input: { videoId: 'video1', atSeconds: 87 },
-      });
-    });
-
-    it('notifies and refetches on success, notifies on error', async () => {
+    it('captures, signs, uploads, persists and refetches on click', async () => {
       const onNotify = vi.fn();
       const onThumbnailUpdated = vi.fn();
 
@@ -661,18 +724,82 @@ describe('VideoDetailContainer', () => {
         );
       });
 
-      await act(async () => {
-        capturedThumbnailHandlers.onSuccess?.();
+      await pauseAndCapture();
+
+      // Frame captured from the player's <video> element.
+      expect(mockCaptureFrameBlob).toHaveBeenCalledWith(mockVideoElement.value);
+
+      // Signed URL requested for this video.
+      expect(mockCreateSignedUploadUrl).toHaveBeenCalledWith({
+        input: {
+          site: 'watch',
+          action: 'VIDEO_THUMBNAIL_UPLOAD',
+          id: 'video1',
+          contentType: 'image/jpeg',
+        },
       });
+
+      // Blob PUT to the signed URL.
+      expect(mockUploadBlob).toHaveBeenCalledWith({
+        uploadUrl: 'https://signed.example/put',
+        blob: expect.any(Blob),
+      });
+
+      // Persisted against the video via objectPath.
+      expect(mockSetVideoThumbnailUrl).toHaveBeenCalledWith({
+        input: { videoId: 'video1', objectPath: 'watch/video1/thumb.jpg' },
+      });
+
+      // Refetch + success toast.
       expect(onThumbnailUpdated).toHaveBeenCalledTimes(1);
       expect(onNotify).toHaveBeenCalledWith({
         message: 'Thumbnail updated',
         severity: 'success',
       });
+    });
+
+    it('shows a CORS-specific error and skips upload on a tainted canvas', async () => {
+      const onNotify = vi.fn();
+      const onThumbnailUpdated = vi.fn();
+      mockCaptureFrameBlob.mockRejectedValue(new TaintedCanvasError());
 
       await act(async () => {
-        capturedThumbnailHandlers.onError?.();
+        renderWithTheme(
+          <VideoDetailContainer
+            {...createProps({ onNotify, onThumbnailUpdated })}
+          />,
+        );
       });
+
+      await pauseAndCapture();
+
+      expect(mockCreateSignedUploadUrl).not.toHaveBeenCalled();
+      expect(mockUploadBlob).not.toHaveBeenCalled();
+      expect(mockSetVideoThumbnailUrl).not.toHaveBeenCalled();
+      expect(onThumbnailUpdated).not.toHaveBeenCalled();
+      expect(onNotify).toHaveBeenCalledWith({
+        message: TAINTED_CANVAS_MESSAGE,
+        severity: 'error',
+      });
+    });
+
+    it('shows a generic error when the upload fails', async () => {
+      const onNotify = vi.fn();
+      const onThumbnailUpdated = vi.fn();
+      mockUploadBlob.mockRejectedValue(new Error('403'));
+
+      await act(async () => {
+        renderWithTheme(
+          <VideoDetailContainer
+            {...createProps({ onNotify, onThumbnailUpdated })}
+          />,
+        );
+      });
+
+      await pauseAndCapture();
+
+      expect(mockSetVideoThumbnailUrl).not.toHaveBeenCalled();
+      expect(onThumbnailUpdated).not.toHaveBeenCalled();
       expect(onNotify).toHaveBeenCalledWith({
         message: 'Failed to update thumbnail',
         severity: 'error',

--- a/packages/ui/src/watch/video-detail-page/containers/index.tsx
+++ b/packages/ui/src/watch/video-detail-page/containers/index.tsx
@@ -7,12 +7,22 @@ import Chip from '@mui/material/Chip';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import { useAuthContext } from 'core/providers/auth';
+import { useCreateSignedUploadUrl } from 'core/watch/mutation-hooks/create-signed-upload-url';
 import { useSaveSubtitle } from 'core/watch/mutation-hooks/save-subtitle';
+// Server-side ffmpeg thumbnail action. Kept available as a fallback but no
+// longer the primary path — it's unreliable (Hono cold start + Linux ffmpeg
+// seek quirks). The click now captures the frame in the browser instead.
 import { useSetVideoThumbnail } from 'core/watch/mutation-hooks/set-video-thumbnail';
+import { useSetVideoThumbnailUrl } from 'core/watch/mutation-hooks/set-video-thumbnail-url';
 import React, { Suspense } from 'react';
 import { getMediaDisplayName } from '../../utils';
 import { VideoContainer } from '../../videos/video-container';
 import { RelatedList } from '../related-list';
+import {
+  captureFrameBlob,
+  TaintedCanvasError,
+  uploadBlob,
+} from './capture-thumbnail';
 import { MainContentSkeleton, RelatedContentSkeleton } from './skeleton';
 import { StyledRelatedContainer } from './styled';
 import type { VideoDetailContainerProps } from './types';
@@ -68,6 +78,13 @@ const MainContent = (props: VideoDetailContainerProps) => {
   const [isPaused, setIsPaused] = React.useState(false);
   // Filled by the player with a getter for the current playback time (seconds).
   const getCurrentTimeRef = React.useRef<(() => number | null) | null>(null);
+  // Filled by the player with a getter for the underlying <video> element, used
+  // to draw the paused frame to a canvas for client-side thumbnail capture.
+  const getVideoElementRef = React.useRef<
+    (() => HTMLVideoElement | null) | null
+  >(null);
+  // Guards against overlapping captures if the button is clicked repeatedly.
+  const isCapturingRef = React.useRef(false);
 
   const videoDetail = React.useMemo(
     () => videos.find((video) => video.id === activeVideoId),
@@ -76,29 +93,74 @@ const MainContent = (props: VideoDetailContainerProps) => {
 
   const isOwner = Boolean(user?.id) && videoDetail?.userId === user?.id;
 
-  const { mutate: setVideoThumbnail } = useSetVideoThumbnail({
+  // Fallback server action (ffmpeg). Retained for reference/emergency use; the
+  // primary flow below captures the frame in the browser and uploads it.
+  useSetVideoThumbnail({ getAccessToken });
+
+  const { mutateAsync: createSignedUploadUrl } = useCreateSignedUploadUrl({
     getAccessToken,
-    onSuccess: () => {
-      // Ask the route to refetch its own detail query so the new thumbnail is
-      // reflected without a hard reload (the route owns its query key).
-      onThumbnailUpdated?.();
-      onNotify?.({ message: 'Thumbnail updated', severity: 'success' });
-    },
-    onError: () => {
-      onNotify?.({ message: 'Failed to update thumbnail', severity: 'error' });
-    },
+  });
+  const { mutateAsync: setVideoThumbnailUrl } = useSetVideoThumbnailUrl({
+    getAccessToken,
   });
 
-  const handleSetThumbnail = React.useCallback(() => {
-    if (!videoDetail) return;
+  const handleSetThumbnail = React.useCallback(async () => {
+    if (!videoDetail || isCapturingRef.current) return;
 
-    const atSeconds = getCurrentTimeRef.current?.() ?? null;
-    if (atSeconds === null) return;
+    const videoEl = getVideoElementRef.current?.();
+    if (!videoEl) {
+      onNotify?.({ message: 'Failed to update thumbnail', severity: 'error' });
+      return;
+    }
 
-    setVideoThumbnail({
-      input: { videoId: videoDetail.id, atSeconds },
-    });
-  }, [videoDetail, setVideoThumbnail]);
+    isCapturingRef.current = true;
+    try {
+      // 1. Capture + downscale the current frame to a JPEG blob.
+      const blob = await captureFrameBlob(videoEl);
+
+      // 2. Ask the backend for a signed PUT URL scoped to this video.
+      const signed = await createSignedUploadUrl({
+        input: {
+          site: 'watch',
+          action: 'VIDEO_THUMBNAIL_UPLOAD',
+          id: videoDetail.id,
+          contentType: 'image/jpeg',
+        },
+      });
+      const dataObject = signed.createSignedUploadUrl.dataObject;
+      if (!dataObject) {
+        throw new Error('No signed upload URL returned');
+      }
+
+      // 3. Upload the blob straight to the bucket.
+      await uploadBlob({ uploadUrl: dataObject.uploadUrl, blob });
+
+      // 4. Persist the thumbnail against the video record.
+      await setVideoThumbnailUrl({
+        input: { videoId: videoDetail.id, objectPath: dataObject.objectPath },
+      });
+
+      // 5. Refetch (route owns the query key) so the new thumbnail shows.
+      onThumbnailUpdated?.();
+      onNotify?.({ message: 'Thumbnail updated', severity: 'success' });
+    } catch (error) {
+      // A tainted canvas is a distinct, actionable failure (CORS), so surface
+      // its specific message; everything else gets the generic error.
+      const message =
+        error instanceof TaintedCanvasError
+          ? error.message
+          : 'Failed to update thumbnail';
+      onNotify?.({ message, severity: 'error' });
+    } finally {
+      isCapturingRef.current = false;
+    }
+  }, [
+    videoDetail,
+    createSignedUploadUrl,
+    setVideoThumbnailUrl,
+    onThumbnailUpdated,
+    onNotify,
+  ]);
 
   React.useEffect(() => {
     shouldPlayNextRef.current = autoPlay;
@@ -191,6 +253,7 @@ const MainContent = (props: VideoDetailContainerProps) => {
           onEnded={handleVideoEnd}
           onPausedChange={setIsPaused}
           getCurrentTimeRef={getCurrentTimeRef}
+          getVideoElementRef={getVideoElementRef}
         />
       </Box>
       <Stack direction="row" alignItems="center" spacing={1} sx={{ mt: 2 }}>

--- a/packages/ui/src/watch/videos/video-container/index.tsx
+++ b/packages/ui/src/watch/videos/video-container/index.tsx
@@ -8,10 +8,18 @@ interface VideoContainerInterface {
   onError?: (error: unknown) => void;
   onPausedChange?: (isPaused: boolean) => void;
   getCurrentTimeRef?: MutableRefObject<(() => number | null) | null>;
+  getVideoElementRef?: MutableRefObject<(() => HTMLVideoElement | null) | null>;
 }
 
 const VideoContainer = (props: VideoContainerInterface) => {
-  const { video, onEnded, onError, onPausedChange, getCurrentTimeRef } = props;
+  const {
+    video,
+    onEnded,
+    onError,
+    onPausedChange,
+    getCurrentTimeRef,
+    getVideoElementRef,
+  } = props;
 
   return (
     <VideoPlayer
@@ -20,6 +28,7 @@ const VideoContainer = (props: VideoContainerInterface) => {
       onError={onError}
       onPausedChange={onPausedChange}
       getCurrentTimeRef={getCurrentTimeRef}
+      getVideoElementRef={getVideoElementRef}
     />
   );
 };

--- a/packages/ui/src/watch/videos/video-player/index.tsx
+++ b/packages/ui/src/watch/videos/video-player/index.tsx
@@ -39,6 +39,10 @@ interface VideoPlayerProps {
   // seconds, letting the parent read the paused frame without owning the
   // player instance.
   getCurrentTimeRef?: MutableRefObject<(() => number | null) | null>;
+  // A ref the player fills with a getter for the underlying <video> element, so
+  // the parent can capture the current frame client-side (thumbnail capture)
+  // without owning the player instance.
+  getVideoElementRef?: MutableRefObject<(() => HTMLVideoElement | null) | null>;
 }
 
 /**
@@ -64,7 +68,14 @@ interface VideoPlayerProps {
  */
 
 const VideoPlayer = (props: VideoPlayerProps) => {
-  const { video, onEnded, onError, onPausedChange, getCurrentTimeRef } = props;
+  const {
+    video,
+    onEnded,
+    onError,
+    onPausedChange,
+    getCurrentTimeRef,
+    getVideoElementRef,
+  } = props;
   const { title, source, thumbnailUrl, subtitles } = video;
   const { isSignedIn, getAccessToken } = useAuthContext();
   const {
@@ -118,8 +129,18 @@ const VideoPlayer = (props: VideoPlayerProps) => {
         getCurrentTimeRef.current = () =>
           playerRef.current?.getCurrentTime?.() ?? null;
       }
+
+      // Expose the underlying <video> element (the file player's internal
+      // player) so the parent can draw the current frame to a canvas for
+      // client-side thumbnail capture.
+      if (getVideoElementRef) {
+        getVideoElementRef.current = () => {
+          const internal = playerRef.current?.getInternalPlayer?.();
+          return internal instanceof HTMLVideoElement ? internal : null;
+        };
+      }
     },
-    [getCurrentTimeRef],
+    [getCurrentTimeRef, getVideoElementRef],
   );
 
   // Wrap the progress-tracking pause/play handlers so the parent also learns
@@ -428,7 +449,11 @@ const VideoPlayer = (props: VideoPlayerProps) => {
               hlsVersion: '1.5.20',
               attributes: {
                 playsInline: true, // Important for iOS
-                crossOrigin: 'true',
+                // `anonymous` loads the media without credentials but *with*
+                // CORS, so drawing a frame to a canvas doesn't taint it. This
+                // plus permissive GET CORS headers on the video bucket is
+                // required for client-side thumbnail capture.
+                crossOrigin: 'anonymous',
               },
               tracks: subtitles?.map((subtitle) => ({
                 kind: 'subtitles',


### PR DESCRIPTION
## Summary

Makes "Set as thumbnail" reliable by capturing the frame in your browser instead of on the server. When you pause your own video and click **Set as thumbnail**, the app grabs the current frame, shrinks it to a small (~300×200) image, uploads it straight to storage, and sets it as the thumbnail — no server-side video processing, so none of the timeouts/failures the old path had. Part of SWO-278 / SWO-282.

Stacked on #312 (the hooks). Needs the video bucket to allow browser reads (GET CORS) for the capture to work; if it's not enabled, the app shows a clear message instead of failing silently.

## Test plan

- [ ] Open a video you own in the **Watch** app, pause it, click **Set as thumbnail** — the thumbnail updates to that frame, without a page reload.
- [ ] On a video you don't own, the button doesn't appear.
- [ ] CI green