### PR TITLE
[WIP] feat(listen): add playlist query hooks

### DIFF
--- a/packages/core/schema.graphql
+++ b/packages/core/schema.graphql
@@ -72,6 +72,21 @@ input Int_comparison_exp {
   _nin: [Int!]
 }
 
+input SetVideoThumbnailAtTimeInput {
+  atSeconds: Float!
+  videoId: String!
+}
+
+type SetVideoThumbnailAtTimeOutput {
+  thumbnailUrl: String!
+}
+
+type SetVideoThumbnailAtTimeResponse {
+  dataObject: SetVideoThumbnailAtTimeOutput
+  message: String!
+  success: Boolean!
+}
+
 input SignedUploadUrlInput {
   action: String!
   contentType: String!
@@ -480,6 +495,56 @@ type audios {
   createdAt: timestamptz!
   id: uuid!
   name: String!
+  """
+  An array relationship
+  """
+  playlist_audios(
+    """
+    distinct select on columns
+    """
+    distinct_on: [playlist_audios_select_column!]
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [playlist_audios_order_by!]
+    """
+    filter the rows returned
+    """
+    where: playlist_audios_bool_exp
+  ): [playlist_audios!]!
+  """
+  An aggregate relationship
+  """
+  playlist_audios_aggregate(
+    """
+    distinct select on columns
+    """
+    distinct_on: [playlist_audios_select_column!]
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [playlist_audios_order_by!]
+    """
+    filter the rows returned
+    """
+    where: playlist_audios_bool_exp
+  ): playlist_audios_aggregate!
   public: Boolean!
   source: String!
   thumbnailUrl: String
@@ -568,6 +633,8 @@ input audios_bool_exp {
   createdAt: timestamptz_comparison_exp
   id: uuid_comparison_exp
   name: String_comparison_exp
+  playlist_audios: playlist_audios_bool_exp
+  playlist_audios_aggregate: playlist_audios_aggregate_bool_exp
   public: Boolean_comparison_exp
   source: String_comparison_exp
   thumbnailUrl: String_comparison_exp
@@ -595,6 +662,7 @@ input audios_insert_input {
   createdAt: timestamptz
   id: uuid
   name: String
+  playlist_audios: playlist_audios_arr_rel_insert_input
   public: Boolean
   source: String
   thumbnailUrl: String
@@ -702,6 +770,7 @@ input audios_order_by {
   createdAt: order_by
   id: order_by
   name: order_by
+  playlist_audios_aggregate: playlist_audios_aggregate_order_by
   public: order_by
   source: order_by
   thumbnailUrl: order_by
@@ -4220,6 +4289,22 @@ type mutation_root {
     where: playlist_bool_exp!
   ): playlist_mutation_response
   """
+  delete data from the table: "playlist_audios"
+  """
+  delete_playlist_audios(
+    """
+    filter the rows which have to be deleted
+    """
+    where: playlist_audios_bool_exp!
+  ): playlist_audios_mutation_response
+  """
+  delete single row from the table: "playlist_audios"
+  """
+  delete_playlist_audios_by_pk(
+    audio_id: uuid!
+    playlist_id: uuid!
+  ): playlist_audios
+  """
   delete single row from the table: "playlist"
   """
   delete_playlist_by_pk(id: uuid!): playlist
@@ -4682,6 +4767,32 @@ type mutation_root {
     on_conflict: playlist_on_conflict
   ): playlist_mutation_response
   """
+  insert data into the table: "playlist_audios"
+  """
+  insert_playlist_audios(
+    """
+    the rows to be inserted
+    """
+    objects: [playlist_audios_insert_input!]!
+    """
+    upsert condition
+    """
+    on_conflict: playlist_audios_on_conflict
+  ): playlist_audios_mutation_response
+  """
+  insert a single row into the table: "playlist_audios"
+  """
+  insert_playlist_audios_one(
+    """
+    the row to be inserted
+    """
+    object: playlist_audios_insert_input!
+    """
+    upsert condition
+    """
+    on_conflict: playlist_audios_on_conflict
+  ): playlist_audios
+  """
   insert a single row into the table: "playlist"
   """
   insert_playlist_one(
@@ -5058,6 +5169,12 @@ type mutation_root {
     """
     on_conflict: videos_on_conflict
   ): videos
+  """
+  Capture the frame at a given timestamp and persist it as the video's thumbnail; ownership enforced server-side against the session user.
+  """
+  setVideoThumbnailAtTime(
+    input: SetVideoThumbnailAtTimeInput!
+  ): SetVideoThumbnailAtTimeResponse!
   """
   update data of the table: "audio_tags"
   """
@@ -5547,6 +5664,46 @@ type mutation_root {
     """
     where: playlist_bool_exp!
   ): playlist_mutation_response
+  """
+  update data of the table: "playlist_audios"
+  """
+  update_playlist_audios(
+    """
+    increments the numeric columns with given value of the filtered values
+    """
+    _inc: playlist_audios_inc_input
+    """
+    sets the columns of the filtered rows to the given values
+    """
+    _set: playlist_audios_set_input
+    """
+    filter the rows which have to be updated
+    """
+    where: playlist_audios_bool_exp!
+  ): playlist_audios_mutation_response
+  """
+  update single row of the table: "playlist_audios"
+  """
+  update_playlist_audios_by_pk(
+    """
+    increments the numeric columns with given value of the filtered values
+    """
+    _inc: playlist_audios_inc_input
+    """
+    sets the columns of the filtered rows to the given values
+    """
+    _set: playlist_audios_set_input
+    pk_columns: playlist_audios_pk_columns_input!
+  ): playlist_audios
+  """
+  update multiples rows of table: "playlist_audios"
+  """
+  update_playlist_audios_many(
+    """
+    updates to execute, in order
+    """
+    updates: [playlist_audios_updates!]!
+  ): [playlist_audios_mutation_response]
   """
   update single row of the table: "playlist"
   """
@@ -6667,6 +6824,56 @@ type playlist {
   """
   An array relationship
   """
+  playlist_audios(
+    """
+    distinct select on columns
+    """
+    distinct_on: [playlist_audios_select_column!]
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [playlist_audios_order_by!]
+    """
+    filter the rows returned
+    """
+    where: playlist_audios_bool_exp
+  ): [playlist_audios!]!
+  """
+  An aggregate relationship
+  """
+  playlist_audios_aggregate(
+    """
+    distinct select on columns
+    """
+    distinct_on: [playlist_audios_select_column!]
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [playlist_audios_order_by!]
+    """
+    filter the rows returned
+    """
+    where: playlist_audios_bool_exp
+  ): playlist_audios_aggregate!
+  """
+  An array relationship
+  """
   playlist_videos(
     """
     distinct select on columns
@@ -6787,6 +6994,7 @@ type playlist {
     """
     where: shared_playlist_recipients_bool_exp
   ): shared_playlist_recipients_aggregate!
+  site: String!
   slug: String!
   thumbnailUrl: String
   title: String!
@@ -6877,6 +7085,438 @@ input playlist_arr_rel_insert_input {
 }
 
 """
+Junction table between audios and playlist
+"""
+type playlist_audios {
+  """
+  An object relationship
+  """
+  audio: audios!
+  audio_id: uuid!
+  createdAt: timestamptz!
+  """
+  An object relationship
+  """
+  playlist: playlist!
+  playlist_id: uuid!
+  position: Int!
+  updatedAt: timestamptz!
+}
+
+"""
+aggregated selection of "playlist_audios"
+"""
+type playlist_audios_aggregate {
+  aggregate: playlist_audios_aggregate_fields
+  nodes: [playlist_audios!]!
+}
+
+input playlist_audios_aggregate_bool_exp {
+  count: playlist_audios_aggregate_bool_exp_count
+}
+
+input playlist_audios_aggregate_bool_exp_count {
+  arguments: [playlist_audios_select_column!]
+  distinct: Boolean
+  filter: playlist_audios_bool_exp
+  predicate: Int_comparison_exp!
+}
+
+"""
+aggregate fields of "playlist_audios"
+"""
+type playlist_audios_aggregate_fields {
+  avg: playlist_audios_avg_fields
+  count(columns: [playlist_audios_select_column!], distinct: Boolean): Int!
+  max: playlist_audios_max_fields
+  min: playlist_audios_min_fields
+  stddev: playlist_audios_stddev_fields
+  stddev_pop: playlist_audios_stddev_pop_fields
+  stddev_samp: playlist_audios_stddev_samp_fields
+  sum: playlist_audios_sum_fields
+  var_pop: playlist_audios_var_pop_fields
+  var_samp: playlist_audios_var_samp_fields
+  variance: playlist_audios_variance_fields
+}
+
+"""
+order by aggregate values of table "playlist_audios"
+"""
+input playlist_audios_aggregate_order_by {
+  avg: playlist_audios_avg_order_by
+  count: order_by
+  max: playlist_audios_max_order_by
+  min: playlist_audios_min_order_by
+  stddev: playlist_audios_stddev_order_by
+  stddev_pop: playlist_audios_stddev_pop_order_by
+  stddev_samp: playlist_audios_stddev_samp_order_by
+  sum: playlist_audios_sum_order_by
+  var_pop: playlist_audios_var_pop_order_by
+  var_samp: playlist_audios_var_samp_order_by
+  variance: playlist_audios_variance_order_by
+}
+
+"""
+input type for inserting array relation for remote table "playlist_audios"
+"""
+input playlist_audios_arr_rel_insert_input {
+  data: [playlist_audios_insert_input!]!
+  """
+  upsert condition
+  """
+  on_conflict: playlist_audios_on_conflict
+}
+
+"""
+aggregate avg on columns
+"""
+type playlist_audios_avg_fields {
+  position: Float
+}
+
+"""
+order by avg() on columns of table "playlist_audios"
+"""
+input playlist_audios_avg_order_by {
+  position: order_by
+}
+
+"""
+Boolean expression to filter rows from the table "playlist_audios". All fields are combined with a logical 'AND'.
+"""
+input playlist_audios_bool_exp {
+  _and: [playlist_audios_bool_exp!]
+  _not: playlist_audios_bool_exp
+  _or: [playlist_audios_bool_exp!]
+  audio: audios_bool_exp
+  audio_id: uuid_comparison_exp
+  createdAt: timestamptz_comparison_exp
+  playlist: playlist_bool_exp
+  playlist_id: uuid_comparison_exp
+  position: Int_comparison_exp
+  updatedAt: timestamptz_comparison_exp
+}
+
+"""
+unique or primary key constraints on table "playlist_audios"
+"""
+enum playlist_audios_constraint {
+  """
+  unique or primary key constraint on columns "audio_id", "playlist_id"
+  """
+  playlist_audios_pkey
+}
+
+"""
+input type for incrementing numeric columns in table "playlist_audios"
+"""
+input playlist_audios_inc_input {
+  position: Int
+}
+
+"""
+input type for inserting data into table "playlist_audios"
+"""
+input playlist_audios_insert_input {
+  audio: audios_obj_rel_insert_input
+  audio_id: uuid
+  createdAt: timestamptz
+  playlist: playlist_obj_rel_insert_input
+  playlist_id: uuid
+  position: Int
+  updatedAt: timestamptz
+}
+
+"""
+aggregate max on columns
+"""
+type playlist_audios_max_fields {
+  audio_id: uuid
+  createdAt: timestamptz
+  playlist_id: uuid
+  position: Int
+  updatedAt: timestamptz
+}
+
+"""
+order by max() on columns of table "playlist_audios"
+"""
+input playlist_audios_max_order_by {
+  audio_id: order_by
+  createdAt: order_by
+  playlist_id: order_by
+  position: order_by
+  updatedAt: order_by
+}
+
+"""
+aggregate min on columns
+"""
+type playlist_audios_min_fields {
+  audio_id: uuid
+  createdAt: timestamptz
+  playlist_id: uuid
+  position: Int
+  updatedAt: timestamptz
+}
+
+"""
+order by min() on columns of table "playlist_audios"
+"""
+input playlist_audios_min_order_by {
+  audio_id: order_by
+  createdAt: order_by
+  playlist_id: order_by
+  position: order_by
+  updatedAt: order_by
+}
+
+"""
+response of any mutation on the table "playlist_audios"
+"""
+type playlist_audios_mutation_response {
+  """
+  number of rows affected by the mutation
+  """
+  affected_rows: Int!
+  """
+  data from the rows affected by the mutation
+  """
+  returning: [playlist_audios!]!
+}
+
+"""
+on_conflict condition type for table "playlist_audios"
+"""
+input playlist_audios_on_conflict {
+  constraint: playlist_audios_constraint!
+  update_columns: [playlist_audios_update_column!]! = []
+  where: playlist_audios_bool_exp
+}
+
+"""
+Ordering options when selecting data from "playlist_audios".
+"""
+input playlist_audios_order_by {
+  audio: audios_order_by
+  audio_id: order_by
+  createdAt: order_by
+  playlist: playlist_order_by
+  playlist_id: order_by
+  position: order_by
+  updatedAt: order_by
+}
+
+"""
+primary key columns input for table: playlist_audios
+"""
+input playlist_audios_pk_columns_input {
+  audio_id: uuid!
+  playlist_id: uuid!
+}
+
+"""
+select columns of table "playlist_audios"
+"""
+enum playlist_audios_select_column {
+  """
+  column name
+  """
+  audio_id
+  """
+  column name
+  """
+  createdAt
+  """
+  column name
+  """
+  playlist_id
+  """
+  column name
+  """
+  position
+  """
+  column name
+  """
+  updatedAt
+}
+
+"""
+input type for updating data in table "playlist_audios"
+"""
+input playlist_audios_set_input {
+  audio_id: uuid
+  createdAt: timestamptz
+  playlist_id: uuid
+  position: Int
+  updatedAt: timestamptz
+}
+
+"""
+aggregate stddev on columns
+"""
+type playlist_audios_stddev_fields {
+  position: Float
+}
+
+"""
+order by stddev() on columns of table "playlist_audios"
+"""
+input playlist_audios_stddev_order_by {
+  position: order_by
+}
+
+"""
+aggregate stddev_pop on columns
+"""
+type playlist_audios_stddev_pop_fields {
+  position: Float
+}
+
+"""
+order by stddev_pop() on columns of table "playlist_audios"
+"""
+input playlist_audios_stddev_pop_order_by {
+  position: order_by
+}
+
+"""
+aggregate stddev_samp on columns
+"""
+type playlist_audios_stddev_samp_fields {
+  position: Float
+}
+
+"""
+order by stddev_samp() on columns of table "playlist_audios"
+"""
+input playlist_audios_stddev_samp_order_by {
+  position: order_by
+}
+
+"""
+Streaming cursor of the table "playlist_audios"
+"""
+input playlist_audios_stream_cursor_input {
+  """
+  Stream column input with initial value
+  """
+  initial_value: playlist_audios_stream_cursor_value_input!
+  """
+  cursor ordering
+  """
+  ordering: cursor_ordering
+}
+
+"""
+Initial value of the column from where the streaming should start
+"""
+input playlist_audios_stream_cursor_value_input {
+  audio_id: uuid
+  createdAt: timestamptz
+  playlist_id: uuid
+  position: Int
+  updatedAt: timestamptz
+}
+
+"""
+aggregate sum on columns
+"""
+type playlist_audios_sum_fields {
+  position: Int
+}
+
+"""
+order by sum() on columns of table "playlist_audios"
+"""
+input playlist_audios_sum_order_by {
+  position: order_by
+}
+
+"""
+update columns of table "playlist_audios"
+"""
+enum playlist_audios_update_column {
+  """
+  column name
+  """
+  audio_id
+  """
+  column name
+  """
+  createdAt
+  """
+  column name
+  """
+  playlist_id
+  """
+  column name
+  """
+  position
+  """
+  column name
+  """
+  updatedAt
+}
+
+input playlist_audios_updates {
+  """
+  increments the numeric columns with given value of the filtered values
+  """
+  _inc: playlist_audios_inc_input
+  """
+  sets the columns of the filtered rows to the given values
+  """
+  _set: playlist_audios_set_input
+  """
+  filter the rows which have to be updated
+  """
+  where: playlist_audios_bool_exp!
+}
+
+"""
+aggregate var_pop on columns
+"""
+type playlist_audios_var_pop_fields {
+  position: Float
+}
+
+"""
+order by var_pop() on columns of table "playlist_audios"
+"""
+input playlist_audios_var_pop_order_by {
+  position: order_by
+}
+
+"""
+aggregate var_samp on columns
+"""
+type playlist_audios_var_samp_fields {
+  position: Float
+}
+
+"""
+order by var_samp() on columns of table "playlist_audios"
+"""
+input playlist_audios_var_samp_order_by {
+  position: order_by
+}
+
+"""
+aggregate variance on columns
+"""
+type playlist_audios_variance_fields {
+  position: Float
+}
+
+"""
+order by variance() on columns of table "playlist_audios"
+"""
+input playlist_audios_variance_order_by {
+  position: order_by
+}
+
+"""
 Boolean expression to filter rows from the table "playlist". All fields are combined with a logical 'AND'.
 """
 input playlist_bool_exp {
@@ -6886,6 +7526,8 @@ input playlist_bool_exp {
   createdAt: timestamptz_comparison_exp
   description: String_comparison_exp
   id: uuid_comparison_exp
+  playlist_audios: playlist_audios_bool_exp
+  playlist_audios_aggregate: playlist_audios_aggregate_bool_exp
   playlist_videos: playlist_videos_bool_exp
   playlist_videos_aggregate: playlist_videos_aggregate_bool_exp
   public: Boolean_comparison_exp
@@ -6894,6 +7536,7 @@ input playlist_bool_exp {
   sharedRecipientsInput: jsonb_comparison_exp
   shared_playlist_recipients: shared_playlist_recipients_bool_exp
   shared_playlist_recipients_aggregate: shared_playlist_recipients_aggregate_bool_exp
+  site: String_comparison_exp
   slug: String_comparison_exp
   thumbnailUrl: String_comparison_exp
   title: String_comparison_exp
@@ -6969,6 +7612,7 @@ input playlist_insert_input {
   createdAt: timestamptz
   description: String
   id: uuid
+  playlist_audios: playlist_audios_arr_rel_insert_input
   playlist_videos: playlist_videos_arr_rel_insert_input
   public: Boolean
   """
@@ -6984,6 +7628,7 @@ input playlist_insert_input {
   """
   sharedRecipientsInput: jsonb
   shared_playlist_recipients: shared_playlist_recipients_arr_rel_insert_input
+  site: String
   slug: String
   thumbnailUrl: String
   title: String
@@ -7003,6 +7648,7 @@ type playlist_max_fields {
   Short id like Youtube video id
   """
   sId: String
+  site: String
   slug: String
   thumbnailUrl: String
   title: String
@@ -7021,6 +7667,7 @@ input playlist_max_order_by {
   Short id like Youtube video id
   """
   sId: order_by
+  site: order_by
   slug: order_by
   thumbnailUrl: order_by
   title: order_by
@@ -7039,6 +7686,7 @@ type playlist_min_fields {
   Short id like Youtube video id
   """
   sId: String
+  site: String
   slug: String
   thumbnailUrl: String
   title: String
@@ -7057,6 +7705,7 @@ input playlist_min_order_by {
   Short id like Youtube video id
   """
   sId: order_by
+  site: order_by
   slug: order_by
   thumbnailUrl: order_by
   title: order_by
@@ -7105,12 +7754,14 @@ input playlist_order_by {
   createdAt: order_by
   description: order_by
   id: order_by
+  playlist_audios_aggregate: playlist_audios_aggregate_order_by
   playlist_videos_aggregate: playlist_videos_aggregate_order_by
   public: order_by
   sId: order_by
   sharedRecipients: order_by
   sharedRecipientsInput: order_by
   shared_playlist_recipients_aggregate: shared_playlist_recipients_aggregate_order_by
+  site: order_by
   slug: order_by
   thumbnailUrl: order_by
   title: order_by
@@ -7175,6 +7826,10 @@ enum playlist_select_column {
   """
   column name
   """
+  site
+  """
+  column name
+  """
   slug
   """
   column name
@@ -7234,6 +7889,7 @@ input playlist_set_input {
   List of recipient emails from user input, not validated yet. End user can update this.
   """
   sharedRecipientsInput: jsonb
+  site: String
   slug: String
   thumbnailUrl: String
   title: String
@@ -7275,6 +7931,7 @@ input playlist_stream_cursor_value_input {
   List of recipient emails from user input, not validated yet. End user can update this.
   """
   sharedRecipientsInput: jsonb
+  site: String
   slug: String
   thumbnailUrl: String
   title: String
@@ -7314,6 +7971,10 @@ enum playlist_update_column {
   column name
   """
   sharedRecipientsInput
+  """
+  column name
+  """
+  site
   """
   column name
   """
@@ -7813,7 +8474,7 @@ type posts {
   """
   Hashnode public id
   """
-  hId: String
+  hId: String!
   id: uuid!
   markdownContent: String!
   pinned: Boolean!
@@ -8842,6 +9503,60 @@ type query_root {
     """
     where: playlist_bool_exp
   ): playlist_aggregate!
+  """
+  An array relationship
+  """
+  playlist_audios(
+    """
+    distinct select on columns
+    """
+    distinct_on: [playlist_audios_select_column!]
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [playlist_audios_order_by!]
+    """
+    filter the rows returned
+    """
+    where: playlist_audios_bool_exp
+  ): [playlist_audios!]!
+  """
+  An aggregate relationship
+  """
+  playlist_audios_aggregate(
+    """
+    distinct select on columns
+    """
+    distinct_on: [playlist_audios_select_column!]
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [playlist_audios_order_by!]
+    """
+    filter the rows returned
+    """
+    where: playlist_audios_bool_exp
+  ): playlist_audios_aggregate!
+  """
+  fetch data from the table: "playlist_audios" using primary key columns
+  """
+  playlist_audios_by_pk(audio_id: uuid!, playlist_id: uuid!): playlist_audios
   """
   fetch data from the table: "playlist" using primary key columns
   """
@@ -10508,8 +11223,8 @@ type shared_video_recipients {
   """
   An object relationship
   """
-  video: videos
-  videoId: uuid
+  video: videos!
+  videoId: uuid!
   viewed: Boolean!
 }
 
@@ -11624,6 +12339,77 @@ type subscription_root {
     """
     where: playlist_bool_exp
   ): playlist_aggregate!
+  """
+  An array relationship
+  """
+  playlist_audios(
+    """
+    distinct select on columns
+    """
+    distinct_on: [playlist_audios_select_column!]
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [playlist_audios_order_by!]
+    """
+    filter the rows returned
+    """
+    where: playlist_audios_bool_exp
+  ): [playlist_audios!]!
+  """
+  An aggregate relationship
+  """
+  playlist_audios_aggregate(
+    """
+    distinct select on columns
+    """
+    distinct_on: [playlist_audios_select_column!]
+    """
+    limit the number of rows returned
+    """
+    limit: Int
+    """
+    skip the first n rows. Use only with order_by
+    """
+    offset: Int
+    """
+    sort the rows by one or more columns
+    """
+    order_by: [playlist_audios_order_by!]
+    """
+    filter the rows returned
+    """
+    where: playlist_audios_bool_exp
+  ): playlist_audios_aggregate!
+  """
+  fetch data from the table: "playlist_audios" using primary key columns
+  """
+  playlist_audios_by_pk(audio_id: uuid!, playlist_id: uuid!): playlist_audios
+  """
+  fetch data from the table in a streaming manner: "playlist_audios"
+  """
+  playlist_audios_stream(
+    """
+    maximum number of rows returned in a single batch
+    """
+    batch_size: Int!
+    """
+    cursor to stream the results returned by the query
+    """
+    cursor: [playlist_audios_stream_cursor_input]!
+    """
+    filter the rows returned
+    """
+    where: playlist_audios_bool_exp
+  ): [playlist_audios!]!
   """
   fetch data from the table: "playlist" using primary key columns
   """

--- a/packages/core/src/graphql/gql.ts
+++ b/packages/core/src/graphql/gql.ts
@@ -30,6 +30,11 @@ type Documents = {
   '\n  query GetReadingStats($monthStart: timestamptz!) {\n    books_aggregate {\n      aggregate {\n        count\n      }\n    }\n    completed_books: books_aggregate(where: { reading_progresses: { percentage: { _gte: 100 } } }) {\n      aggregate {\n        count\n      }\n    }\n    currently_reading: books_aggregate(where: { reading_progresses: { percentage: { _gt: 0, _lt: 100 } } }) {\n      aggregate {\n        count\n      }\n    }\n    reading_time_this_month: reading_progresses_aggregate(where: { lastReadAt: { _gte: $monthStart } }) {\n      aggregate {\n        sum {\n          readingTimeMinutes\n        }\n      }\n    }\n  }\n': typeof types.GetReadingStatsDocument;
   '\n  query GetAudiosAndFeelings @cached {\n    audios {\n      id\n      name\n      source\n      thumbnailUrl\n      public\n      artistName\n      createdAt\n      audio_tags {\n        tag_id\n      }\n    }\n    tags(where: { site: { _eq: "listen" } }) {\n      id\n      name\n    }\n  }\n': typeof types.GetAudiosAndFeelingsDocument;
   '\n  query GetPublicAudiosAndFeelings @cached {\n    audios(where: { public: { _eq: true } }) {\n      id\n      name\n      source\n      thumbnailUrl\n      artistName\n      audio_tags {\n        tag_id\n      }\n    }\n    tags(where: { site: { _eq: "listen" }, audio_tags: { audio: { public: { _eq: true } } } }) {\n      id\n      name\n    }\n  }\n': typeof types.GetPublicAudiosAndFeelingsDocument;
+  '\n  fragment AudioFields on audios {\n    id\n    name\n    source\n    thumbnailUrl\n    artistName\n    createdAt\n  }\n': typeof types.AudioFieldsFragmentDoc;
+  '\n  fragment PlaylistAudioFields on playlist_audios {\n    position\n    audio {\n      ...AudioFields\n    }\n  }\n': typeof types.PlaylistAudioFieldsFragmentDoc;
+  '\n  fragment ListenPlaylistFields on playlist {\n    id\n    title\n    thumbnailUrl\n    slug\n    createdAt\n    description\n    playlist_audios(order_by: { position: asc }) {\n      ...PlaylistAudioFields\n    }\n  }\n': typeof types.ListenPlaylistFieldsFragmentDoc;
+  '\n  query ListenPlaylistDetail($id: uuid!) {\n    playlist_by_pk(id: $id) {\n      ...ListenPlaylistFields\n    }\n  }\n': typeof types.ListenPlaylistDetailDocument;
+  '\n  query ListenPlaylists {\n    playlist(\n      where: { site: { _eq: "listen" } }\n      order_by: { createdAt: desc }\n    ) {\n      id\n      title\n      slug\n    }\n  }\n': typeof types.ListenPlaylistsDocument;
   '\n  mutation InsertPost($object: posts_insert_input!) {\n    insert_posts_one(object: $object) {\n      id\n      title\n      slug\n      brief\n      markdownContent\n      readTimeInMinutes\n      created_at\n      updated_at\n    }\n  }\n': typeof types.InsertPostDocument;
   '\n  mutation UpdatePost($id: uuid!, $object: posts_set_input!) {\n    update_posts_by_pk(pk_columns: { id: $id }, _set: $object) {\n      id\n      title\n      slug\n      brief\n      markdownContent\n      readTimeInMinutes\n      created_at\n      updated_at\n      status\n    }\n  }\n': typeof types.UpdatePostDocument;
   '\n  query Post($id: uuid!) {\n    posts_by_pk(id: $id) {\n      title\n      readTimeInMinutes\n      markdownContent\n      id\n      brief\n      slug\n      created_at\n      status\n      visibility\n      pinned\n    }\n  }\n': typeof types.PostDocument;
@@ -39,12 +44,12 @@ type Documents = {
   '\n  mutation MarkNotificationsAsRead($ids: [uuid!]!) {\n    update_notifications(where: { id: { _in: $ids }, readAt: { _is_null: true } }, _set: { readAt: "now()" }) {\n      affected_rows\n      returning {\n        id\n        readAt\n      }\n    }\n  }\n': typeof types.MarkNotificationsAsReadDocument;
   '\n  subscription Notifications {\n    notifications(order_by: { createdAt: desc }) {\n      id\n      entityId\n      entityType\n      type\n      readAt\n      link\n      metadata\n      video {\n        id\n        title\n      }\n    }\n  }\n': typeof types.NotificationsDocument;
   '\n  mutation InsertVideos($objects: [videos_insert_input!]!) {\n    insert_videos(objects: $objects) {\n      returning {\n        id\n        title\n        description\n      }\n    }\n  }\n': typeof types.InsertVideosDocument;
+  '\n  mutation CreateSignedUploadUrl($input: SignedUploadUrlInput!) {\n    createSignedUploadUrl(input: $input) {\n      success\n      message\n      dataObject {\n        uploadUrl\n        publicUrl\n        objectPath\n        expiresAt\n      }\n    }\n  }\n': typeof types.CreateSignedUploadUrlDocument;
   '\n  mutation SaveSubtitle($id: uuid!, $object: subtitles_set_input!) {\n    update_subtitles_by_pk(pk_columns: { id: $id }, _set: $object) {\n      id\n    }\n  }\n': typeof types.SaveSubtitleDocument;
   '\n  mutation SetVideoThumbnailAtTime($input: SetVideoThumbnailAtTimeInput!) {\n    setVideoThumbnailAtTime(input: $input) {\n      success\n      message\n      dataObject {\n        thumbnailUrl\n      }\n    }\n  }\n': typeof types.SetVideoThumbnailAtTimeDocument;
-  '\n  mutation CreateSignedUploadUrl($input: SignedUploadUrlInput!) {\n    createSignedUploadUrl(input: $input) {\n      success\n      message\n      dataObject {\n        uploadUrl\n        publicUrl\n        objectPath\n        expiresAt\n      }\n    }\n  }\n': typeof types.CreateSignedUploadUrlDocument;
-  '\n  mutation UpdateVideoThumbnail($id: uuid!, $thumbnailUrl: String!) {\n    update_videos_by_pk(pk_columns: { id: $id }, _set: { thumbnailUrl: $thumbnailUrl }) {\n      id\n      thumbnailUrl\n    }\n  }\n': typeof types.UpdateVideoThumbnailDocument;
   '\n  mutation sharePlaylist($id: uuid!, $emails: jsonb) {\n    update_playlist_by_pk(pk_columns: { id: $id }, _set: { sharedRecipientsInput: $emails }) {\n      id\n    }\n  }\n': typeof types.SharePlaylistDocument;
   '\n  mutation shareVideo($id: uuid!, $emails: jsonb) {\n    update_videos_by_pk(pk_columns: { id: $id }, _set: { sharedRecipientsInput: $emails }) {\n      id\n    }\n  }\n': typeof types.ShareVideoDocument;
+  '\n  mutation UpdateVideoThumbnail($id: uuid!, $thumbnailUrl: String!) {\n    update_videos_by_pk(pk_columns: { id: $id }, _set: { thumbnailUrl: $thumbnailUrl }) {\n      id\n      thumbnailUrl\n    }\n  }\n': typeof types.UpdateVideoThumbnailDocument;
   '\n  mutation UpdateVideoProgress($videoId: uuid!, $progressSeconds: Int!, $lastWatchedAt: timestamptz!) {\n    insert_user_video_history_one(\n      object: { video_id: $videoId, progress_seconds: $progressSeconds, last_watched_at: $lastWatchedAt }\n      on_conflict: {\n        constraint: user_video_history_user_id_video_id_key\n        update_columns: [progress_seconds, last_watched_at]\n      }\n    ) {\n      id\n      progress_seconds\n      last_watched_at\n    }\n  }\n': typeof types.UpdateVideoProgressDocument;
   '\n  fragment UserFields on users {\n    username\n  }\n': typeof types.UserFieldsFragmentDoc;
   '\n  fragment VideoFields on videos {\n    id\n    title\n    description\n    duration\n    thumbnailUrl\n    source\n    slug\n    createdAt\n    user_id\n    user {\n      ...UserFields\n    }\n    user_video_histories {\n      last_watched_at\n      progress_seconds\n    }\n    subtitles {\n      id\n      isDefault\n      lang\n      url\n    }\n  }\n': typeof types.VideoFieldsFragmentDoc;
@@ -91,6 +96,16 @@ const documents: Documents = {
     types.GetAudiosAndFeelingsDocument,
   '\n  query GetPublicAudiosAndFeelings @cached {\n    audios(where: { public: { _eq: true } }) {\n      id\n      name\n      source\n      thumbnailUrl\n      artistName\n      audio_tags {\n        tag_id\n      }\n    }\n    tags(where: { site: { _eq: "listen" }, audio_tags: { audio: { public: { _eq: true } } } }) {\n      id\n      name\n    }\n  }\n':
     types.GetPublicAudiosAndFeelingsDocument,
+  '\n  fragment AudioFields on audios {\n    id\n    name\n    source\n    thumbnailUrl\n    artistName\n    createdAt\n  }\n':
+    types.AudioFieldsFragmentDoc,
+  '\n  fragment PlaylistAudioFields on playlist_audios {\n    position\n    audio {\n      ...AudioFields\n    }\n  }\n':
+    types.PlaylistAudioFieldsFragmentDoc,
+  '\n  fragment ListenPlaylistFields on playlist {\n    id\n    title\n    thumbnailUrl\n    slug\n    createdAt\n    description\n    playlist_audios(order_by: { position: asc }) {\n      ...PlaylistAudioFields\n    }\n  }\n':
+    types.ListenPlaylistFieldsFragmentDoc,
+  '\n  query ListenPlaylistDetail($id: uuid!) {\n    playlist_by_pk(id: $id) {\n      ...ListenPlaylistFields\n    }\n  }\n':
+    types.ListenPlaylistDetailDocument,
+  '\n  query ListenPlaylists {\n    playlist(\n      where: { site: { _eq: "listen" } }\n      order_by: { createdAt: desc }\n    ) {\n      id\n      title\n      slug\n    }\n  }\n':
+    types.ListenPlaylistsDocument,
   '\n  mutation InsertPost($object: posts_insert_input!) {\n    insert_posts_one(object: $object) {\n      id\n      title\n      slug\n      brief\n      markdownContent\n      readTimeInMinutes\n      created_at\n      updated_at\n    }\n  }\n':
     types.InsertPostDocument,
   '\n  mutation UpdatePost($id: uuid!, $object: posts_set_input!) {\n    update_posts_by_pk(pk_columns: { id: $id }, _set: $object) {\n      id\n      title\n      slug\n      brief\n      markdownContent\n      readTimeInMinutes\n      created_at\n      updated_at\n      status\n    }\n  }\n':
@@ -109,18 +124,18 @@ const documents: Documents = {
     types.NotificationsDocument,
   '\n  mutation InsertVideos($objects: [videos_insert_input!]!) {\n    insert_videos(objects: $objects) {\n      returning {\n        id\n        title\n        description\n      }\n    }\n  }\n':
     types.InsertVideosDocument,
+  '\n  mutation CreateSignedUploadUrl($input: SignedUploadUrlInput!) {\n    createSignedUploadUrl(input: $input) {\n      success\n      message\n      dataObject {\n        uploadUrl\n        publicUrl\n        objectPath\n        expiresAt\n      }\n    }\n  }\n':
+    types.CreateSignedUploadUrlDocument,
   '\n  mutation SaveSubtitle($id: uuid!, $object: subtitles_set_input!) {\n    update_subtitles_by_pk(pk_columns: { id: $id }, _set: $object) {\n      id\n    }\n  }\n':
     types.SaveSubtitleDocument,
   '\n  mutation SetVideoThumbnailAtTime($input: SetVideoThumbnailAtTimeInput!) {\n    setVideoThumbnailAtTime(input: $input) {\n      success\n      message\n      dataObject {\n        thumbnailUrl\n      }\n    }\n  }\n':
     types.SetVideoThumbnailAtTimeDocument,
-  '\n  mutation CreateSignedUploadUrl($input: SignedUploadUrlInput!) {\n    createSignedUploadUrl(input: $input) {\n      success\n      message\n      dataObject {\n        uploadUrl\n        publicUrl\n        objectPath\n        expiresAt\n      }\n    }\n  }\n':
-    types.CreateSignedUploadUrlDocument,
-  '\n  mutation UpdateVideoThumbnail($id: uuid!, $thumbnailUrl: String!) {\n    update_videos_by_pk(pk_columns: { id: $id }, _set: { thumbnailUrl: $thumbnailUrl }) {\n      id\n      thumbnailUrl\n    }\n  }\n':
-    types.UpdateVideoThumbnailDocument,
   '\n  mutation sharePlaylist($id: uuid!, $emails: jsonb) {\n    update_playlist_by_pk(pk_columns: { id: $id }, _set: { sharedRecipientsInput: $emails }) {\n      id\n    }\n  }\n':
     types.SharePlaylistDocument,
   '\n  mutation shareVideo($id: uuid!, $emails: jsonb) {\n    update_videos_by_pk(pk_columns: { id: $id }, _set: { sharedRecipientsInput: $emails }) {\n      id\n    }\n  }\n':
     types.ShareVideoDocument,
+  '\n  mutation UpdateVideoThumbnail($id: uuid!, $thumbnailUrl: String!) {\n    update_videos_by_pk(pk_columns: { id: $id }, _set: { thumbnailUrl: $thumbnailUrl }) {\n      id\n      thumbnailUrl\n    }\n  }\n':
+    types.UpdateVideoThumbnailDocument,
   '\n  mutation UpdateVideoProgress($videoId: uuid!, $progressSeconds: Int!, $lastWatchedAt: timestamptz!) {\n    insert_user_video_history_one(\n      object: { video_id: $videoId, progress_seconds: $progressSeconds, last_watched_at: $lastWatchedAt }\n      on_conflict: {\n        constraint: user_video_history_user_id_video_id_key\n        update_columns: [progress_seconds, last_watched_at]\n      }\n    ) {\n      id\n      progress_seconds\n      last_watched_at\n    }\n  }\n':
     types.UpdateVideoProgressDocument,
   '\n  fragment UserFields on users {\n    username\n  }\n':
@@ -249,6 +264,36 @@ export function graphql(
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(
+  source: '\n  fragment AudioFields on audios {\n    id\n    name\n    source\n    thumbnailUrl\n    artistName\n    createdAt\n  }\n',
+): typeof import('./graphql').AudioFieldsFragmentDoc;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: '\n  fragment PlaylistAudioFields on playlist_audios {\n    position\n    audio {\n      ...AudioFields\n    }\n  }\n',
+): typeof import('./graphql').PlaylistAudioFieldsFragmentDoc;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: '\n  fragment ListenPlaylistFields on playlist {\n    id\n    title\n    thumbnailUrl\n    slug\n    createdAt\n    description\n    playlist_audios(order_by: { position: asc }) {\n      ...PlaylistAudioFields\n    }\n  }\n',
+): typeof import('./graphql').ListenPlaylistFieldsFragmentDoc;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: '\n  query ListenPlaylistDetail($id: uuid!) {\n    playlist_by_pk(id: $id) {\n      ...ListenPlaylistFields\n    }\n  }\n',
+): typeof import('./graphql').ListenPlaylistDetailDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: '\n  query ListenPlaylists {\n    playlist(\n      where: { site: { _eq: "listen" } }\n      order_by: { createdAt: desc }\n    ) {\n      id\n      title\n      slug\n    }\n  }\n',
+): typeof import('./graphql').ListenPlaylistsDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
   source: '\n  mutation InsertPost($object: posts_insert_input!) {\n    insert_posts_one(object: $object) {\n      id\n      title\n      slug\n      brief\n      markdownContent\n      readTimeInMinutes\n      created_at\n      updated_at\n    }\n  }\n',
 ): typeof import('./graphql').InsertPostDocument;
 /**
@@ -303,6 +348,12 @@ export function graphql(
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(
+  source: '\n  mutation CreateSignedUploadUrl($input: SignedUploadUrlInput!) {\n    createSignedUploadUrl(input: $input) {\n      success\n      message\n      dataObject {\n        uploadUrl\n        publicUrl\n        objectPath\n        expiresAt\n      }\n    }\n  }\n',
+): typeof import('./graphql').CreateSignedUploadUrlDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
   source: '\n  mutation SaveSubtitle($id: uuid!, $object: subtitles_set_input!) {\n    update_subtitles_by_pk(pk_columns: { id: $id }, _set: $object) {\n      id\n    }\n  }\n',
 ): typeof import('./graphql').SaveSubtitleDocument;
 /**
@@ -315,18 +366,6 @@ export function graphql(
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(
-  source: '\n  mutation CreateSignedUploadUrl($input: SignedUploadUrlInput!) {\n    createSignedUploadUrl(input: $input) {\n      success\n      message\n      dataObject {\n        uploadUrl\n        publicUrl\n        objectPath\n        expiresAt\n      }\n    }\n  }\n',
-): typeof import('./graphql').CreateSignedUploadUrlDocument;
-/**
- * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
- */
-export function graphql(
-  source: '\n  mutation UpdateVideoThumbnail($id: uuid!, $thumbnailUrl: String!) {\n    update_videos_by_pk(pk_columns: { id: $id }, _set: { thumbnailUrl: $thumbnailUrl }) {\n      id\n      thumbnailUrl\n    }\n  }\n',
-): typeof import('./graphql').UpdateVideoThumbnailDocument;
-/**
- * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
- */
-export function graphql(
   source: '\n  mutation sharePlaylist($id: uuid!, $emails: jsonb) {\n    update_playlist_by_pk(pk_columns: { id: $id }, _set: { sharedRecipientsInput: $emails }) {\n      id\n    }\n  }\n',
 ): typeof import('./graphql').SharePlaylistDocument;
 /**
@@ -335,6 +374,12 @@ export function graphql(
 export function graphql(
   source: '\n  mutation shareVideo($id: uuid!, $emails: jsonb) {\n    update_videos_by_pk(pk_columns: { id: $id }, _set: { sharedRecipientsInput: $emails }) {\n      id\n    }\n  }\n',
 ): typeof import('./graphql').ShareVideoDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: '\n  mutation UpdateVideoThumbnail($id: uuid!, $thumbnailUrl: String!) {\n    update_videos_by_pk(pk_columns: { id: $id }, _set: { thumbnailUrl: $thumbnailUrl }) {\n      id\n      thumbnailUrl\n    }\n  }\n',
+): typeof import('./graphql').UpdateVideoThumbnailDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/packages/core/src/graphql/graphql.ts
+++ b/packages/core/src/graphql/graphql.ts
@@ -88,6 +88,23 @@ export type Int_Comparison_Exp = {
   _nin?: InputMaybe<Array<Scalars['Int']['input']>>;
 };
 
+export type SetVideoThumbnailAtTimeInput = {
+  atSeconds: Scalars['Float']['input'];
+  videoId: Scalars['String']['input'];
+};
+
+export type SetVideoThumbnailAtTimeOutput = {
+  __typename?: 'SetVideoThumbnailAtTimeOutput';
+  thumbnailUrl: Scalars['String']['output'];
+};
+
+export type SetVideoThumbnailAtTimeResponse = {
+  __typename?: 'SetVideoThumbnailAtTimeResponse';
+  dataObject?: Maybe<SetVideoThumbnailAtTimeOutput>;
+  message: Scalars['String']['output'];
+  success: Scalars['Boolean']['output'];
+};
+
 export type SignedUploadUrlInput = {
   action: Scalars['String']['input'];
   contentType: Scalars['String']['input'];
@@ -363,6 +380,10 @@ export type Audios = {
   createdAt: Scalars['timestamptz']['output'];
   id: Scalars['uuid']['output'];
   name: Scalars['String']['output'];
+  /** An array relationship */
+  playlist_audios: Array<Playlist_Audios>;
+  /** An aggregate relationship */
+  playlist_audios_aggregate: Playlist_Audios_Aggregate;
   public: Scalars['Boolean']['output'];
   source: Scalars['String']['output'];
   thumbnailUrl?: Maybe<Scalars['String']['output']>;
@@ -388,6 +409,24 @@ export type AudiosAudio_Tags_AggregateArgs = {
   offset?: InputMaybe<Scalars['Int']['input']>;
   order_by?: InputMaybe<Array<Audio_Tags_Order_By>>;
   where?: InputMaybe<Audio_Tags_Bool_Exp>;
+};
+
+/** Audios for listen site */
+export type AudiosPlaylist_AudiosArgs = {
+  distinct_on?: InputMaybe<Array<Playlist_Audios_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Playlist_Audios_Order_By>>;
+  where?: InputMaybe<Playlist_Audios_Bool_Exp>;
+};
+
+/** Audios for listen site */
+export type AudiosPlaylist_Audios_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Playlist_Audios_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Playlist_Audios_Order_By>>;
+  where?: InputMaybe<Playlist_Audios_Bool_Exp>;
 };
 
 /** aggregated selection of "audios" */
@@ -463,6 +502,8 @@ export type Audios_Bool_Exp = {
   createdAt?: InputMaybe<Timestamptz_Comparison_Exp>;
   id?: InputMaybe<Uuid_Comparison_Exp>;
   name?: InputMaybe<String_Comparison_Exp>;
+  playlist_audios?: InputMaybe<Playlist_Audios_Bool_Exp>;
+  playlist_audios_aggregate?: InputMaybe<Playlist_Audios_Aggregate_Bool_Exp>;
   public?: InputMaybe<Boolean_Comparison_Exp>;
   source?: InputMaybe<String_Comparison_Exp>;
   thumbnailUrl?: InputMaybe<String_Comparison_Exp>;
@@ -484,6 +525,7 @@ export type Audios_Insert_Input = {
   createdAt?: InputMaybe<Scalars['timestamptz']['input']>;
   id?: InputMaybe<Scalars['uuid']['input']>;
   name?: InputMaybe<Scalars['String']['input']>;
+  playlist_audios?: InputMaybe<Playlist_Audios_Arr_Rel_Insert_Input>;
   public?: InputMaybe<Scalars['Boolean']['input']>;
   source?: InputMaybe<Scalars['String']['input']>;
   thumbnailUrl?: InputMaybe<Scalars['String']['input']>;
@@ -572,6 +614,7 @@ export type Audios_Order_By = {
   createdAt?: InputMaybe<Order_By>;
   id?: InputMaybe<Order_By>;
   name?: InputMaybe<Order_By>;
+  playlist_audios_aggregate?: InputMaybe<Playlist_Audios_Aggregate_Order_By>;
   public?: InputMaybe<Order_By>;
   source?: InputMaybe<Order_By>;
   thumbnailUrl?: InputMaybe<Order_By>;
@@ -3091,6 +3134,10 @@ export type Mutation_Root = {
   delete_notifications_by_pk?: Maybe<Notifications>;
   /** delete data from the table: "playlist" */
   delete_playlist?: Maybe<Playlist_Mutation_Response>;
+  /** delete data from the table: "playlist_audios" */
+  delete_playlist_audios?: Maybe<Playlist_Audios_Mutation_Response>;
+  /** delete single row from the table: "playlist_audios" */
+  delete_playlist_audios_by_pk?: Maybe<Playlist_Audios>;
   /** delete single row from the table: "playlist" */
   delete_playlist_by_pk?: Maybe<Playlist>;
   /** delete data from the table: "playlist_videos" */
@@ -3191,6 +3238,10 @@ export type Mutation_Root = {
   insert_notifications_one?: Maybe<Notifications>;
   /** insert data into the table: "playlist" */
   insert_playlist?: Maybe<Playlist_Mutation_Response>;
+  /** insert data into the table: "playlist_audios" */
+  insert_playlist_audios?: Maybe<Playlist_Audios_Mutation_Response>;
+  /** insert a single row into the table: "playlist_audios" */
+  insert_playlist_audios_one?: Maybe<Playlist_Audios>;
   /** insert a single row into the table: "playlist" */
   insert_playlist_one?: Maybe<Playlist>;
   /** insert data into the table: "playlist_videos" */
@@ -3249,6 +3300,8 @@ export type Mutation_Root = {
   insert_videos?: Maybe<Videos_Mutation_Response>;
   /** insert a single row into the table: "videos" */
   insert_videos_one?: Maybe<Videos>;
+  /** Capture the frame at a given timestamp and persist it as the video's thumbnail; ownership enforced server-side against the session user. */
+  setVideoThumbnailAtTime: SetVideoThumbnailAtTimeResponse;
   /** update data of the table: "audio_tags" */
   update_audio_tags?: Maybe<Audio_Tags_Mutation_Response>;
   /** update single row of the table: "audio_tags" */
@@ -3323,6 +3376,14 @@ export type Mutation_Root = {
   >;
   /** update data of the table: "playlist" */
   update_playlist?: Maybe<Playlist_Mutation_Response>;
+  /** update data of the table: "playlist_audios" */
+  update_playlist_audios?: Maybe<Playlist_Audios_Mutation_Response>;
+  /** update single row of the table: "playlist_audios" */
+  update_playlist_audios_by_pk?: Maybe<Playlist_Audios>;
+  /** update multiples rows of table: "playlist_audios" */
+  update_playlist_audios_many?: Maybe<
+    Array<Maybe<Playlist_Audios_Mutation_Response>>
+  >;
   /** update single row of the table: "playlist" */
   update_playlist_by_pk?: Maybe<Playlist>;
   /** update multiples rows of table: "playlist" */
@@ -3537,6 +3598,17 @@ export type Mutation_RootDelete_Notifications_By_PkArgs = {
 /** mutation root */
 export type Mutation_RootDelete_PlaylistArgs = {
   where: Playlist_Bool_Exp;
+};
+
+/** mutation root */
+export type Mutation_RootDelete_Playlist_AudiosArgs = {
+  where: Playlist_Audios_Bool_Exp;
+};
+
+/** mutation root */
+export type Mutation_RootDelete_Playlist_Audios_By_PkArgs = {
+  audio_id: Scalars['uuid']['input'];
+  playlist_id: Scalars['uuid']['input'];
 };
 
 /** mutation root */
@@ -3813,6 +3885,18 @@ export type Mutation_RootInsert_PlaylistArgs = {
 };
 
 /** mutation root */
+export type Mutation_RootInsert_Playlist_AudiosArgs = {
+  objects: Array<Playlist_Audios_Insert_Input>;
+  on_conflict?: InputMaybe<Playlist_Audios_On_Conflict>;
+};
+
+/** mutation root */
+export type Mutation_RootInsert_Playlist_Audios_OneArgs = {
+  object: Playlist_Audios_Insert_Input;
+  on_conflict?: InputMaybe<Playlist_Audios_On_Conflict>;
+};
+
+/** mutation root */
 export type Mutation_RootInsert_Playlist_OneArgs = {
   object: Playlist_Insert_Input;
   on_conflict?: InputMaybe<Playlist_On_Conflict>;
@@ -3984,6 +4068,11 @@ export type Mutation_RootInsert_VideosArgs = {
 export type Mutation_RootInsert_Videos_OneArgs = {
   object: Videos_Insert_Input;
   on_conflict?: InputMaybe<Videos_On_Conflict>;
+};
+
+/** mutation root */
+export type Mutation_RootSetVideoThumbnailAtTimeArgs = {
+  input: SetVideoThumbnailAtTimeInput;
 };
 
 /** mutation root */
@@ -4199,6 +4288,25 @@ export type Mutation_RootUpdate_PlaylistArgs = {
   _prepend?: InputMaybe<Playlist_Prepend_Input>;
   _set?: InputMaybe<Playlist_Set_Input>;
   where: Playlist_Bool_Exp;
+};
+
+/** mutation root */
+export type Mutation_RootUpdate_Playlist_AudiosArgs = {
+  _inc?: InputMaybe<Playlist_Audios_Inc_Input>;
+  _set?: InputMaybe<Playlist_Audios_Set_Input>;
+  where: Playlist_Audios_Bool_Exp;
+};
+
+/** mutation root */
+export type Mutation_RootUpdate_Playlist_Audios_By_PkArgs = {
+  _inc?: InputMaybe<Playlist_Audios_Inc_Input>;
+  _set?: InputMaybe<Playlist_Audios_Set_Input>;
+  pk_columns: Playlist_Audios_Pk_Columns_Input;
+};
+
+/** mutation root */
+export type Mutation_RootUpdate_Playlist_Audios_ManyArgs = {
+  updates: Array<Playlist_Audios_Updates>;
 };
 
 /** mutation root */
@@ -4853,6 +4961,10 @@ export type Playlist = {
   description?: Maybe<Scalars['String']['output']>;
   id: Scalars['uuid']['output'];
   /** An array relationship */
+  playlist_audios: Array<Playlist_Audios>;
+  /** An aggregate relationship */
+  playlist_audios_aggregate: Playlist_Audios_Aggregate;
+  /** An array relationship */
   playlist_videos: Array<Playlist_Videos>;
   /** An aggregate relationship */
   playlist_videos_aggregate: Playlist_Videos_Aggregate;
@@ -4867,6 +4979,7 @@ export type Playlist = {
   shared_playlist_recipients: Array<Shared_Playlist_Recipients>;
   /** An aggregate relationship */
   shared_playlist_recipients_aggregate: Shared_Playlist_Recipients_Aggregate;
+  site: Scalars['String']['output'];
   slug: Scalars['String']['output'];
   thumbnailUrl?: Maybe<Scalars['String']['output']>;
   title: Scalars['String']['output'];
@@ -4874,6 +4987,24 @@ export type Playlist = {
   /** An object relationship */
   user: Users;
   user_id: Scalars['uuid']['output'];
+};
+
+/** Playlist contain set of videos or audios */
+export type PlaylistPlaylist_AudiosArgs = {
+  distinct_on?: InputMaybe<Array<Playlist_Audios_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Playlist_Audios_Order_By>>;
+  where?: InputMaybe<Playlist_Audios_Bool_Exp>;
+};
+
+/** Playlist contain set of videos or audios */
+export type PlaylistPlaylist_Audios_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Playlist_Audios_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Playlist_Audios_Order_By>>;
+  where?: InputMaybe<Playlist_Audios_Bool_Exp>;
 };
 
 /** Playlist contain set of videos or audios */
@@ -4992,6 +5123,340 @@ export type Playlist_Arr_Rel_Insert_Input = {
   on_conflict?: InputMaybe<Playlist_On_Conflict>;
 };
 
+/** Junction table between audios and playlist */
+export type Playlist_Audios = {
+  __typename?: 'playlist_audios';
+  /** An object relationship */
+  audio: Audios;
+  audio_id: Scalars['uuid']['output'];
+  createdAt: Scalars['timestamptz']['output'];
+  /** An object relationship */
+  playlist: Playlist;
+  playlist_id: Scalars['uuid']['output'];
+  position: Scalars['Int']['output'];
+  updatedAt: Scalars['timestamptz']['output'];
+};
+
+/** aggregated selection of "playlist_audios" */
+export type Playlist_Audios_Aggregate = {
+  __typename?: 'playlist_audios_aggregate';
+  aggregate?: Maybe<Playlist_Audios_Aggregate_Fields>;
+  nodes: Array<Playlist_Audios>;
+};
+
+export type Playlist_Audios_Aggregate_Bool_Exp = {
+  count?: InputMaybe<Playlist_Audios_Aggregate_Bool_Exp_Count>;
+};
+
+export type Playlist_Audios_Aggregate_Bool_Exp_Count = {
+  arguments?: InputMaybe<Array<Playlist_Audios_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+  filter?: InputMaybe<Playlist_Audios_Bool_Exp>;
+  predicate: Int_Comparison_Exp;
+};
+
+/** aggregate fields of "playlist_audios" */
+export type Playlist_Audios_Aggregate_Fields = {
+  __typename?: 'playlist_audios_aggregate_fields';
+  avg?: Maybe<Playlist_Audios_Avg_Fields>;
+  count: Scalars['Int']['output'];
+  max?: Maybe<Playlist_Audios_Max_Fields>;
+  min?: Maybe<Playlist_Audios_Min_Fields>;
+  stddev?: Maybe<Playlist_Audios_Stddev_Fields>;
+  stddev_pop?: Maybe<Playlist_Audios_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Playlist_Audios_Stddev_Samp_Fields>;
+  sum?: Maybe<Playlist_Audios_Sum_Fields>;
+  var_pop?: Maybe<Playlist_Audios_Var_Pop_Fields>;
+  var_samp?: Maybe<Playlist_Audios_Var_Samp_Fields>;
+  variance?: Maybe<Playlist_Audios_Variance_Fields>;
+};
+
+/** aggregate fields of "playlist_audios" */
+export type Playlist_Audios_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Playlist_Audios_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** order by aggregate values of table "playlist_audios" */
+export type Playlist_Audios_Aggregate_Order_By = {
+  avg?: InputMaybe<Playlist_Audios_Avg_Order_By>;
+  count?: InputMaybe<Order_By>;
+  max?: InputMaybe<Playlist_Audios_Max_Order_By>;
+  min?: InputMaybe<Playlist_Audios_Min_Order_By>;
+  stddev?: InputMaybe<Playlist_Audios_Stddev_Order_By>;
+  stddev_pop?: InputMaybe<Playlist_Audios_Stddev_Pop_Order_By>;
+  stddev_samp?: InputMaybe<Playlist_Audios_Stddev_Samp_Order_By>;
+  sum?: InputMaybe<Playlist_Audios_Sum_Order_By>;
+  var_pop?: InputMaybe<Playlist_Audios_Var_Pop_Order_By>;
+  var_samp?: InputMaybe<Playlist_Audios_Var_Samp_Order_By>;
+  variance?: InputMaybe<Playlist_Audios_Variance_Order_By>;
+};
+
+/** input type for inserting array relation for remote table "playlist_audios" */
+export type Playlist_Audios_Arr_Rel_Insert_Input = {
+  data: Array<Playlist_Audios_Insert_Input>;
+  /** upsert condition */
+  on_conflict?: InputMaybe<Playlist_Audios_On_Conflict>;
+};
+
+/** aggregate avg on columns */
+export type Playlist_Audios_Avg_Fields = {
+  __typename?: 'playlist_audios_avg_fields';
+  position?: Maybe<Scalars['Float']['output']>;
+};
+
+/** order by avg() on columns of table "playlist_audios" */
+export type Playlist_Audios_Avg_Order_By = {
+  position?: InputMaybe<Order_By>;
+};
+
+/** Boolean expression to filter rows from the table "playlist_audios". All fields are combined with a logical 'AND'. */
+export type Playlist_Audios_Bool_Exp = {
+  _and?: InputMaybe<Array<Playlist_Audios_Bool_Exp>>;
+  _not?: InputMaybe<Playlist_Audios_Bool_Exp>;
+  _or?: InputMaybe<Array<Playlist_Audios_Bool_Exp>>;
+  audio?: InputMaybe<Audios_Bool_Exp>;
+  audio_id?: InputMaybe<Uuid_Comparison_Exp>;
+  createdAt?: InputMaybe<Timestamptz_Comparison_Exp>;
+  playlist?: InputMaybe<Playlist_Bool_Exp>;
+  playlist_id?: InputMaybe<Uuid_Comparison_Exp>;
+  position?: InputMaybe<Int_Comparison_Exp>;
+  updatedAt?: InputMaybe<Timestamptz_Comparison_Exp>;
+};
+
+/** unique or primary key constraints on table "playlist_audios" */
+export enum Playlist_Audios_Constraint {
+  /** unique or primary key constraint on columns "audio_id", "playlist_id" */
+  PlaylistAudiosPkey = 'playlist_audios_pkey',
+}
+
+/** input type for incrementing numeric columns in table "playlist_audios" */
+export type Playlist_Audios_Inc_Input = {
+  position?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** input type for inserting data into table "playlist_audios" */
+export type Playlist_Audios_Insert_Input = {
+  audio?: InputMaybe<Audios_Obj_Rel_Insert_Input>;
+  audio_id?: InputMaybe<Scalars['uuid']['input']>;
+  createdAt?: InputMaybe<Scalars['timestamptz']['input']>;
+  playlist?: InputMaybe<Playlist_Obj_Rel_Insert_Input>;
+  playlist_id?: InputMaybe<Scalars['uuid']['input']>;
+  position?: InputMaybe<Scalars['Int']['input']>;
+  updatedAt?: InputMaybe<Scalars['timestamptz']['input']>;
+};
+
+/** aggregate max on columns */
+export type Playlist_Audios_Max_Fields = {
+  __typename?: 'playlist_audios_max_fields';
+  audio_id?: Maybe<Scalars['uuid']['output']>;
+  createdAt?: Maybe<Scalars['timestamptz']['output']>;
+  playlist_id?: Maybe<Scalars['uuid']['output']>;
+  position?: Maybe<Scalars['Int']['output']>;
+  updatedAt?: Maybe<Scalars['timestamptz']['output']>;
+};
+
+/** order by max() on columns of table "playlist_audios" */
+export type Playlist_Audios_Max_Order_By = {
+  audio_id?: InputMaybe<Order_By>;
+  createdAt?: InputMaybe<Order_By>;
+  playlist_id?: InputMaybe<Order_By>;
+  position?: InputMaybe<Order_By>;
+  updatedAt?: InputMaybe<Order_By>;
+};
+
+/** aggregate min on columns */
+export type Playlist_Audios_Min_Fields = {
+  __typename?: 'playlist_audios_min_fields';
+  audio_id?: Maybe<Scalars['uuid']['output']>;
+  createdAt?: Maybe<Scalars['timestamptz']['output']>;
+  playlist_id?: Maybe<Scalars['uuid']['output']>;
+  position?: Maybe<Scalars['Int']['output']>;
+  updatedAt?: Maybe<Scalars['timestamptz']['output']>;
+};
+
+/** order by min() on columns of table "playlist_audios" */
+export type Playlist_Audios_Min_Order_By = {
+  audio_id?: InputMaybe<Order_By>;
+  createdAt?: InputMaybe<Order_By>;
+  playlist_id?: InputMaybe<Order_By>;
+  position?: InputMaybe<Order_By>;
+  updatedAt?: InputMaybe<Order_By>;
+};
+
+/** response of any mutation on the table "playlist_audios" */
+export type Playlist_Audios_Mutation_Response = {
+  __typename?: 'playlist_audios_mutation_response';
+  /** number of rows affected by the mutation */
+  affected_rows: Scalars['Int']['output'];
+  /** data from the rows affected by the mutation */
+  returning: Array<Playlist_Audios>;
+};
+
+/** on_conflict condition type for table "playlist_audios" */
+export type Playlist_Audios_On_Conflict = {
+  constraint: Playlist_Audios_Constraint;
+  update_columns?: Array<Playlist_Audios_Update_Column>;
+  where?: InputMaybe<Playlist_Audios_Bool_Exp>;
+};
+
+/** Ordering options when selecting data from "playlist_audios". */
+export type Playlist_Audios_Order_By = {
+  audio?: InputMaybe<Audios_Order_By>;
+  audio_id?: InputMaybe<Order_By>;
+  createdAt?: InputMaybe<Order_By>;
+  playlist?: InputMaybe<Playlist_Order_By>;
+  playlist_id?: InputMaybe<Order_By>;
+  position?: InputMaybe<Order_By>;
+  updatedAt?: InputMaybe<Order_By>;
+};
+
+/** primary key columns input for table: playlist_audios */
+export type Playlist_Audios_Pk_Columns_Input = {
+  audio_id: Scalars['uuid']['input'];
+  playlist_id: Scalars['uuid']['input'];
+};
+
+/** select columns of table "playlist_audios" */
+export enum Playlist_Audios_Select_Column {
+  /** column name */
+  AudioId = 'audio_id',
+  /** column name */
+  CreatedAt = 'createdAt',
+  /** column name */
+  PlaylistId = 'playlist_id',
+  /** column name */
+  Position = 'position',
+  /** column name */
+  UpdatedAt = 'updatedAt',
+}
+
+/** input type for updating data in table "playlist_audios" */
+export type Playlist_Audios_Set_Input = {
+  audio_id?: InputMaybe<Scalars['uuid']['input']>;
+  createdAt?: InputMaybe<Scalars['timestamptz']['input']>;
+  playlist_id?: InputMaybe<Scalars['uuid']['input']>;
+  position?: InputMaybe<Scalars['Int']['input']>;
+  updatedAt?: InputMaybe<Scalars['timestamptz']['input']>;
+};
+
+/** aggregate stddev on columns */
+export type Playlist_Audios_Stddev_Fields = {
+  __typename?: 'playlist_audios_stddev_fields';
+  position?: Maybe<Scalars['Float']['output']>;
+};
+
+/** order by stddev() on columns of table "playlist_audios" */
+export type Playlist_Audios_Stddev_Order_By = {
+  position?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Playlist_Audios_Stddev_Pop_Fields = {
+  __typename?: 'playlist_audios_stddev_pop_fields';
+  position?: Maybe<Scalars['Float']['output']>;
+};
+
+/** order by stddev_pop() on columns of table "playlist_audios" */
+export type Playlist_Audios_Stddev_Pop_Order_By = {
+  position?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Playlist_Audios_Stddev_Samp_Fields = {
+  __typename?: 'playlist_audios_stddev_samp_fields';
+  position?: Maybe<Scalars['Float']['output']>;
+};
+
+/** order by stddev_samp() on columns of table "playlist_audios" */
+export type Playlist_Audios_Stddev_Samp_Order_By = {
+  position?: InputMaybe<Order_By>;
+};
+
+/** Streaming cursor of the table "playlist_audios" */
+export type Playlist_Audios_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Playlist_Audios_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Playlist_Audios_Stream_Cursor_Value_Input = {
+  audio_id?: InputMaybe<Scalars['uuid']['input']>;
+  createdAt?: InputMaybe<Scalars['timestamptz']['input']>;
+  playlist_id?: InputMaybe<Scalars['uuid']['input']>;
+  position?: InputMaybe<Scalars['Int']['input']>;
+  updatedAt?: InputMaybe<Scalars['timestamptz']['input']>;
+};
+
+/** aggregate sum on columns */
+export type Playlist_Audios_Sum_Fields = {
+  __typename?: 'playlist_audios_sum_fields';
+  position?: Maybe<Scalars['Int']['output']>;
+};
+
+/** order by sum() on columns of table "playlist_audios" */
+export type Playlist_Audios_Sum_Order_By = {
+  position?: InputMaybe<Order_By>;
+};
+
+/** update columns of table "playlist_audios" */
+export enum Playlist_Audios_Update_Column {
+  /** column name */
+  AudioId = 'audio_id',
+  /** column name */
+  CreatedAt = 'createdAt',
+  /** column name */
+  PlaylistId = 'playlist_id',
+  /** column name */
+  Position = 'position',
+  /** column name */
+  UpdatedAt = 'updatedAt',
+}
+
+export type Playlist_Audios_Updates = {
+  /** increments the numeric columns with given value of the filtered values */
+  _inc?: InputMaybe<Playlist_Audios_Inc_Input>;
+  /** sets the columns of the filtered rows to the given values */
+  _set?: InputMaybe<Playlist_Audios_Set_Input>;
+  /** filter the rows which have to be updated */
+  where: Playlist_Audios_Bool_Exp;
+};
+
+/** aggregate var_pop on columns */
+export type Playlist_Audios_Var_Pop_Fields = {
+  __typename?: 'playlist_audios_var_pop_fields';
+  position?: Maybe<Scalars['Float']['output']>;
+};
+
+/** order by var_pop() on columns of table "playlist_audios" */
+export type Playlist_Audios_Var_Pop_Order_By = {
+  position?: InputMaybe<Order_By>;
+};
+
+/** aggregate var_samp on columns */
+export type Playlist_Audios_Var_Samp_Fields = {
+  __typename?: 'playlist_audios_var_samp_fields';
+  position?: Maybe<Scalars['Float']['output']>;
+};
+
+/** order by var_samp() on columns of table "playlist_audios" */
+export type Playlist_Audios_Var_Samp_Order_By = {
+  position?: InputMaybe<Order_By>;
+};
+
+/** aggregate variance on columns */
+export type Playlist_Audios_Variance_Fields = {
+  __typename?: 'playlist_audios_variance_fields';
+  position?: Maybe<Scalars['Float']['output']>;
+};
+
+/** order by variance() on columns of table "playlist_audios" */
+export type Playlist_Audios_Variance_Order_By = {
+  position?: InputMaybe<Order_By>;
+};
+
 /** Boolean expression to filter rows from the table "playlist". All fields are combined with a logical 'AND'. */
 export type Playlist_Bool_Exp = {
   _and?: InputMaybe<Array<Playlist_Bool_Exp>>;
@@ -5000,6 +5465,8 @@ export type Playlist_Bool_Exp = {
   createdAt?: InputMaybe<Timestamptz_Comparison_Exp>;
   description?: InputMaybe<String_Comparison_Exp>;
   id?: InputMaybe<Uuid_Comparison_Exp>;
+  playlist_audios?: InputMaybe<Playlist_Audios_Bool_Exp>;
+  playlist_audios_aggregate?: InputMaybe<Playlist_Audios_Aggregate_Bool_Exp>;
   playlist_videos?: InputMaybe<Playlist_Videos_Bool_Exp>;
   playlist_videos_aggregate?: InputMaybe<Playlist_Videos_Aggregate_Bool_Exp>;
   public?: InputMaybe<Boolean_Comparison_Exp>;
@@ -5008,6 +5475,7 @@ export type Playlist_Bool_Exp = {
   sharedRecipientsInput?: InputMaybe<Jsonb_Comparison_Exp>;
   shared_playlist_recipients?: InputMaybe<Shared_Playlist_Recipients_Bool_Exp>;
   shared_playlist_recipients_aggregate?: InputMaybe<Shared_Playlist_Recipients_Aggregate_Bool_Exp>;
+  site?: InputMaybe<String_Comparison_Exp>;
   slug?: InputMaybe<String_Comparison_Exp>;
   thumbnailUrl?: InputMaybe<String_Comparison_Exp>;
   title?: InputMaybe<String_Comparison_Exp>;
@@ -5055,6 +5523,7 @@ export type Playlist_Insert_Input = {
   createdAt?: InputMaybe<Scalars['timestamptz']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
   id?: InputMaybe<Scalars['uuid']['input']>;
+  playlist_audios?: InputMaybe<Playlist_Audios_Arr_Rel_Insert_Input>;
   playlist_videos?: InputMaybe<Playlist_Videos_Arr_Rel_Insert_Input>;
   public?: InputMaybe<Scalars['Boolean']['input']>;
   /** Short id like Youtube video id */
@@ -5064,6 +5533,7 @@ export type Playlist_Insert_Input = {
   /** List of recipient emails from user input, not validated yet. End user can update this. */
   sharedRecipientsInput?: InputMaybe<Scalars['jsonb']['input']>;
   shared_playlist_recipients?: InputMaybe<Shared_Playlist_Recipients_Arr_Rel_Insert_Input>;
+  site?: InputMaybe<Scalars['String']['input']>;
   slug?: InputMaybe<Scalars['String']['input']>;
   thumbnailUrl?: InputMaybe<Scalars['String']['input']>;
   title?: InputMaybe<Scalars['String']['input']>;
@@ -5080,6 +5550,7 @@ export type Playlist_Max_Fields = {
   id?: Maybe<Scalars['uuid']['output']>;
   /** Short id like Youtube video id */
   sId?: Maybe<Scalars['String']['output']>;
+  site?: Maybe<Scalars['String']['output']>;
   slug?: Maybe<Scalars['String']['output']>;
   thumbnailUrl?: Maybe<Scalars['String']['output']>;
   title?: Maybe<Scalars['String']['output']>;
@@ -5094,6 +5565,7 @@ export type Playlist_Max_Order_By = {
   id?: InputMaybe<Order_By>;
   /** Short id like Youtube video id */
   sId?: InputMaybe<Order_By>;
+  site?: InputMaybe<Order_By>;
   slug?: InputMaybe<Order_By>;
   thumbnailUrl?: InputMaybe<Order_By>;
   title?: InputMaybe<Order_By>;
@@ -5109,6 +5581,7 @@ export type Playlist_Min_Fields = {
   id?: Maybe<Scalars['uuid']['output']>;
   /** Short id like Youtube video id */
   sId?: Maybe<Scalars['String']['output']>;
+  site?: Maybe<Scalars['String']['output']>;
   slug?: Maybe<Scalars['String']['output']>;
   thumbnailUrl?: Maybe<Scalars['String']['output']>;
   title?: Maybe<Scalars['String']['output']>;
@@ -5123,6 +5596,7 @@ export type Playlist_Min_Order_By = {
   id?: InputMaybe<Order_By>;
   /** Short id like Youtube video id */
   sId?: InputMaybe<Order_By>;
+  site?: InputMaybe<Order_By>;
   slug?: InputMaybe<Order_By>;
   thumbnailUrl?: InputMaybe<Order_By>;
   title?: InputMaybe<Order_By>;
@@ -5158,12 +5632,14 @@ export type Playlist_Order_By = {
   createdAt?: InputMaybe<Order_By>;
   description?: InputMaybe<Order_By>;
   id?: InputMaybe<Order_By>;
+  playlist_audios_aggregate?: InputMaybe<Playlist_Audios_Aggregate_Order_By>;
   playlist_videos_aggregate?: InputMaybe<Playlist_Videos_Aggregate_Order_By>;
   public?: InputMaybe<Order_By>;
   sId?: InputMaybe<Order_By>;
   sharedRecipients?: InputMaybe<Order_By>;
   sharedRecipientsInput?: InputMaybe<Order_By>;
   shared_playlist_recipients_aggregate?: InputMaybe<Shared_Playlist_Recipients_Aggregate_Order_By>;
+  site?: InputMaybe<Order_By>;
   slug?: InputMaybe<Order_By>;
   thumbnailUrl?: InputMaybe<Order_By>;
   title?: InputMaybe<Order_By>;
@@ -5202,6 +5678,8 @@ export enum Playlist_Select_Column {
   /** column name */
   SharedRecipientsInput = 'sharedRecipientsInput',
   /** column name */
+  Site = 'site',
+  /** column name */
   Slug = 'slug',
   /** column name */
   ThumbnailUrl = 'thumbnailUrl',
@@ -5237,6 +5715,7 @@ export type Playlist_Set_Input = {
   sharedRecipients?: InputMaybe<Scalars['jsonb']['input']>;
   /** List of recipient emails from user input, not validated yet. End user can update this. */
   sharedRecipientsInput?: InputMaybe<Scalars['jsonb']['input']>;
+  site?: InputMaybe<Scalars['String']['input']>;
   slug?: InputMaybe<Scalars['String']['input']>;
   thumbnailUrl?: InputMaybe<Scalars['String']['input']>;
   title?: InputMaybe<Scalars['String']['input']>;
@@ -5264,6 +5743,7 @@ export type Playlist_Stream_Cursor_Value_Input = {
   sharedRecipients?: InputMaybe<Scalars['jsonb']['input']>;
   /** List of recipient emails from user input, not validated yet. End user can update this. */
   sharedRecipientsInput?: InputMaybe<Scalars['jsonb']['input']>;
+  site?: InputMaybe<Scalars['String']['input']>;
   slug?: InputMaybe<Scalars['String']['input']>;
   thumbnailUrl?: InputMaybe<Scalars['String']['input']>;
   title?: InputMaybe<Scalars['String']['input']>;
@@ -5287,6 +5767,8 @@ export enum Playlist_Update_Column {
   SharedRecipients = 'sharedRecipients',
   /** column name */
   SharedRecipientsInput = 'sharedRecipientsInput',
+  /** column name */
+  Site = 'site',
   /** column name */
   Slug = 'slug',
   /** column name */
@@ -5659,7 +6141,7 @@ export type Posts = {
   brief: Scalars['String']['output'];
   created_at: Scalars['timestamptz']['output'];
   /** Hashnode public id */
-  hId?: Maybe<Scalars['String']['output']>;
+  hId: Scalars['String']['output'];
   id: Scalars['uuid']['output'];
   markdownContent: Scalars['String']['output'];
   pinned: Scalars['Boolean']['output'];
@@ -6052,6 +6534,12 @@ export type Query_Root = {
   playlist: Array<Playlist>;
   /** fetch aggregated fields from the table: "playlist" */
   playlist_aggregate: Playlist_Aggregate;
+  /** An array relationship */
+  playlist_audios: Array<Playlist_Audios>;
+  /** An aggregate relationship */
+  playlist_audios_aggregate: Playlist_Audios_Aggregate;
+  /** fetch data from the table: "playlist_audios" using primary key columns */
+  playlist_audios_by_pk?: Maybe<Playlist_Audios>;
   /** fetch data from the table: "playlist" using primary key columns */
   playlist_by_pk?: Maybe<Playlist>;
   /** An array relationship */
@@ -6355,6 +6843,27 @@ export type Query_RootPlaylist_AggregateArgs = {
   offset?: InputMaybe<Scalars['Int']['input']>;
   order_by?: InputMaybe<Array<Playlist_Order_By>>;
   where?: InputMaybe<Playlist_Bool_Exp>;
+};
+
+export type Query_RootPlaylist_AudiosArgs = {
+  distinct_on?: InputMaybe<Array<Playlist_Audios_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Playlist_Audios_Order_By>>;
+  where?: InputMaybe<Playlist_Audios_Bool_Exp>;
+};
+
+export type Query_RootPlaylist_Audios_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Playlist_Audios_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Playlist_Audios_Order_By>>;
+  where?: InputMaybe<Playlist_Audios_Bool_Exp>;
+};
+
+export type Query_RootPlaylist_Audios_By_PkArgs = {
+  audio_id: Scalars['uuid']['input'];
+  playlist_id: Scalars['uuid']['input'];
 };
 
 export type Query_RootPlaylist_By_PkArgs = {
@@ -7092,23 +7601,6 @@ export type Reading_Progresses_Variance_Order_By = {
   totalPages?: InputMaybe<Order_By>;
 };
 
-export type SetVideoThumbnailAtTimeInput = {
-  atSeconds: Scalars['Float']['input'];
-  videoId: Scalars['String']['input'];
-};
-
-export type SetVideoThumbnailAtTimeOutput = {
-  __typename?: 'SetVideoThumbnailAtTimeOutput';
-  thumbnailUrl: Scalars['String']['output'];
-};
-
-export type SetVideoThumbnailAtTimeResponse = {
-  __typename?: 'SetVideoThumbnailAtTimeResponse';
-  dataObject?: Maybe<SetVideoThumbnailAtTimeOutput>;
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
-};
-
 /** This table tell us what playlist is shared to whom. All videos in the playlist should be shared, not selective */
 export type Shared_Playlist_Recipients = {
   __typename?: 'shared_playlist_recipients';
@@ -7344,8 +7836,8 @@ export type Shared_Video_Recipients = {
   recipientId?: Maybe<Scalars['uuid']['output']>;
   updatedAt: Scalars['timestamptz']['output'];
   /** An object relationship */
-  video?: Maybe<Videos>;
-  videoId?: Maybe<Scalars['uuid']['output']>;
+  video: Videos;
+  videoId: Scalars['uuid']['output'];
   viewed: Scalars['Boolean']['output'];
 };
 
@@ -7689,6 +8181,14 @@ export type Subscription_Root = {
   playlist: Array<Playlist>;
   /** fetch aggregated fields from the table: "playlist" */
   playlist_aggregate: Playlist_Aggregate;
+  /** An array relationship */
+  playlist_audios: Array<Playlist_Audios>;
+  /** An aggregate relationship */
+  playlist_audios_aggregate: Playlist_Audios_Aggregate;
+  /** fetch data from the table: "playlist_audios" using primary key columns */
+  playlist_audios_by_pk?: Maybe<Playlist_Audios>;
+  /** fetch data from the table in a streaming manner: "playlist_audios" */
+  playlist_audios_stream: Array<Playlist_Audios>;
   /** fetch data from the table: "playlist" using primary key columns */
   playlist_by_pk?: Maybe<Playlist>;
   /** fetch data from the table in a streaming manner: "playlist" */
@@ -8082,6 +8582,33 @@ export type Subscription_RootPlaylist_AggregateArgs = {
   offset?: InputMaybe<Scalars['Int']['input']>;
   order_by?: InputMaybe<Array<Playlist_Order_By>>;
   where?: InputMaybe<Playlist_Bool_Exp>;
+};
+
+export type Subscription_RootPlaylist_AudiosArgs = {
+  distinct_on?: InputMaybe<Array<Playlist_Audios_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Playlist_Audios_Order_By>>;
+  where?: InputMaybe<Playlist_Audios_Bool_Exp>;
+};
+
+export type Subscription_RootPlaylist_Audios_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Playlist_Audios_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Playlist_Audios_Order_By>>;
+  where?: InputMaybe<Playlist_Audios_Bool_Exp>;
+};
+
+export type Subscription_RootPlaylist_Audios_By_PkArgs = {
+  audio_id: Scalars['uuid']['input'];
+  playlist_id: Scalars['uuid']['input'];
+};
+
+export type Subscription_RootPlaylist_Audios_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Playlist_Audios_Stream_Cursor_Input>>;
+  where?: InputMaybe<Playlist_Audios_Bool_Exp>;
 };
 
 export type Subscription_RootPlaylist_By_PkArgs = {
@@ -12285,6 +12812,68 @@ export type GetPublicAudiosAndFeelingsQuery = {
   tags: Array<{ __typename?: 'tags'; id: any; name: string }>;
 };
 
+export type AudioFieldsFragment = {
+  __typename?: 'audios';
+  id: any;
+  name: string;
+  source: string;
+  thumbnailUrl?: string | null;
+  artistName: string;
+  createdAt: any;
+} & { ' $fragmentName'?: 'AudioFieldsFragment' };
+
+export type PlaylistAudioFieldsFragment = {
+  __typename?: 'playlist_audios';
+  position: number;
+  audio: { __typename?: 'audios' } & {
+    ' $fragmentRefs'?: { AudioFieldsFragment: AudioFieldsFragment };
+  };
+} & { ' $fragmentName'?: 'PlaylistAudioFieldsFragment' };
+
+export type ListenPlaylistFieldsFragment = {
+  __typename?: 'playlist';
+  id: any;
+  title: string;
+  thumbnailUrl?: string | null;
+  slug: string;
+  createdAt: any;
+  description?: string | null;
+  playlist_audios: Array<
+    { __typename?: 'playlist_audios' } & {
+      ' $fragmentRefs'?: {
+        PlaylistAudioFieldsFragment: PlaylistAudioFieldsFragment;
+      };
+    }
+  >;
+} & { ' $fragmentName'?: 'ListenPlaylistFieldsFragment' };
+
+export type ListenPlaylistDetailQueryVariables = Exact<{
+  id: Scalars['uuid']['input'];
+}>;
+
+export type ListenPlaylistDetailQuery = {
+  __typename?: 'query_root';
+  playlist_by_pk?:
+    | ({ __typename?: 'playlist' } & {
+        ' $fragmentRefs'?: {
+          ListenPlaylistFieldsFragment: ListenPlaylistFieldsFragment;
+        };
+      })
+    | null;
+};
+
+export type ListenPlaylistsQueryVariables = Exact<{ [key: string]: never }>;
+
+export type ListenPlaylistsQuery = {
+  __typename?: 'query_root';
+  playlist: Array<{
+    __typename?: 'playlist';
+    id: any;
+    title: string;
+    slug: string;
+  }>;
+};
+
 export type InsertPostMutationVariables = Exact<{
   object: Posts_Insert_Input;
 }>;
@@ -12443,43 +13032,6 @@ export type InsertVideosMutation = {
   } | null;
 };
 
-export type SaveSubtitleMutationVariables = Exact<{
-  id: Scalars['uuid']['input'];
-  object: Subtitles_Set_Input;
-}>;
-
-export type SaveSubtitleMutation = {
-  __typename?: 'mutation_root';
-  update_subtitles_by_pk?: { __typename?: 'subtitles'; id: any } | null;
-};
-
-export type SharePlaylistMutationVariables = Exact<{
-  id: Scalars['uuid']['input'];
-  emails?: InputMaybe<Scalars['jsonb']['input']>;
-}>;
-
-export type SharePlaylistMutation = {
-  __typename?: 'mutation_root';
-  update_playlist_by_pk?: { __typename?: 'playlist'; id: any } | null;
-};
-
-export type SetVideoThumbnailAtTimeMutationVariables = Exact<{
-  input: SetVideoThumbnailAtTimeInput;
-}>;
-
-export type SetVideoThumbnailAtTimeMutation = {
-  __typename?: 'mutation_root';
-  setVideoThumbnailAtTime: {
-    __typename?: 'SetVideoThumbnailAtTimeResponse';
-    success: boolean;
-    message: string;
-    dataObject?: {
-      __typename?: 'SetVideoThumbnailAtTimeOutput';
-      thumbnailUrl: string;
-    } | null;
-  };
-};
-
 export type CreateSignedUploadUrlMutationVariables = Exact<{
   input: SignedUploadUrlInput;
 }>;
@@ -12500,6 +13052,53 @@ export type CreateSignedUploadUrlMutation = {
   };
 };
 
+export type SaveSubtitleMutationVariables = Exact<{
+  id: Scalars['uuid']['input'];
+  object: Subtitles_Set_Input;
+}>;
+
+export type SaveSubtitleMutation = {
+  __typename?: 'mutation_root';
+  update_subtitles_by_pk?: { __typename?: 'subtitles'; id: any } | null;
+};
+
+export type SetVideoThumbnailAtTimeMutationVariables = Exact<{
+  input: SetVideoThumbnailAtTimeInput;
+}>;
+
+export type SetVideoThumbnailAtTimeMutation = {
+  __typename?: 'mutation_root';
+  setVideoThumbnailAtTime: {
+    __typename?: 'SetVideoThumbnailAtTimeResponse';
+    success: boolean;
+    message: string;
+    dataObject?: {
+      __typename?: 'SetVideoThumbnailAtTimeOutput';
+      thumbnailUrl: string;
+    } | null;
+  };
+};
+
+export type SharePlaylistMutationVariables = Exact<{
+  id: Scalars['uuid']['input'];
+  emails?: InputMaybe<Scalars['jsonb']['input']>;
+}>;
+
+export type SharePlaylistMutation = {
+  __typename?: 'mutation_root';
+  update_playlist_by_pk?: { __typename?: 'playlist'; id: any } | null;
+};
+
+export type ShareVideoMutationVariables = Exact<{
+  id: Scalars['uuid']['input'];
+  emails?: InputMaybe<Scalars['jsonb']['input']>;
+}>;
+
+export type ShareVideoMutation = {
+  __typename?: 'mutation_root';
+  update_videos_by_pk?: { __typename?: 'videos'; id: any } | null;
+};
+
 export type UpdateVideoThumbnailMutationVariables = Exact<{
   id: Scalars['uuid']['input'];
   thumbnailUrl: Scalars['String']['input'];
@@ -12512,16 +13111,6 @@ export type UpdateVideoThumbnailMutation = {
     id: any;
     thumbnailUrl?: string | null;
   } | null;
-};
-
-export type ShareVideoMutationVariables = Exact<{
-  id: Scalars['uuid']['input'];
-  emails?: InputMaybe<Scalars['jsonb']['input']>;
-}>;
-
-export type ShareVideoMutation = {
-  __typename?: 'mutation_root';
-  update_videos_by_pk?: { __typename?: 'videos'; id: any } | null;
 };
 
 export type UpdateVideoProgressMutationVariables = Exact<{
@@ -12745,6 +13334,66 @@ export class TypedDocumentString<TResult, TVariables>
     return this.value;
   }
 }
+export const AudioFieldsFragmentDoc = new TypedDocumentString(
+  `
+    fragment AudioFields on audios {
+  id
+  name
+  source
+  thumbnailUrl
+  artistName
+  createdAt
+}
+    `,
+  { fragmentName: 'AudioFields' },
+) as unknown as TypedDocumentString<AudioFieldsFragment, unknown>;
+export const PlaylistAudioFieldsFragmentDoc = new TypedDocumentString(
+  `
+    fragment PlaylistAudioFields on playlist_audios {
+  position
+  audio {
+    ...AudioFields
+  }
+}
+    fragment AudioFields on audios {
+  id
+  name
+  source
+  thumbnailUrl
+  artistName
+  createdAt
+}`,
+  { fragmentName: 'PlaylistAudioFields' },
+) as unknown as TypedDocumentString<PlaylistAudioFieldsFragment, unknown>;
+export const ListenPlaylistFieldsFragmentDoc = new TypedDocumentString(
+  `
+    fragment ListenPlaylistFields on playlist {
+  id
+  title
+  thumbnailUrl
+  slug
+  createdAt
+  description
+  playlist_audios(order_by: {position: asc}) {
+    ...PlaylistAudioFields
+  }
+}
+    fragment AudioFields on audios {
+  id
+  name
+  source
+  thumbnailUrl
+  artistName
+  createdAt
+}
+fragment PlaylistAudioFields on playlist_audios {
+  position
+  audio {
+    ...AudioFields
+  }
+}`,
+  { fragmentName: 'ListenPlaylistFields' },
+) as unknown as TypedDocumentString<ListenPlaylistFieldsFragment, unknown>;
 export const UserFieldsFragmentDoc = new TypedDocumentString(
   `
     fragment UserFields on users {
@@ -13266,6 +13915,52 @@ export const GetPublicAudiosAndFeelingsDocument = new TypedDocumentString(`
   GetPublicAudiosAndFeelingsQuery,
   GetPublicAudiosAndFeelingsQueryVariables
 >;
+export const ListenPlaylistDetailDocument = new TypedDocumentString(`
+    query ListenPlaylistDetail($id: uuid!) {
+  playlist_by_pk(id: $id) {
+    ...ListenPlaylistFields
+  }
+}
+    fragment AudioFields on audios {
+  id
+  name
+  source
+  thumbnailUrl
+  artistName
+  createdAt
+}
+fragment PlaylistAudioFields on playlist_audios {
+  position
+  audio {
+    ...AudioFields
+  }
+}
+fragment ListenPlaylistFields on playlist {
+  id
+  title
+  thumbnailUrl
+  slug
+  createdAt
+  description
+  playlist_audios(order_by: {position: asc}) {
+    ...PlaylistAudioFields
+  }
+}`) as unknown as TypedDocumentString<
+  ListenPlaylistDetailQuery,
+  ListenPlaylistDetailQueryVariables
+>;
+export const ListenPlaylistsDocument = new TypedDocumentString(`
+    query ListenPlaylists {
+  playlist(where: {site: {_eq: "listen"}}, order_by: {createdAt: desc}) {
+    id
+    title
+    slug
+  }
+}
+    `) as unknown as TypedDocumentString<
+  ListenPlaylistsQuery,
+  ListenPlaylistsQueryVariables
+>;
 export const InsertPostDocument = new TypedDocumentString(`
     mutation InsertPost($object: posts_insert_input!) {
   insert_posts_one(object: $object) {
@@ -13410,6 +14105,23 @@ export const InsertVideosDocument = new TypedDocumentString(`
   InsertVideosMutation,
   InsertVideosMutationVariables
 >;
+export const CreateSignedUploadUrlDocument = new TypedDocumentString(`
+    mutation CreateSignedUploadUrl($input: SignedUploadUrlInput!) {
+  createSignedUploadUrl(input: $input) {
+    success
+    message
+    dataObject {
+      uploadUrl
+      publicUrl
+      objectPath
+      expiresAt
+    }
+  }
+}
+    `) as unknown as TypedDocumentString<
+  CreateSignedUploadUrlMutation,
+  CreateSignedUploadUrlMutationVariables
+>;
 export const SaveSubtitleDocument = new TypedDocumentString(`
     mutation SaveSubtitle($id: uuid!, $object: subtitles_set_input!) {
   update_subtitles_by_pk(pk_columns: {id: $id}, _set: $object) {
@@ -13433,34 +14145,6 @@ export const SetVideoThumbnailAtTimeDocument = new TypedDocumentString(`
     `) as unknown as TypedDocumentString<
   SetVideoThumbnailAtTimeMutation,
   SetVideoThumbnailAtTimeMutationVariables
->;
-export const CreateSignedUploadUrlDocument = new TypedDocumentString(`
-    mutation CreateSignedUploadUrl($input: SignedUploadUrlInput!) {
-  createSignedUploadUrl(input: $input) {
-    success
-    message
-    dataObject {
-      uploadUrl
-      publicUrl
-      objectPath
-      expiresAt
-    }
-  }
-}
-    `) as unknown as TypedDocumentString<
-  CreateSignedUploadUrlMutation,
-  CreateSignedUploadUrlMutationVariables
->;
-export const UpdateVideoThumbnailDocument = new TypedDocumentString(`
-    mutation UpdateVideoThumbnail($id: uuid!, $thumbnailUrl: String!) {
-  update_videos_by_pk(pk_columns: {id: $id}, _set: {thumbnailUrl: $thumbnailUrl}) {
-    id
-    thumbnailUrl
-  }
-}
-    `) as unknown as TypedDocumentString<
-  UpdateVideoThumbnailMutation,
-  UpdateVideoThumbnailMutationVariables
 >;
 export const SharePlaylistDocument = new TypedDocumentString(`
     mutation sharePlaylist($id: uuid!, $emails: jsonb) {
@@ -13487,6 +14171,17 @@ export const ShareVideoDocument = new TypedDocumentString(`
     `) as unknown as TypedDocumentString<
   ShareVideoMutation,
   ShareVideoMutationVariables
+>;
+export const UpdateVideoThumbnailDocument = new TypedDocumentString(`
+    mutation UpdateVideoThumbnail($id: uuid!, $thumbnailUrl: String!) {
+  update_videos_by_pk(pk_columns: {id: $id}, _set: {thumbnailUrl: $thumbnailUrl}) {
+    id
+    thumbnailUrl
+  }
+}
+    `) as unknown as TypedDocumentString<
+  UpdateVideoThumbnailMutation,
+  UpdateVideoThumbnailMutationVariables
 >;
 export const UpdateVideoProgressDocument = new TypedDocumentString(`
     mutation UpdateVideoProgress($videoId: uuid!, $progressSeconds: Int!, $lastWatchedAt: timestamptz!) {

--- a/packages/core/src/listen/index.ts
+++ b/packages/core/src/listen/index.ts
@@ -1,1 +1,1 @@
-export * as queryHooks from './query-hooks/audios';
+export * as queryHooks from './query-hooks';

--- a/packages/core/src/listen/query-hooks/fragments.ts
+++ b/packages/core/src/listen/query-hooks/fragments.ts
@@ -1,0 +1,37 @@
+import { graphql } from '../../graphql';
+
+const AudioFragment = graphql(/* GraphQL */ `
+  fragment AudioFields on audios {
+    id
+    name
+    source
+    thumbnailUrl
+    artistName
+    createdAt
+  }
+`);
+
+const PlaylistAudioFragment = graphql(/* GraphQL */ `
+  fragment PlaylistAudioFields on playlist_audios {
+    position
+    audio {
+      ...AudioFields
+    }
+  }
+`);
+
+const PlaylistFragment = graphql(/* GraphQL */ `
+  fragment ListenPlaylistFields on playlist {
+    id
+    title
+    thumbnailUrl
+    slug
+    createdAt
+    description
+    playlist_audios(order_by: { position: asc }) {
+      ...PlaylistAudioFields
+    }
+  }
+`);
+
+export { AudioFragment, PlaylistAudioFragment, PlaylistFragment };

--- a/packages/core/src/listen/query-hooks/index.ts
+++ b/packages/core/src/listen/query-hooks/index.ts
@@ -1,0 +1,3 @@
+export * from './audios';
+export * from './playlist-detail';
+export * from './playlists';

--- a/packages/core/src/listen/query-hooks/playlist-detail.test.ts
+++ b/packages/core/src/listen/query-hooks/playlist-detail.test.ts
@@ -1,0 +1,175 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useRequest } from '../../universal/hooks/use-request';
+import { useLoadPlaylistDetail } from './playlist-detail';
+
+vi.mock('../../universal/hooks/use-request', () => ({
+  useRequest: vi.fn(),
+}));
+
+describe('useLoadPlaylistDetail', () => {
+  const mockGetAccessToken = vi.fn().mockResolvedValue('mock-token');
+
+  // Intentionally out of order to assert the transform sorts by position.
+  const mockPlaylistData = {
+    id: 'playlist-123',
+    title: 'Chill',
+    thumbnailUrl: '',
+    slug: 'chill',
+    createdAt: '2024-01-01T00:00:00Z',
+    description: '',
+    playlist_audios: [
+      {
+        position: 2,
+        audio: {
+          id: 'audio-2',
+          name: 'Second',
+          source: 'https://example.com/2.mp3',
+          thumbnailUrl: '',
+          artistName: 'Artist 2',
+          createdAt: '2024-02-01T00:00:00Z',
+        },
+      },
+      {
+        position: 1,
+        audio: {
+          id: 'audio-1',
+          name: 'First',
+          source: 'https://example.com/1.mp3',
+          thumbnailUrl: 'thumb1.jpg',
+          artistName: 'Artist 1',
+          createdAt: '2024-01-15T00:00:00Z',
+        },
+      },
+    ],
+  };
+
+  const expectedAudios = [
+    {
+      id: 'audio-1',
+      name: 'First',
+      source: 'https://example.com/1.mp3',
+      thumbnailUrl: 'thumb1.jpg',
+      artistName: 'Artist 1',
+      createdAt: '2024-01-15T00:00:00Z',
+    },
+    {
+      id: 'audio-2',
+      name: 'Second',
+      source: 'https://example.com/2.mp3',
+      thumbnailUrl: '',
+      artistName: 'Artist 2',
+      createdAt: '2024-02-01T00:00:00Z',
+    },
+  ];
+
+  beforeEach(() => {
+    vi.mocked(useRequest).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    } as ReturnType<typeof useRequest>);
+  });
+
+  it('should set up useRequest with correct params', () => {
+    renderHook(() =>
+      useLoadPlaylistDetail({
+        id: 'playlist-123',
+        getAccessToken: mockGetAccessToken,
+      }),
+    );
+
+    expect(useRequest).toHaveBeenCalledWith({
+      queryKey: ['listen-playlist-detail', 'playlist-123'],
+      getAccessToken: mockGetAccessToken,
+      document: expect.anything(),
+      variables: { id: 'playlist-123' },
+    });
+  });
+
+  it('should return loading state from useRequest', () => {
+    vi.mocked(useRequest).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as ReturnType<typeof useRequest>);
+
+    const { result } = renderHook(() =>
+      useLoadPlaylistDetail({
+        id: 'playlist-123',
+        getAccessToken: mockGetAccessToken,
+      }),
+    );
+
+    expect(result.current).toEqual({
+      audios: [],
+      playlist: null,
+      isLoading: true,
+      error: undefined,
+    });
+  });
+
+  it('should return audios ordered by position when loaded', () => {
+    vi.mocked(useRequest).mockReturnValue({
+      data: { playlist_by_pk: mockPlaylistData },
+      isLoading: false,
+    } as ReturnType<typeof useRequest>);
+
+    const { result } = renderHook(() =>
+      useLoadPlaylistDetail({
+        id: 'playlist-123',
+        getAccessToken: mockGetAccessToken,
+      }),
+    );
+
+    expect(result.current).toEqual({
+      audios: expectedAudios,
+      playlist: mockPlaylistData,
+      isLoading: false,
+      error: undefined,
+    });
+  });
+
+  it('should return an empty audios list for an empty playlist', () => {
+    const emptyPlaylist = { ...mockPlaylistData, playlist_audios: [] };
+    vi.mocked(useRequest).mockReturnValue({
+      data: { playlist_by_pk: emptyPlaylist },
+      isLoading: false,
+    } as ReturnType<typeof useRequest>);
+
+    const { result } = renderHook(() =>
+      useLoadPlaylistDetail({
+        id: 'playlist-123',
+        getAccessToken: mockGetAccessToken,
+      }),
+    );
+
+    expect(result.current).toEqual({
+      audios: [],
+      playlist: emptyPlaylist,
+      isLoading: false,
+      error: undefined,
+    });
+  });
+
+  it('should handle error from useRequest', () => {
+    const mockError = new Error('API Error');
+    vi.mocked(useRequest).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: mockError,
+    } as ReturnType<typeof useRequest>);
+
+    const { result } = renderHook(() =>
+      useLoadPlaylistDetail({
+        id: 'playlist-123',
+        getAccessToken: mockGetAccessToken,
+      }),
+    );
+
+    expect(result.current).toEqual({
+      audios: [],
+      playlist: null,
+      isLoading: false,
+      error: mockError,
+    });
+  });
+});

--- a/packages/core/src/listen/query-hooks/playlist-detail.ts
+++ b/packages/core/src/listen/query-hooks/playlist-detail.ts
@@ -1,0 +1,63 @@
+import { getFragmentData, graphql } from '../../graphql';
+import type { ListenPlaylistDetailQuery } from '../../graphql/graphql';
+import { useRequest } from '../../universal/hooks/use-request';
+import { PlaylistAudioFragment, PlaylistFragment } from './fragments';
+import { transformAudioFragment } from './transformers';
+
+const playlistDetailQuery = graphql(/* GraphQL */ `
+  query ListenPlaylistDetail($id: uuid!) {
+    playlist_by_pk(id: $id) {
+      ...ListenPlaylistFields
+    }
+  }
+`);
+
+interface LoadPlaylistDetailProps {
+  id: string;
+  getAccessToken: () => Promise<string>;
+}
+
+const transform = (data: ListenPlaylistDetailQuery) => {
+  const playlist = getFragmentData(PlaylistFragment, data.playlist_by_pk);
+  const audios =
+    getFragmentData(PlaylistAudioFragment, playlist?.playlist_audios)
+      ?.slice()
+      .sort((a, b) => a.position - b.position)
+      .map(({ audio }) => transformAudioFragment(audio)) || [];
+
+  return {
+    audios,
+    playlist,
+  };
+};
+
+const useLoadPlaylistDetail = (props: LoadPlaylistDetailProps) => {
+  const { id, getAccessToken } = props;
+
+  const { data, isLoading, error } = useRequest<
+    ListenPlaylistDetailQuery,
+    { id: string }
+  >({
+    queryKey: ['listen-playlist-detail', id],
+    getAccessToken,
+    document: playlistDetailQuery,
+    variables: {
+      id,
+    },
+  });
+
+  const transformed = data
+    ? transform(data)
+    : {
+        audios: [],
+        playlist: null,
+      };
+
+  return {
+    ...transformed,
+    isLoading,
+    error,
+  };
+};
+
+export { useLoadPlaylistDetail };

--- a/packages/core/src/listen/query-hooks/playlists.test.ts
+++ b/packages/core/src/listen/query-hooks/playlists.test.ts
@@ -1,0 +1,104 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useRequest } from '../../universal/hooks/use-request';
+import { useLoadPlaylists } from './playlists';
+
+vi.mock('../../universal/hooks/use-request', () => ({
+  useRequest: vi.fn(),
+}));
+
+describe('useLoadPlaylists', () => {
+  const mockGetAccessToken = vi.fn().mockResolvedValue('mock-token');
+
+  const mockPlaylists = [
+    { id: '1', title: 'Chill', slug: 'chill' },
+    { id: '2', title: 'Focus', slug: 'focus' },
+  ];
+
+  beforeEach(() => {
+    vi.mocked(useRequest).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    } as ReturnType<typeof useRequest>);
+  });
+
+  it('should set up useRequest with the listen-playlists key', () => {
+    renderHook(() => useLoadPlaylists({ getAccessToken: mockGetAccessToken }));
+
+    expect(useRequest).toHaveBeenCalledWith({
+      queryKey: ['listen-playlists'],
+      getAccessToken: mockGetAccessToken,
+      document: expect.anything(),
+    });
+  });
+
+  it('should return loading state from useRequest', () => {
+    vi.mocked(useRequest).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as ReturnType<typeof useRequest>);
+
+    const { result } = renderHook(() =>
+      useLoadPlaylists({ getAccessToken: mockGetAccessToken }),
+    );
+
+    expect(result.current).toEqual({
+      playlists: [],
+      isLoading: true,
+      error: undefined,
+    });
+  });
+
+  it('should return data when loaded', () => {
+    vi.mocked(useRequest).mockReturnValue({
+      data: { playlist: mockPlaylists },
+      isLoading: false,
+    } as ReturnType<typeof useRequest>);
+
+    const { result } = renderHook(() =>
+      useLoadPlaylists({ getAccessToken: mockGetAccessToken }),
+    );
+
+    expect(result.current).toEqual({
+      playlists: mockPlaylists,
+      isLoading: false,
+      error: undefined,
+    });
+  });
+
+  it('should handle null response data', () => {
+    vi.mocked(useRequest).mockReturnValue({
+      data: null,
+      isLoading: false,
+    } as ReturnType<typeof useRequest>);
+
+    const { result } = renderHook(() =>
+      useLoadPlaylists({ getAccessToken: mockGetAccessToken }),
+    );
+
+    expect(result.current).toEqual({
+      playlists: [],
+      isLoading: false,
+      error: undefined,
+    });
+  });
+
+  it('should surface error from useRequest', () => {
+    const mockError = new Error('API Error');
+    vi.mocked(useRequest).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: mockError,
+    } as ReturnType<typeof useRequest>);
+
+    const { result } = renderHook(() =>
+      useLoadPlaylists({ getAccessToken: mockGetAccessToken }),
+    );
+
+    expect(result.current).toEqual({
+      playlists: [],
+      isLoading: false,
+      error: mockError,
+    });
+  });
+});

--- a/packages/core/src/listen/query-hooks/playlists.ts
+++ b/packages/core/src/listen/query-hooks/playlists.ts
@@ -1,0 +1,38 @@
+import { graphql } from '../../graphql';
+import type { ListenPlaylistsQuery } from '../../graphql/graphql';
+import { useRequest } from '../../universal/hooks/use-request';
+
+const playlistsQuery = graphql(/* GraphQL */ `
+  query ListenPlaylists {
+    playlist(
+      where: { site: { _eq: "listen" } }
+      order_by: { createdAt: desc }
+    ) {
+      id
+      title
+      slug
+    }
+  }
+`);
+
+interface LoadPlaylistsProps {
+  getAccessToken: () => Promise<string>;
+}
+
+const useLoadPlaylists = (props: LoadPlaylistsProps) => {
+  const { getAccessToken } = props;
+
+  const { data, isLoading, error } = useRequest<ListenPlaylistsQuery>({
+    queryKey: ['listen-playlists'],
+    getAccessToken,
+    document: playlistsQuery,
+  });
+
+  return {
+    playlists: data ? data.playlist : [],
+    isLoading,
+    error,
+  };
+};
+
+export { useLoadPlaylists };

--- a/packages/core/src/listen/query-hooks/transformers.ts
+++ b/packages/core/src/listen/query-hooks/transformers.ts
@@ -1,0 +1,19 @@
+import { type FragmentType, getFragmentData } from '../../graphql';
+import { AudioFragment } from './fragments';
+
+const transformAudioFragment = (
+  audioData: FragmentType<typeof AudioFragment>,
+) => {
+  const audio = getFragmentData(AudioFragment, audioData);
+
+  return {
+    id: audio.id,
+    name: audio.name,
+    source: audio.source,
+    thumbnailUrl: audio.thumbnailUrl || '',
+    artistName: audio.artistName,
+    createdAt: audio.createdAt,
+  };
+};
+
+export { transformAudioFragment };


### PR DESCRIPTION
## Summary

Read-side data hooks for **listen playlists** (SWO-287, Wave 1 of SWO-285), mirroring the watch playlist hooks but scoped to `site = 'listen'` and reading the new `playlist_audios` junction.

- `query-hooks/fragments.ts` — `AudioFields`, `PlaylistAudioFields`, `ListenPlaylistFields`
- `query-hooks/transformers.ts` — `transformAudioFragment`
- `query-hooks/playlists.ts` — `useLoadPlaylists` (list, `where: { site: { _eq: "listen" } }`, newest first)
- `query-hooks/playlist-detail.ts` — `useLoadPlaylistDetail` (by pk; audios ordered by `position`). **Empty playlists are valid and do not throw** (unlike watch) — per the feature design, an audio playlist has identity even when empty.
- `listen/index.ts` now exports a `query-hooks` barrel so `listenQueryHooks` gains the playlist hooks while keeping `useLoadAudios` / `useLoadPublicAudios`.

### Generated files note
Types were regenerated against **local** Hasura (which has SWO-286's migration applied). The generated diff also includes a few already-merged video-thumbnail action/operation types (`setVideoThumbnailAtTime`, `createSignedUploadUrl`, `UpdateVideoThumbnail`) — the committed generated files predated those merges, so codegen simply brought them current. No unrelated source changes.

## Test plan

- [x] `vitest run src/listen` — 18 pass (10 new + 8 existing)
- [x] `biome lint` clean on new files
- [x] Local codegen produces `ListenPlaylists*` types with no errors
- [ ] Consumed by the listen UI in SWO-289

Ref: SWO-287 · depends on SWO-286 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added playlist browsing and playlist detail loading, including playlist tracks sorted in the correct order.
  * Introduced support for updating a video thumbnail at a specific time.
  * Expanded audio/playlist relationships so playlists can now show linked audio items more reliably.

* **Bug Fixes**
  * Tightened data requirements for a few fields to prevent missing playlist and sharing details from appearing inconsistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->