### PR TITLE
fix(core): reset React Query cache when the signed-in user changes

### DIFF
--- a/packages/core/src/providers/query/index.test.tsx
+++ b/packages/core/src/providers/query/index.test.tsx
@@ -12,9 +12,16 @@ vi.mock('@tanstack/react-query', () => ({
   QueryClient: vi.fn().mockImplementation(() => ({
     removeQueries: vi.fn(),
     refetchQueries: vi.fn(),
+    clear: vi.fn(),
   })),
   QueryClientProvider: ({ children }: { children: React.ReactNode }) =>
     children,
+}));
+
+// Controllable auth context so we can drive userId changes in tests.
+const mockUser = vi.hoisted(() => ({ current: null as { id: string } | null }));
+vi.mock('../auth', () => ({
+  useAuthContext: () => ({ user: mockUser.current }),
 }));
 
 vi.mock('@rollbar/react', () => ({
@@ -220,6 +227,38 @@ describe('Query Provider and Context', () => {
 
     expect(outerContextValue).toEqual(expectedContextValue);
     expect(innerContextValue).toEqual(expectedNestedContextValue);
+  });
+
+  it('should reset the query cache when the signed-in user changes', () => {
+    const queryClientInstance = vi.mocked(QueryClient).mock.results[0].value;
+    queryClientInstance.clear.mockClear();
+
+    mockUser.current = { id: 'user-a' };
+    const { rerender } = render(
+      <QueryProvider config={mockConfig}>
+        <div>child</div>
+      </QueryProvider>,
+    );
+
+    // Cleared once on initial mount for user-a.
+    expect(queryClientInstance.clear).toHaveBeenCalledTimes(1);
+
+    // A re-render with the same user must NOT clear the cache again.
+    rerender(
+      <QueryProvider config={mockConfig}>
+        <div>child</div>
+      </QueryProvider>,
+    );
+    expect(queryClientInstance.clear).toHaveBeenCalledTimes(1);
+
+    // Switching to a different user clears the cache.
+    mockUser.current = { id: 'user-b' };
+    rerender(
+      <QueryProvider config={mockConfig}>
+        <div>child</div>
+      </QueryProvider>,
+    );
+    expect(queryClientInstance.clear).toHaveBeenCalledTimes(2);
   });
 
   it('should handle missing config gracefully', () => {

--- a/packages/core/src/providers/query/index.tsx
+++ b/packages/core/src/providers/query/index.tsx
@@ -1,7 +1,8 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { createContext, type FC, useContext } from 'react';
+import { createContext, type FC, useContext, useEffect } from 'react';
 import { useFeatureFlagSubscription } from '../../universal/hooks/useFeatureFlagSubscription';
 import { useNotificationsSubscription } from '../../universal/hooks/useNotificationsSubscription';
+import { useAuthContext } from '../auth';
 
 const queryClient = new QueryClient();
 
@@ -27,6 +28,25 @@ const QueryContextProvider = (props: QueryContextProviderProps) => {
   const { hasuraUrl } = config;
   const featureFlags = useFeatureFlagSubscription(hasuraUrl);
   const notifications = useNotificationsSubscription(hasuraUrl);
+  const { user } = useAuthContext();
+  const userId = user?.id ?? null;
+
+  /**
+   * Reset the React Query cache whenever the signed-in user changes.
+   *
+   * `queryClient` is a module-level singleton and query keys are NOT scoped
+   * by userId, so without this the previous identity's data (or anonymous
+   * data) keeps being served from cache to the newly signed-in user until
+   * staleTime elapses. Clearing on userId change drops those entries; active
+   * observers then refetch with the new token. Only the query cache is
+   * affected — the feature-flag / notification WebSocket subscriptions are not.
+   *
+   * userId is the trigger, not a value read inside the effect body.
+   */
+  // biome-ignore lint/correctness/useExhaustiveDependencies: userId is the change trigger, not read inside the effect.
+  useEffect(() => {
+    queryClient.clear();
+  }, [userId]);
 
   const contextValue: QueryContextValue = {
     hasuraUrl,


### PR DESCRIPTION
## Summary

Queries did not invalidate after a user signed in (when `userId` changes) — the previous identity's (or anonymous) data kept being served from cache to the newly signed-in user.

Root cause (all in `packages/core`):
- `queryClient` is a module-level singleton that survives every auth-state change,
- no query key includes the `userId` (all hooks key on domain + params only), and
- nothing reset the cache on auth change — so with the default 5min `staleTime`, cached data stayed "fresh" across the user switch.

Fix: a bridge in `QueryProvider` reads `userId` from auth context and clears the React Query cache when it changes. `AuthProvider` wraps `QueryProvider` in every app, so this one change fixes all apps and all hooks — no per-hook key changes. `clear()` only touches the query cache; the feature-flag / notification WebSocket subscriptions are untouched, and active observers refetch with the new token.

Closes SWO-284.

## Test plan

- [x] Unit: `providers/query/index.test.tsx` — cache clears on `userId` change, and **not** on re-renders where it's unchanged (8/8 pass).
- [x] `use-request` tests still pass (11/11).
- [x] `biome check` clean on changed source.
- [ ] Manual: sign in as user A → load data → sign out → sign in as user B → user B sees their own data, not user A's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app data freshness by clearing cached query data when the signed-in user changes.
  * Prevents stale results from carrying over between sign-ins, sign-outs, or account switches.
  * Added test coverage to verify cache reset behavior across initial load and user changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->