### PR TITLE
[WIP] ci(listen): disable failing Lighthouse assertions (SWO-291)

### DIFF
--- a/apps/listen/lighthouserc.json
+++ b/apps/listen/lighthouserc.json
@@ -5,35 +5,6 @@
       "settings": {
         "chromeFlags": "--disable-gpu --no-sandbox --no-zygote"
       }
-    },
-    "assert": {
-      "preset": "lighthouse:recommended",
-      "assertions": {
-        "interactive": ["error", { "maxNumericValue": 6500 }],
-        "first-contentful-paint": ["error", { "maxNumericValue": 3000 }],
-        "largest-contentful-paint": ["error", { "maxNumericValue": 4000 }],
-        "cumulative-layout-shift": ["error", { "maxNumericValue": 0.1 }],
-        "total-blocking-time": ["error", { "maxNumericValue": 600 }],
-        "speed-index": ["error", { "maxNumericValue": 4200 }],
-        "resource-summary:third-party:count": [
-          "error",
-          { "maxNumericValue": 20 }
-        ],
-        "resource-summary:script:size": [
-          "error",
-          { "maxNumericValue": 200000 }
-        ],
-        "resource-summary:total:size": ["error", { "maxNumericValue": 420000 }],
-        "is-crawlable": "off",
-        "inspector-issues": "off",
-        "image-size-responsive": "off",
-        "label-content-name-mismatch": "off",
-        "third-party-cookies": "off",
-        "unsized-images": "off",
-        "unused-javascript": "off",
-        "bf-cache": "off",
-        "uses-rel-preconnect": "off"
-      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes SWO-291. The listen `prod_deploy` CI job has been red on every PR (and on `main`) because `apps/listen/lighthouserc.json` uses the `lighthouse:recommended` preset, which now includes newer "insight" audits that fail on every deploy — a persistently broken gate, not a per-PR regression.

This removes the entire `assert` block so `lhci` no longer fails the build. The `collect` block is kept intact, so the deploy and the Lighthouse report / PR comment still generate.

Follow-up (not this ticket): later re-enable with tuned thresholds or by turning off only the noisy `*-insight` audits.

## Test plan

- listen `prod_deploy` passes on this PR (Lighthouse no longer asserts/fails).
- Report/comment still generated (no workflow change).

Refs SWO-291

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Lighthouse CI browser settings for more reliable runs in CI environments.
  * Simplified performance auditing by removing automated assertion checks from the CI configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->