### PR TITLE
[WIP] feat(listen): add playlist detail page with in-order playback

### DIFF
--- a/apps/listen/src/routeTree.gen.ts
+++ b/apps/listen/src/routeTree.gen.ts
@@ -8,16 +8,17 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute } from '@tanstack/react-router'
 
 // Import Routes
 
-import { Route as rootRoute } from './routes/__root';
+import { Route as rootRoute } from './routes/__root'
 
 // Create Virtual Routes
 
-const IndexLazyImport = createFileRoute('/')();
-const PlaylistsIndexLazyImport = createFileRoute('/playlists/')();
+const IndexLazyImport = createFileRoute('/')()
+const PlaylistsIndexLazyImport = createFileRoute('/playlists/')()
+const PlaylistsIdLazyImport = createFileRoute('/playlists/$id')()
 
 // Create/Update Routes
 
@@ -25,7 +26,7 @@ const IndexLazyRoute = IndexLazyImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRoute,
-} as any).lazy(() => import('./routes/index.lazy').then((d) => d.Route));
+} as any).lazy(() => import('./routes/index.lazy').then((d) => d.Route))
 
 const PlaylistsIndexLazyRoute = PlaylistsIndexLazyImport.update({
   id: '/playlists/',
@@ -33,69 +34,87 @@ const PlaylistsIndexLazyRoute = PlaylistsIndexLazyImport.update({
   getParentRoute: () => rootRoute,
 } as any).lazy(() =>
   import('./routes/playlists.index.lazy').then((d) => d.Route),
-);
+)
+
+const PlaylistsIdLazyRoute = PlaylistsIdLazyImport.update({
+  id: '/playlists/$id',
+  path: '/playlists/$id',
+  getParentRoute: () => rootRoute,
+} as any).lazy(() => import('./routes/playlists.$id.lazy').then((d) => d.Route))
 
 // Populate the FileRoutesByPath interface
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
     '/': {
-      id: '/';
-      path: '/';
-      fullPath: '/';
-      preLoaderRoute: typeof IndexLazyImport;
-      parentRoute: typeof rootRoute;
-    };
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexLazyImport
+      parentRoute: typeof rootRoute
+    }
+    '/playlists/$id': {
+      id: '/playlists/$id'
+      path: '/playlists/$id'
+      fullPath: '/playlists/$id'
+      preLoaderRoute: typeof PlaylistsIdLazyImport
+      parentRoute: typeof rootRoute
+    }
     '/playlists/': {
-      id: '/playlists/';
-      path: '/playlists';
-      fullPath: '/playlists';
-      preLoaderRoute: typeof PlaylistsIndexLazyImport;
-      parentRoute: typeof rootRoute;
-    };
+      id: '/playlists/'
+      path: '/playlists'
+      fullPath: '/playlists'
+      preLoaderRoute: typeof PlaylistsIndexLazyImport
+      parentRoute: typeof rootRoute
+    }
   }
 }
 
 // Create and export the route tree
 
 export interface FileRoutesByFullPath {
-  '/': typeof IndexLazyRoute;
-  '/playlists': typeof PlaylistsIndexLazyRoute;
+  '/': typeof IndexLazyRoute
+  '/playlists/$id': typeof PlaylistsIdLazyRoute
+  '/playlists': typeof PlaylistsIndexLazyRoute
 }
 
 export interface FileRoutesByTo {
-  '/': typeof IndexLazyRoute;
-  '/playlists': typeof PlaylistsIndexLazyRoute;
+  '/': typeof IndexLazyRoute
+  '/playlists/$id': typeof PlaylistsIdLazyRoute
+  '/playlists': typeof PlaylistsIndexLazyRoute
 }
 
 export interface FileRoutesById {
-  __root__: typeof rootRoute;
-  '/': typeof IndexLazyRoute;
-  '/playlists/': typeof PlaylistsIndexLazyRoute;
+  __root__: typeof rootRoute
+  '/': typeof IndexLazyRoute
+  '/playlists/$id': typeof PlaylistsIdLazyRoute
+  '/playlists/': typeof PlaylistsIndexLazyRoute
 }
 
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath;
-  fullPaths: '/' | '/playlists';
-  fileRoutesByTo: FileRoutesByTo;
-  to: '/' | '/playlists';
-  id: '__root__' | '/' | '/playlists/';
-  fileRoutesById: FileRoutesById;
+  fileRoutesByFullPath: FileRoutesByFullPath
+  fullPaths: '/' | '/playlists/$id' | '/playlists'
+  fileRoutesByTo: FileRoutesByTo
+  to: '/' | '/playlists/$id' | '/playlists'
+  id: '__root__' | '/' | '/playlists/$id' | '/playlists/'
+  fileRoutesById: FileRoutesById
 }
 
 export interface RootRouteChildren {
-  IndexLazyRoute: typeof IndexLazyRoute;
-  PlaylistsIndexLazyRoute: typeof PlaylistsIndexLazyRoute;
+  IndexLazyRoute: typeof IndexLazyRoute
+  PlaylistsIdLazyRoute: typeof PlaylistsIdLazyRoute
+  PlaylistsIndexLazyRoute: typeof PlaylistsIndexLazyRoute
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexLazyRoute: IndexLazyRoute,
+  PlaylistsIdLazyRoute: PlaylistsIdLazyRoute,
   PlaylistsIndexLazyRoute: PlaylistsIndexLazyRoute,
-};
+}
 
 export const routeTree = rootRoute
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>();
+  ._addFileTypes<FileRouteTypes>()
 
 /* ROUTE_MANIFEST_START
 {
@@ -104,11 +123,15 @@ export const routeTree = rootRoute
       "filePath": "__root.tsx",
       "children": [
         "/",
+        "/playlists/$id",
         "/playlists/"
       ]
     },
     "/": {
       "filePath": "index.lazy.tsx"
+    },
+    "/playlists/$id": {
+      "filePath": "playlists.$id.lazy.tsx"
     },
     "/playlists/": {
       "filePath": "playlists.index.lazy.tsx"

--- a/apps/listen/src/routeTree.gen.ts
+++ b/apps/listen/src/routeTree.gen.ts
@@ -8,17 +8,17 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute } from '@tanstack/react-router';
 
 // Import Routes
 
-import { Route as rootRoute } from './routes/__root'
+import { Route as rootRoute } from './routes/__root';
 
 // Create Virtual Routes
 
-const IndexLazyImport = createFileRoute('/')()
-const PlaylistsIndexLazyImport = createFileRoute('/playlists/')()
-const PlaylistsIdLazyImport = createFileRoute('/playlists/$id')()
+const IndexLazyImport = createFileRoute('/')();
+const PlaylistsIndexLazyImport = createFileRoute('/playlists/')();
+const PlaylistsIdLazyImport = createFileRoute('/playlists/$id')();
 
 // Create/Update Routes
 
@@ -26,7 +26,7 @@ const IndexLazyRoute = IndexLazyImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRoute,
-} as any).lazy(() => import('./routes/index.lazy').then((d) => d.Route))
+} as any).lazy(() => import('./routes/index.lazy').then((d) => d.Route));
 
 const PlaylistsIndexLazyRoute = PlaylistsIndexLazyImport.update({
   id: '/playlists/',
@@ -34,87 +34,89 @@ const PlaylistsIndexLazyRoute = PlaylistsIndexLazyImport.update({
   getParentRoute: () => rootRoute,
 } as any).lazy(() =>
   import('./routes/playlists.index.lazy').then((d) => d.Route),
-)
+);
 
 const PlaylistsIdLazyRoute = PlaylistsIdLazyImport.update({
   id: '/playlists/$id',
   path: '/playlists/$id',
   getParentRoute: () => rootRoute,
-} as any).lazy(() => import('./routes/playlists.$id.lazy').then((d) => d.Route))
+} as any).lazy(() =>
+  import('./routes/playlists.$id.lazy').then((d) => d.Route),
+);
 
 // Populate the FileRoutesByPath interface
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
     '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexLazyImport
-      parentRoute: typeof rootRoute
-    }
+      id: '/';
+      path: '/';
+      fullPath: '/';
+      preLoaderRoute: typeof IndexLazyImport;
+      parentRoute: typeof rootRoute;
+    };
     '/playlists/$id': {
-      id: '/playlists/$id'
-      path: '/playlists/$id'
-      fullPath: '/playlists/$id'
-      preLoaderRoute: typeof PlaylistsIdLazyImport
-      parentRoute: typeof rootRoute
-    }
+      id: '/playlists/$id';
+      path: '/playlists/$id';
+      fullPath: '/playlists/$id';
+      preLoaderRoute: typeof PlaylistsIdLazyImport;
+      parentRoute: typeof rootRoute;
+    };
     '/playlists/': {
-      id: '/playlists/'
-      path: '/playlists'
-      fullPath: '/playlists'
-      preLoaderRoute: typeof PlaylistsIndexLazyImport
-      parentRoute: typeof rootRoute
-    }
+      id: '/playlists/';
+      path: '/playlists';
+      fullPath: '/playlists';
+      preLoaderRoute: typeof PlaylistsIndexLazyImport;
+      parentRoute: typeof rootRoute;
+    };
   }
 }
 
 // Create and export the route tree
 
 export interface FileRoutesByFullPath {
-  '/': typeof IndexLazyRoute
-  '/playlists/$id': typeof PlaylistsIdLazyRoute
-  '/playlists': typeof PlaylistsIndexLazyRoute
+  '/': typeof IndexLazyRoute;
+  '/playlists/$id': typeof PlaylistsIdLazyRoute;
+  '/playlists': typeof PlaylistsIndexLazyRoute;
 }
 
 export interface FileRoutesByTo {
-  '/': typeof IndexLazyRoute
-  '/playlists/$id': typeof PlaylistsIdLazyRoute
-  '/playlists': typeof PlaylistsIndexLazyRoute
+  '/': typeof IndexLazyRoute;
+  '/playlists/$id': typeof PlaylistsIdLazyRoute;
+  '/playlists': typeof PlaylistsIndexLazyRoute;
 }
 
 export interface FileRoutesById {
-  __root__: typeof rootRoute
-  '/': typeof IndexLazyRoute
-  '/playlists/$id': typeof PlaylistsIdLazyRoute
-  '/playlists/': typeof PlaylistsIndexLazyRoute
+  __root__: typeof rootRoute;
+  '/': typeof IndexLazyRoute;
+  '/playlists/$id': typeof PlaylistsIdLazyRoute;
+  '/playlists/': typeof PlaylistsIndexLazyRoute;
 }
 
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/playlists/$id' | '/playlists'
-  fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/playlists/$id' | '/playlists'
-  id: '__root__' | '/' | '/playlists/$id' | '/playlists/'
-  fileRoutesById: FileRoutesById
+  fileRoutesByFullPath: FileRoutesByFullPath;
+  fullPaths: '/' | '/playlists/$id' | '/playlists';
+  fileRoutesByTo: FileRoutesByTo;
+  to: '/' | '/playlists/$id' | '/playlists';
+  id: '__root__' | '/' | '/playlists/$id' | '/playlists/';
+  fileRoutesById: FileRoutesById;
 }
 
 export interface RootRouteChildren {
-  IndexLazyRoute: typeof IndexLazyRoute
-  PlaylistsIdLazyRoute: typeof PlaylistsIdLazyRoute
-  PlaylistsIndexLazyRoute: typeof PlaylistsIndexLazyRoute
+  IndexLazyRoute: typeof IndexLazyRoute;
+  PlaylistsIdLazyRoute: typeof PlaylistsIdLazyRoute;
+  PlaylistsIndexLazyRoute: typeof PlaylistsIndexLazyRoute;
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexLazyRoute: IndexLazyRoute,
   PlaylistsIdLazyRoute: PlaylistsIdLazyRoute,
   PlaylistsIndexLazyRoute: PlaylistsIndexLazyRoute,
-}
+};
 
 export const routeTree = rootRoute
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>()
+  ._addFileTypes<FileRouteTypes>();
 
 /* ROUTE_MANIFEST_START
 {

--- a/apps/listen/src/routes/playlists.$id.lazy.tsx
+++ b/apps/listen/src/routes/playlists.$id.lazy.tsx
@@ -1,0 +1,39 @@
+import { createLazyFileRoute, Link } from '@tanstack/react-router';
+import { listenMutationHooks, listenQueryHooks } from 'core';
+import { useAuthContext } from 'core/providers/auth';
+import React from 'react';
+import { PlaylistDetail } from 'ui/listen/minimalism';
+import { AuthRoute } from 'ui/universal/authRoute';
+import { Layout } from '../components/layout';
+
+const Content = () => {
+  const { id } = Route.useParams();
+  const { getAccessToken } = useAuthContext();
+  const queryRs = listenQueryHooks.useLoadPlaylistDetail({
+    id,
+    getAccessToken,
+  });
+  const removeAudio = listenMutationHooks.useRemoveAudioFromPlaylist();
+
+  const handleRemove = (audioId: string) => {
+    removeAudio({ playlistId: id, audioId });
+  };
+
+  return (
+    <Layout>
+      <PlaylistDetail
+        queryRs={queryRs}
+        onRemove={handleRemove}
+        LinkComponent={Link}
+      />
+    </Layout>
+  );
+};
+
+export const Route = createLazyFileRoute('/playlists/$id')({
+  component: () => (
+    <AuthRoute>
+      <Content />
+    </AuthRoute>
+  ),
+});

--- a/packages/ui/src/listen/minimalism/index.ts
+++ b/packages/ui/src/listen/minimalism/index.ts
@@ -4,6 +4,7 @@ import { FeelingList } from './home/feeling-list';
 import { MainContainer } from './home/main-container';
 import { SettingsPanel } from './home/settings';
 import MusicWidget from './music-widget';
+import { PlaylistDetail } from './playlists/detail';
 import { PlaylistLibrary } from './playlists/library';
 import MinimalismThemeProvider from './ThemeProvider';
 
@@ -16,4 +17,5 @@ export {
   AudioList,
   MainContainer,
   PlaylistLibrary,
+  PlaylistDetail,
 };

--- a/packages/ui/src/listen/minimalism/playlists/detail.test.tsx
+++ b/packages/ui/src/listen/minimalism/playlists/detail.test.tsx
@@ -1,0 +1,107 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { PlaylistDetail } from './detail';
+
+// Stub the player + audio hook so this stays a focused unit test.
+vi.mock('../music-widget', () => ({
+  default: () => <div data-testid="music-widget" />,
+}));
+
+vi.mock('core', () => ({
+  default: {
+    useSAudioPlayer: () => ({
+      getControlsProps: () => ({ onPlay: vi.fn() }),
+      getAudioProps: () => ({}),
+      getSeekerProps: () => ({}),
+      playerState: { isPlay: false, audioItem: null },
+    }),
+  },
+}));
+
+const MockLink = (props: { children?: React.ReactNode }) => (
+  <a href="#">{props.children}</a>
+);
+
+const audios = [
+  {
+    id: 'a1',
+    name: 'First',
+    source: 's1',
+    thumbnailUrl: 't1',
+    artistName: 'Artist 1',
+  },
+  {
+    id: 'a2',
+    name: 'Second',
+    source: 's2',
+    thumbnailUrl: 't2',
+    artistName: 'Artist 2',
+  },
+];
+
+describe('PlaylistDetail', () => {
+  it('renders a loading state', () => {
+    render(
+      <PlaylistDetail
+        queryRs={{ playlist: null, audios: [], isLoading: true }}
+        LinkComponent={MockLink}
+      />,
+    );
+
+    expect(screen.getByLabelText('loading playlist')).toBeInTheDocument();
+  });
+
+  it('renders an error state when the playlist is missing', () => {
+    render(
+      <PlaylistDetail
+        queryRs={{ playlist: null, audios: [], isLoading: false }}
+        LinkComponent={MockLink}
+      />,
+    );
+
+    expect(screen.getByText(/could not be loaded/i)).toBeInTheDocument();
+  });
+
+  it('renders an empty state for a playlist with no audios', () => {
+    render(
+      <PlaylistDetail
+        queryRs={{
+          playlist: { title: 'Chill' },
+          audios: [],
+          isLoading: false,
+        }}
+        LinkComponent={MockLink}
+      />,
+    );
+
+    expect(screen.getByText('Chill')).toBeInTheDocument();
+    expect(screen.getByText(/no audios yet/i)).toBeInTheDocument();
+  });
+
+  it('renders the player and each audio', () => {
+    render(
+      <PlaylistDetail
+        queryRs={{ playlist: { title: 'Chill' }, audios, isLoading: false }}
+        LinkComponent={MockLink}
+      />,
+    );
+
+    expect(screen.getByTestId('music-widget')).toBeInTheDocument();
+    expect(screen.getByText('First')).toBeInTheDocument();
+    expect(screen.getByText('Second')).toBeInTheDocument();
+  });
+
+  it('calls onRemove with the audio id', () => {
+    const onRemove = vi.fn();
+    render(
+      <PlaylistDetail
+        queryRs={{ playlist: { title: 'Chill' }, audios, isLoading: false }}
+        onRemove={onRemove}
+        LinkComponent={MockLink}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText('remove First'));
+    expect(onRemove).toHaveBeenCalledWith('a1');
+  });
+});

--- a/packages/ui/src/listen/minimalism/playlists/detail.tsx
+++ b/packages/ui/src/listen/minimalism/playlists/detail.tsx
@@ -1,0 +1,165 @@
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import List from '@mui/material/List';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemText from '@mui/material/ListItemText';
+import Skeleton from '@mui/material/Skeleton';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import hooks, { type SAudioPlayerAudioItem } from 'core';
+import { type ElementType, useMemo, useState } from 'react';
+import MusicWidget from '../music-widget';
+
+const { useSAudioPlayer } = hooks;
+
+interface PlaylistDetailAudio {
+  id: string;
+  name: string;
+  source: string;
+  thumbnailUrl: string;
+  artistName: string;
+}
+
+interface PlaylistDetailProps {
+  queryRs: {
+    playlist: { title: string } | null;
+    audios: PlaylistDetailAudio[];
+    isLoading: boolean;
+    error?: unknown;
+  };
+  onRemove?: (audioId: string) => void;
+  LinkComponent: ElementType;
+}
+
+const toAudioItem = (audio: PlaylistDetailAudio): SAudioPlayerAudioItem => ({
+  id: audio.id,
+  src: audio.source,
+  name: audio.name,
+  image: audio.thumbnailUrl,
+  artistName: audio.artistName,
+});
+
+const BackLink = (props: { LinkComponent: ElementType }) => (
+  <IconButton
+    component={props.LinkComponent}
+    to="/playlists"
+    aria-label="back to playlists"
+    size="small"
+  >
+    <ArrowBackIcon />
+  </IconButton>
+);
+
+const Content = (
+  props: Omit<PlaylistDetailProps, 'queryRs'> & {
+    title: string;
+    audios: PlaylistDetailAudio[];
+  },
+) => {
+  const { title, audios, onRemove, LinkComponent } = props;
+  const list = useMemo(() => audios.map(toAudioItem), [audios]);
+  const [index, setIndex] = useState(0);
+
+  const hookResult = useSAudioPlayer({ audioList: list, index });
+  const { getControlsProps, playerState } = hookResult;
+  const { isPlay, audioItem } = playerState;
+  const { onPlay } = getControlsProps();
+
+  const onItemSelect = (id: string) => {
+    const nextIndex = list.findIndex((a) => a.id === id);
+    setIndex(nextIndex < 0 ? 0 : nextIndex);
+    if (!isPlay) {
+      onPlay();
+    }
+  };
+
+  return (
+    <Stack spacing={2} py={3}>
+      <Stack direction="row" alignItems="center" spacing={1}>
+        <BackLink LinkComponent={LinkComponent} />
+        <Typography variant="h5" component="h1">
+          {title}
+        </Typography>
+      </Stack>
+
+      {audios.length === 0 ? (
+        <Typography color="text.secondary">
+          This playlist has no audios yet.
+        </Typography>
+      ) : (
+        <Box>
+          <MusicWidget
+            audioList={list}
+            hookResult={hookResult}
+            onItemSelect={onItemSelect}
+          />
+          <List aria-label="playlist audios">
+            {audios.map((audio) => (
+              <ListItemButton
+                key={audio.id}
+                selected={audio.id === audioItem?.id}
+                onClick={() => onItemSelect(audio.id)}
+              >
+                <ListItemText
+                  primary={audio.name}
+                  secondary={audio.artistName}
+                />
+                {onRemove && (
+                  <IconButton
+                    edge="end"
+                    aria-label={`remove ${audio.name}`}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onRemove(audio.id);
+                    }}
+                  >
+                    <DeleteOutlineIcon />
+                  </IconButton>
+                )}
+              </ListItemButton>
+            ))}
+          </List>
+        </Box>
+      )}
+    </Stack>
+  );
+};
+
+const PlaylistDetail = (props: PlaylistDetailProps) => {
+  const { queryRs, onRemove, LinkComponent } = props;
+  const { playlist, audios, isLoading, error } = queryRs;
+
+  if (isLoading) {
+    return (
+      <Stack spacing={2} py={3} aria-label="loading playlist">
+        <Skeleton variant="text" width={200} height={40} />
+        <Skeleton variant="rounded" height={320} />
+      </Stack>
+    );
+  }
+
+  if (error || !playlist) {
+    return (
+      <Stack spacing={2} py={3}>
+        <BackLink LinkComponent={LinkComponent} />
+        <Typography color="error">
+          This playlist could not be loaded.
+        </Typography>
+      </Stack>
+    );
+  }
+
+  return (
+    <Content
+      title={playlist.title}
+      audios={audios}
+      onRemove={onRemove}
+      LinkComponent={LinkComponent}
+    />
+  );
+};
+
+export { PlaylistDetail };
+export type { PlaylistDetailAudio };


### PR DESCRIPTION
## Summary

Second slice of the listen playlist UI (SWO-289) — the playlist detail page.

- **`ui/listen` `PlaylistDetail`** — drives `useSAudioPlayer` + `MusicWidget` with the playlist's audios for **in-order playback**, plus an editable track list where each row selects/plays that audio and has a **remove** action. Loading / error / empty states included.
- **`/playlists/$id` route** — wires `useLoadPlaylistDetail` + `useRemoveAudioFromPlaylist` into the container, gated by `AuthRoute`, in the shared `Layout`.

Builds on the library page (#320). **Remaining slice:** reorder + the "add audio to playlist" affordance from the audio list, then E2E.

## Test plan

- [x] `vitest` — 5 PlaylistDetail tests (loading/error/empty/list+player/remove); 11 playlist ui tests total
- [x] `biome` clean; `tsc` clean for new `ui` files
- [x] Route tree regenerates with `/playlists/$id`
- [ ] Full app build in CI
- [ ] Manual: open a playlist, play through in order, remove a track

Ref: SWO-289

🤖 Generated with [Claude Code](https://claude.com/claude-code)