### PR TITLE
[WIP] feat(ui): add listen CollectionSelect

### DIFF
--- a/packages/ui/src/listen/minimalism/collection-select/index.stories.tsx
+++ b/packages/ui/src/listen/minimalism/collection-select/index.stories.tsx
@@ -1,0 +1,55 @@
+import Box from '@mui/material/Box';
+import type { Meta, StoryObj } from '@storybook/react';
+import { CollectionSelect } from '.';
+
+const meta: Meta<typeof CollectionSelect> = {
+  title: 'Listen/CollectionSelect',
+  component: CollectionSelect,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    (Story) => (
+      <Box width={'240px'}>
+        <Story />
+      </Box>
+    ),
+  ],
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof CollectionSelect>;
+
+const playlists = [
+  { id: '1', title: 'Focus' },
+  { id: '2', title: 'Chill' },
+  { id: '3', title: 'Workout' },
+];
+
+export const AllSelected: Story = {
+  args: {
+    value: 'all',
+    playlists,
+    onSelect: () => {},
+    onCreateNew: () => {},
+  },
+};
+
+export const PlaylistSelected: Story = {
+  args: {
+    value: '2',
+    playlists,
+    onSelect: () => {},
+    onCreateNew: () => {},
+  },
+};
+
+export const EmptyPlaylists: Story = {
+  args: {
+    value: 'all',
+    playlists: [],
+    onSelect: () => {},
+    onCreateNew: () => {},
+  },
+};

--- a/packages/ui/src/listen/minimalism/collection-select/index.test.tsx
+++ b/packages/ui/src/listen/minimalism/collection-select/index.test.tsx
@@ -1,0 +1,110 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { CollectionSelect } from './index';
+
+describe('CollectionSelect', () => {
+  const playlists = [
+    { id: '1', title: 'Focus' },
+    { id: '2', title: 'Chill' },
+  ];
+
+  const openMenu = () => {
+    fireEvent.mouseDown(screen.getByRole('combobox'));
+  };
+
+  it('renders All, playlist options and New playlist', () => {
+    render(
+      <CollectionSelect
+        value="all"
+        playlists={playlists}
+        onSelect={() => {}}
+        onCreateNew={() => {}}
+      />,
+    );
+
+    openMenu();
+    const listbox = within(screen.getByRole('listbox'));
+    expect(listbox.getByRole('option', { name: 'All' })).toBeInTheDocument();
+    expect(listbox.getByRole('option', { name: 'Focus' })).toBeInTheDocument();
+    expect(listbox.getByRole('option', { name: 'Chill' })).toBeInTheDocument();
+    expect(
+      listbox.getByRole('option', { name: /New playlist/ }),
+    ).toBeInTheDocument();
+  });
+
+  it('reflects the value from props', () => {
+    render(
+      <CollectionSelect
+        value="2"
+        playlists={playlists}
+        onSelect={() => {}}
+        onCreateNew={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole('combobox')).toHaveTextContent('Chill');
+  });
+
+  it('reflects the "all" value from props', () => {
+    render(
+      <CollectionSelect
+        value="all"
+        playlists={playlists}
+        onSelect={() => {}}
+        onCreateNew={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole('combobox')).toHaveTextContent('All');
+  });
+
+  it('calls onSelect with "all" when selecting All', () => {
+    const onSelect = vi.fn();
+    render(
+      <CollectionSelect
+        value="2"
+        playlists={playlists}
+        onSelect={onSelect}
+        onCreateNew={() => {}}
+      />,
+    );
+
+    openMenu();
+    fireEvent.click(screen.getByRole('option', { name: 'All' }));
+    expect(onSelect).toHaveBeenCalledWith('all');
+  });
+
+  it('calls onSelect with the playlist id when selecting a playlist', () => {
+    const onSelect = vi.fn();
+    render(
+      <CollectionSelect
+        value="all"
+        playlists={playlists}
+        onSelect={onSelect}
+        onCreateNew={() => {}}
+      />,
+    );
+
+    openMenu();
+    fireEvent.click(screen.getByRole('option', { name: 'Focus' }));
+    expect(onSelect).toHaveBeenCalledWith('1');
+  });
+
+  it('calls onCreateNew without changing the value when selecting New playlist', () => {
+    const onSelect = vi.fn();
+    const onCreateNew = vi.fn();
+    render(
+      <CollectionSelect
+        value="all"
+        playlists={playlists}
+        onSelect={onSelect}
+        onCreateNew={onCreateNew}
+      />,
+    );
+
+    openMenu();
+    fireEvent.click(screen.getByRole('option', { name: /New playlist/ }));
+    expect(onCreateNew).toHaveBeenCalledTimes(1);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/listen/minimalism/collection-select/index.tsx
+++ b/packages/ui/src/listen/minimalism/collection-select/index.tsx
@@ -1,0 +1,71 @@
+import AddIcon from '@mui/icons-material/Add';
+import Divider from '@mui/material/Divider';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import MenuItem from '@mui/material/MenuItem';
+import type { SelectChangeEvent } from '@mui/material/Select';
+import Select from '@mui/material/Select';
+
+const ALL_VALUE = 'all';
+const NEW_VALUE = '__new__';
+
+interface CollectionSelectPlaylist {
+  id: string;
+  title: string;
+}
+
+interface CollectionSelectProps {
+  value: 'all' | string;
+  playlists: CollectionSelectPlaylist[];
+  onSelect: (value: 'all' | string) => void;
+  onCreateNew: () => void;
+}
+
+const CollectionSelect = (props: CollectionSelectProps) => {
+  const { value, playlists, onSelect, onCreateNew } = props;
+
+  const handleChange = (event: SelectChangeEvent) => {
+    const next = event.target.value;
+
+    if (next === NEW_VALUE) {
+      onCreateNew();
+      return;
+    }
+
+    onSelect(next);
+  };
+
+  return (
+    <Select
+      value={value}
+      onChange={handleChange}
+      size="small"
+      aria-label="collection"
+      renderValue={(selected) => {
+        if (selected === ALL_VALUE) {
+          return 'All';
+        }
+
+        const playlist = playlists.find((p) => p.id === selected);
+        return playlist ? playlist.title : 'All';
+      }}
+    >
+      <MenuItem value={ALL_VALUE}>All</MenuItem>
+      {playlists.map((playlist) => (
+        <MenuItem key={playlist.id} value={playlist.id}>
+          {playlist.title}
+        </MenuItem>
+      ))}
+      <Divider />
+      <MenuItem value={NEW_VALUE}>
+        <ListItemIcon>
+          <AddIcon fontSize="small" />
+        </ListItemIcon>
+        <ListItemText>New playlist…</ListItemText>
+      </MenuItem>
+    </Select>
+  );
+};
+
+export { CollectionSelect };
+export type { CollectionSelectPlaylist, CollectionSelectProps };

--- a/packages/ui/src/listen/minimalism/index.ts
+++ b/packages/ui/src/listen/minimalism/index.ts
@@ -1,3 +1,4 @@
+import { CollectionSelect } from './collection-select';
 import { Header } from './header';
 import { AudioList } from './home/audio-list';
 import { FeelingList } from './home/feeling-list';
@@ -18,4 +19,5 @@ export {
   MainContainer,
   PlaylistLibrary,
   PlaylistDetail,
+  CollectionSelect,
 };


### PR DESCRIPTION
## Summary

Adds a presentational, route-driven `CollectionSelect` for the listen app (`packages/ui/src/listen/minimalism/collection-select`). Options are `All`, one per playlist, and a final `＋ New playlist…` action. The component holds no internal selection state — `value` comes from props (the caller derives it from the route), `onSelect(value)` fires when choosing a collection, and `onCreateNew()` fires for the New action without changing the value. Exported from `packages/ui/src/listen/minimalism/index.ts`.

Implements SWO-293.

## Test plan

- `pnpm --filter ui test` — new `index.test.tsx` covers: renders All + playlist options + New; reflects `value` (both `all` and a playlist id); selecting a collection calls `onSelect` with `'all'`/playlist id; selecting New calls `onCreateNew` without calling `onSelect`.
- Storybook stories: All selected, a playlist selected, empty playlist list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a collection selector for choosing “All” or a specific playlist.
  * Added support for starting a new playlist from the selector.
  * Included Storybook examples for common states, including populated and empty lists.

* **Tests**
  * Added automated coverage for selection behavior, label display, and the new-playlist action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->