### PR TITLE
feat(ui): add listen CreatePlaylistDialog

### DIFF
--- a/packages/ui/src/listen/minimalism/index.ts
+++ b/packages/ui/src/listen/minimalism/index.ts
@@ -4,6 +4,7 @@ import { FeelingList } from './home/feeling-list';
 import { MainContainer } from './home/main-container';
 import { SettingsPanel } from './home/settings';
 import MusicWidget from './music-widget';
+import { CreatePlaylistDialog } from './playlists/create-dialog';
 import { PlaylistDetail } from './playlists/detail';
 import { PlaylistLibrary } from './playlists/library';
 import MinimalismThemeProvider from './ThemeProvider';
@@ -18,4 +19,5 @@ export {
   MainContainer,
   PlaylistLibrary,
   PlaylistDetail,
+  CreatePlaylistDialog,
 };

--- a/packages/ui/src/listen/minimalism/playlists/create-dialog.stories.tsx
+++ b/packages/ui/src/listen/minimalism/playlists/create-dialog.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { CreatePlaylistDialog } from './create-dialog';
+
+const meta: Meta<typeof CreatePlaylistDialog> = {
+  title: 'Listen/Playlists/CreatePlaylistDialog',
+  component: CreatePlaylistDialog,
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    onClose: () => {},
+    onCreate: () => {},
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof CreatePlaylistDialog>;
+
+export const Open: Story = {
+  args: {
+    open: true,
+  },
+};
+
+export const Creating: Story = {
+  args: {
+    open: true,
+    isCreating: true,
+  },
+};
+
+export const Closed: Story = {
+  args: {
+    open: false,
+  },
+};

--- a/packages/ui/src/listen/minimalism/playlists/create-dialog.test.tsx
+++ b/packages/ui/src/listen/minimalism/playlists/create-dialog.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { CreatePlaylistDialog } from './create-dialog';
+
+describe('CreatePlaylistDialog', () => {
+  it('creates a playlist with the trimmed title and closes', () => {
+    const onCreate = vi.fn();
+    const onClose = vi.fn();
+    render(<CreatePlaylistDialog open onClose={onClose} onCreate={onCreate} />);
+
+    fireEvent.change(screen.getByLabelText('Title'), {
+      target: { value: '  Bangers  ' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+    expect(onCreate).toHaveBeenCalledWith('Bangers');
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('submits on Enter with the trimmed title', () => {
+    const onCreate = vi.fn();
+    const onClose = vi.fn();
+    render(<CreatePlaylistDialog open onClose={onClose} onCreate={onCreate} />);
+
+    const input = screen.getByLabelText('Title');
+    fireEvent.change(input, { target: { value: '  Focus  ' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onCreate).toHaveBeenCalledWith('Focus');
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('does not submit a blank or whitespace title', () => {
+    const onCreate = vi.fn();
+    render(<CreatePlaylistDialog open onClose={vi.fn()} onCreate={onCreate} />);
+
+    // Create is disabled for an empty title.
+    expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText('Title'), {
+      target: { value: '   ' },
+    });
+
+    expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled();
+    fireEvent.keyDown(screen.getByLabelText('Title'), { key: 'Enter' });
+    expect(onCreate).not.toHaveBeenCalled();
+  });
+
+  it('calls onClose when cancelled', () => {
+    const onCreate = vi.fn();
+    const onClose = vi.fn();
+    render(<CreatePlaylistDialog open onClose={onClose} onCreate={onCreate} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onClose).toHaveBeenCalled();
+    expect(onCreate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/listen/minimalism/playlists/create-dialog.tsx
+++ b/packages/ui/src/listen/minimalism/playlists/create-dialog.tsx
@@ -1,0 +1,63 @@
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import TextField from '@mui/material/TextField';
+import { useState } from 'react';
+
+interface CreatePlaylistDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onCreate: (title: string) => void;
+  isCreating?: boolean;
+}
+
+const CreatePlaylistDialog = (props: CreatePlaylistDialogProps) => {
+  const { open, onClose, onCreate, isCreating } = props;
+  const [title, setTitle] = useState('');
+
+  const handleClose = () => {
+    setTitle('');
+    onClose();
+  };
+
+  const handleCreate = () => {
+    const trimmed = title.trim();
+    if (!trimmed) return;
+    onCreate(trimmed);
+    handleClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose} fullWidth maxWidth="xs">
+      <DialogTitle>New playlist</DialogTitle>
+      <DialogContent>
+        <TextField
+          autoFocus
+          margin="dense"
+          label="Title"
+          fullWidth
+          value={title}
+          onChange={(event) => setTitle(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') handleCreate();
+          }}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose}>Cancel</Button>
+        <Button
+          onClick={handleCreate}
+          variant="contained"
+          disabled={!title.trim() || isCreating}
+        >
+          Create
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export { CreatePlaylistDialog };
+export type { CreatePlaylistDialogProps };


### PR DESCRIPTION
## Summary

Standalone presentational create-playlist dialog for the listen app (title → `onCreate`), so the upcoming collection select can open it via "＋ New playlist…". Extracted so the old `PlaylistLibrary` can be retired later.

Part of SWO-292. Closes SWO-294.

## Test plan

- [x] `pnpm --filter ui exec vitest run …/create-dialog.test.tsx` — 4/4 pass (trimmed title, Enter submit, blank/whitespace disabled, cancel)
- [x] biome clean
- [x] Storybook story (Open / Creating / Closed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)