### PR TITLE
[WIP] feat(listen): add playlist library page

### DIFF
--- a/apps/listen/src/components/layout/index.tsx
+++ b/apps/listen/src/components/layout/index.tsx
@@ -1,0 +1,40 @@
+import { Auth } from 'core';
+import React, { useState } from 'react';
+import { Header, MainContainer, SettingsPanel } from 'ui/listen/minimalism';
+import { FullWidthContainer } from 'ui/universal';
+import { appConfig } from '../../config';
+
+interface LayoutProps {
+  children: React.ReactNode;
+}
+
+const Layout = (props: LayoutProps) => {
+  const { children } = props;
+  const { signIn, signOut, user } = Auth.useAuthContext();
+  const [settingOpen, toggleSetting] = useState<boolean>(false);
+  const { sites } = appConfig;
+
+  const onProfileClick = () => {
+    if (user) {
+      toggleSetting(true);
+    } else {
+      signIn();
+    }
+  };
+
+  return (
+    <FullWidthContainer>
+      <Header sites={sites} onProfileClick={onProfileClick} user={user} />
+      <React.Suspense fallback={<div />}>
+        <SettingsPanel
+          open={settingOpen}
+          toggle={toggleSetting}
+          actions={{ logout: signOut }}
+        />
+      </React.Suspense>
+      <MainContainer>{children}</MainContainer>
+    </FullWidthContainer>
+  );
+};
+
+export { Layout };

--- a/apps/listen/src/routeTree.gen.ts
+++ b/apps/listen/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as rootRoute } from './routes/__root';
 // Create Virtual Routes
 
 const IndexLazyImport = createFileRoute('/')();
+const PlaylistsIndexLazyImport = createFileRoute('/playlists/')();
 
 // Create/Update Routes
 
@@ -25,6 +26,14 @@ const IndexLazyRoute = IndexLazyImport.update({
   path: '/',
   getParentRoute: () => rootRoute,
 } as any).lazy(() => import('./routes/index.lazy').then((d) => d.Route));
+
+const PlaylistsIndexLazyRoute = PlaylistsIndexLazyImport.update({
+  id: '/playlists/',
+  path: '/playlists/',
+  getParentRoute: () => rootRoute,
+} as any).lazy(() =>
+  import('./routes/playlists.index.lazy').then((d) => d.Route),
+);
 
 // Populate the FileRoutesByPath interface
 
@@ -37,6 +46,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexLazyImport;
       parentRoute: typeof rootRoute;
     };
+    '/playlists/': {
+      id: '/playlists/';
+      path: '/playlists';
+      fullPath: '/playlists';
+      preLoaderRoute: typeof PlaylistsIndexLazyImport;
+      parentRoute: typeof rootRoute;
+    };
   }
 }
 
@@ -44,32 +60,37 @@ declare module '@tanstack/react-router' {
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexLazyRoute;
+  '/playlists': typeof PlaylistsIndexLazyRoute;
 }
 
 export interface FileRoutesByTo {
   '/': typeof IndexLazyRoute;
+  '/playlists': typeof PlaylistsIndexLazyRoute;
 }
 
 export interface FileRoutesById {
   __root__: typeof rootRoute;
   '/': typeof IndexLazyRoute;
+  '/playlists/': typeof PlaylistsIndexLazyRoute;
 }
 
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath;
-  fullPaths: '/';
+  fullPaths: '/' | '/playlists';
   fileRoutesByTo: FileRoutesByTo;
-  to: '/';
-  id: '__root__' | '/';
+  to: '/' | '/playlists';
+  id: '__root__' | '/' | '/playlists/';
   fileRoutesById: FileRoutesById;
 }
 
 export interface RootRouteChildren {
   IndexLazyRoute: typeof IndexLazyRoute;
+  PlaylistsIndexLazyRoute: typeof PlaylistsIndexLazyRoute;
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexLazyRoute: IndexLazyRoute,
+  PlaylistsIndexLazyRoute: PlaylistsIndexLazyRoute,
 };
 
 export const routeTree = rootRoute
@@ -82,11 +103,15 @@ export const routeTree = rootRoute
     "__root__": {
       "filePath": "__root.tsx",
       "children": [
-        "/"
+        "/",
+        "/playlists/"
       ]
     },
     "/": {
       "filePath": "index.lazy.tsx"
+    },
+    "/playlists/": {
+      "filePath": "playlists.index.lazy.tsx"
     }
   }
 }

--- a/apps/listen/src/routes/playlists.index.lazy.tsx
+++ b/apps/listen/src/routes/playlists.index.lazy.tsx
@@ -1,0 +1,42 @@
+import { createLazyFileRoute, Link } from '@tanstack/react-router';
+import { listenMutationHooks, listenQueryHooks } from 'core';
+import { useAuthContext } from 'core/providers/auth';
+import React from 'react';
+import { PlaylistLibrary } from 'ui/listen/minimalism';
+import { AuthRoute } from 'ui/universal/authRoute';
+import { Layout } from '../components/layout';
+
+const slugify = (value: string) =>
+  value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+const Content = () => {
+  const { getAccessToken } = useAuthContext();
+  const queryRs = listenQueryHooks.useLoadPlaylists({ getAccessToken });
+  const createPlaylist = listenMutationHooks.useCreatePlaylist();
+
+  const handleCreate = (title: string) => {
+    createPlaylist({ title, slug: slugify(title), thumbnailUrl: '' });
+  };
+
+  return (
+    <Layout>
+      <PlaylistLibrary
+        queryRs={queryRs}
+        onCreate={handleCreate}
+        LinkComponent={Link}
+      />
+    </Layout>
+  );
+};
+
+export const Route = createLazyFileRoute('/playlists/')({
+  component: () => (
+    <AuthRoute>
+      <Content />
+    </AuthRoute>
+  ),
+});

--- a/packages/ui/src/listen/minimalism/index.ts
+++ b/packages/ui/src/listen/minimalism/index.ts
@@ -4,6 +4,7 @@ import { FeelingList } from './home/feeling-list';
 import { MainContainer } from './home/main-container';
 import { SettingsPanel } from './home/settings';
 import MusicWidget from './music-widget';
+import { PlaylistLibrary } from './playlists/library';
 import MinimalismThemeProvider from './ThemeProvider';
 
 export {
@@ -14,4 +15,5 @@ export {
   FeelingList,
   AudioList,
   MainContainer,
+  PlaylistLibrary,
 };

--- a/packages/ui/src/listen/minimalism/playlists/library.test.tsx
+++ b/packages/ui/src/listen/minimalism/playlists/library.test.tsx
@@ -1,0 +1,98 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { PlaylistLibrary } from './library';
+
+const MockLink = (props: { children?: React.ReactNode }) => (
+  <a href="#">{props.children}</a>
+);
+
+const playlists = [
+  { id: 'p1', title: 'Chill', slug: 'chill' },
+  { id: 'p2', title: 'Focus', slug: 'focus' },
+];
+
+describe('PlaylistLibrary', () => {
+  it('renders skeletons while loading', () => {
+    render(
+      <PlaylistLibrary
+        queryRs={{ playlists: [], isLoading: true }}
+        onCreate={vi.fn()}
+        LinkComponent={MockLink}
+      />,
+    );
+
+    expect(screen.getByLabelText('loading playlists')).toBeInTheDocument();
+  });
+
+  it('renders an empty state when there are no playlists', () => {
+    render(
+      <PlaylistLibrary
+        queryRs={{ playlists: [], isLoading: false }}
+        onCreate={vi.fn()}
+        LinkComponent={MockLink}
+      />,
+    );
+
+    expect(screen.getByText(/no playlists yet/i)).toBeInTheDocument();
+  });
+
+  it('renders each playlist', () => {
+    render(
+      <PlaylistLibrary
+        queryRs={{ playlists, isLoading: false }}
+        onCreate={vi.fn()}
+        LinkComponent={MockLink}
+      />,
+    );
+
+    expect(screen.getByText('Chill')).toBeInTheDocument();
+    expect(screen.getByText('Focus')).toBeInTheDocument();
+  });
+
+  it('shows an error message when the query errors', () => {
+    render(
+      <PlaylistLibrary
+        queryRs={{ playlists: [], isLoading: false, error: new Error('x') }}
+        onCreate={vi.fn()}
+        LinkComponent={MockLink}
+      />,
+    );
+
+    expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+  });
+
+  it('creates a playlist with the trimmed title', () => {
+    const onCreate = vi.fn();
+    render(
+      <PlaylistLibrary
+        queryRs={{ playlists, isLoading: false }}
+        onCreate={onCreate}
+        LinkComponent={MockLink}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'New playlist' }));
+    fireEvent.change(screen.getByLabelText('Title'), {
+      target: { value: '  Bangers  ' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+    expect(onCreate).toHaveBeenCalledWith('Bangers');
+  });
+
+  it('does not create when the title is blank', () => {
+    const onCreate = vi.fn();
+    render(
+      <PlaylistLibrary
+        queryRs={{ playlists, isLoading: false }}
+        onCreate={onCreate}
+        LinkComponent={MockLink}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'New playlist' }));
+    // Create button is disabled for a blank title.
+    expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled();
+    expect(onCreate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/listen/minimalism/playlists/library.tsx
+++ b/packages/ui/src/listen/minimalism/playlists/library.tsx
@@ -1,0 +1,139 @@
+import AddIcon from '@mui/icons-material/Add';
+import QueueMusicIcon from '@mui/icons-material/QueueMusic';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import List from '@mui/material/List';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import Skeleton from '@mui/material/Skeleton';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import type { ElementType } from 'react';
+import { useState } from 'react';
+
+interface PlaylistSummary {
+  id: string;
+  title: string;
+  slug: string;
+}
+
+interface PlaylistLibraryProps {
+  queryRs: {
+    playlists: PlaylistSummary[];
+    isLoading: boolean;
+    error?: unknown;
+  };
+  onCreate: (title: string) => void;
+  isCreating?: boolean;
+  LinkComponent: ElementType;
+}
+
+const PlaylistLibrary = (props: PlaylistLibraryProps) => {
+  const { queryRs, onCreate, isCreating, LinkComponent } = props;
+  const { playlists, isLoading, error } = queryRs;
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [title, setTitle] = useState('');
+
+  const closeDialog = () => {
+    setDialogOpen(false);
+    setTitle('');
+  };
+
+  const handleCreate = () => {
+    const trimmed = title.trim();
+    if (!trimmed) return;
+    onCreate(trimmed);
+    closeDialog();
+  };
+
+  return (
+    <Box py={3}>
+      <Stack
+        direction="row"
+        justifyContent="space-between"
+        alignItems="center"
+        mb={2}
+      >
+        <Typography variant="h5" component="h1">
+          Playlists
+        </Typography>
+        <Button
+          variant="outlined"
+          startIcon={<AddIcon />}
+          onClick={() => setDialogOpen(true)}
+        >
+          New playlist
+        </Button>
+      </Stack>
+
+      {isLoading ? (
+        <Stack spacing={1} aria-label="loading playlists">
+          {Array.from({ length: 4 }).map((_, index) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton list
+            <Skeleton key={index} variant="rounded" height={56} />
+          ))}
+        </Stack>
+      ) : error ? (
+        <Typography color="error">
+          Something went wrong loading your playlists.
+        </Typography>
+      ) : playlists.length === 0 ? (
+        <Typography color="text.secondary">
+          No playlists yet. Create one to start collecting audios.
+        </Typography>
+      ) : (
+        <List aria-label="playlists">
+          {playlists.map((playlist) => (
+            <ListItemButton
+              key={playlist.id}
+              component={LinkComponent}
+              to="/playlists/$id"
+              params={{ id: playlist.id }}
+            >
+              <ListItemIcon>
+                <QueueMusicIcon />
+              </ListItemIcon>
+              <ListItemText primary={playlist.title} />
+            </ListItemButton>
+          ))}
+        </List>
+      )}
+
+      <Dialog open={dialogOpen} onClose={closeDialog} fullWidth maxWidth="xs">
+        <DialogTitle>New playlist</DialogTitle>
+        <DialogContent>
+          <TextField
+            autoFocus
+            margin="dense"
+            label="Title"
+            fullWidth
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') handleCreate();
+            }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={closeDialog}>Cancel</Button>
+          <Button
+            onClick={handleCreate}
+            variant="contained"
+            disabled={!title.trim() || isCreating}
+          >
+            Create
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+};
+
+export { PlaylistLibrary };
+export type { PlaylistSummary };


### PR DESCRIPTION
## Summary

First slice of the listen playlist UI (SWO-289), built on the new TanStack Router scaffold (SWO-290 / #318).

- **`ui/listen` `PlaylistLibrary`** — presentational component: lists the user's playlists (each links to `/playlists/$id`), with loading skeletons, empty state, error state, and a "New playlist" dialog.
- **`apps/listen` `Layout`** — shared chrome (minimalism `Header` + `SettingsPanel`) for routed pages beyond the index, mirroring the watch app's `Layout`.
- **`/playlists` route** — wires `useLoadPlaylists` + `useCreatePlaylist` into the container, gated by `AuthRoute`. `site` is stamped `'listen'` by the mutation hook; slug is derived from the title.

Scoped deliberately to the library page. **Follow-up slices under SWO-289:** playlist detail + in-order playback, and the "add audio to playlist" affordance.

## Test plan

- [x] `vitest` — 6 PlaylistLibrary tests (loading/empty/error/list/create/blank-title)
- [x] `biome` clean; `tsc` clean for the new `ui` files
- [x] Route tree regenerates with `/playlists/`
- [ ] Full app build in CI (turbo builds `core`/`ui` first)
- [ ] Manual: create a playlist, see it listed

Ref: SWO-289 · builds on SWO-286/287/288 (merged) + SWO-290 (router)

🤖 Generated with [Claude Code](https://claude.com/claude-code)