### PR TITLE
feat(ui): add listen ListeningScreen

### DIFF
--- a/packages/ui/src/listen/minimalism/home/audio-list.tsx
+++ b/packages/ui/src/listen/minimalism/home/audio-list.tsx
@@ -1,7 +1,7 @@
 import Card from '@mui/material/Card';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
-import hooks, { type listenQueryHooks } from 'core';
+import hooks from 'core';
 import { lazy, Suspense, useEffect, useMemo, useState } from 'react';
 import { useIsMobile } from '../../../universal/responsive';
 import MusicWidget from '../music-widget';
@@ -15,7 +15,9 @@ const NoItem = () => {
 };
 
 interface AudioListProps {
-  queryRs: ReturnType<typeof listenQueryHooks.useLoadAudios>;
+  // Only `isLoading` is read here, so accept any loading-bearing result —
+  // this lets both the home (useLoadAudios) and a playlist feed the player.
+  queryRs: { isLoading: boolean };
   list: unknown[];
   activeFeelingId: string;
 }

--- a/packages/ui/src/listen/minimalism/index.ts
+++ b/packages/ui/src/listen/minimalism/index.ts
@@ -4,6 +4,7 @@ import { AudioList } from './home/audio-list';
 import { FeelingList } from './home/feeling-list';
 import { MainContainer } from './home/main-container';
 import { SettingsPanel } from './home/settings';
+import { ListeningScreen } from './listening-screen';
 import MusicWidget from './music-widget';
 import { CreatePlaylistDialog } from './playlists/create-dialog';
 import { PlaylistDetail } from './playlists/detail';
@@ -22,4 +23,5 @@ export {
   PlaylistDetail,
   CollectionSelect,
   CreatePlaylistDialog,
+  ListeningScreen,
 };

--- a/packages/ui/src/listen/minimalism/listening-screen/index.stories.tsx
+++ b/packages/ui/src/listen/minimalism/listening-screen/index.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import type { listenQueryHooks } from 'core';
+import { ListeningScreen } from './index';
+
+type AudiosQueryRs = ReturnType<typeof listenQueryHooks.useLoadAudios>;
+
+const audios = [
+  {
+    id: '1',
+    name: 'Reimei',
+    source: '',
+    thumbnailUrl: '',
+    artistName: 'Maon Kurosaki',
+    audio_tags: [],
+  },
+];
+
+const allQueryRs = {
+  isLoading: false,
+  data: { audios, tags: [{ id: 't1', name: 'Chill' }] },
+} as unknown as AudiosQueryRs;
+
+const meta: Meta<typeof ListeningScreen> = {
+  title: 'Listen/ListeningScreen',
+  component: ListeningScreen,
+  parameters: { layout: 'fullscreen' },
+  args: {
+    sites: { listen: '#', watch: '#', play: '#', til: '#' },
+    user: null,
+    onSignIn: () => {},
+    onLogout: () => {},
+    playlists: [
+      { id: 'p1', title: 'Hakuoki' },
+      { id: 'p2', title: 'OST' },
+    ],
+    onSelectCollection: () => {},
+    onCreate: () => {},
+    audios,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ListeningScreen>;
+
+export const AllWithFeelings: Story = {
+  args: {
+    mode: 'all',
+    collectionValue: 'all',
+    queryRs: allQueryRs,
+  },
+};
+
+export const PlaylistNoFeelings: Story = {
+  args: {
+    mode: 'playlist',
+    collectionValue: 'p1',
+    isLoading: false,
+  },
+};

--- a/packages/ui/src/listen/minimalism/listening-screen/index.test.tsx
+++ b/packages/ui/src/listen/minimalism/listening-screen/index.test.tsx
@@ -1,0 +1,89 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { listenQueryHooks } from 'core';
+import { describe, expect, it, vi } from 'vitest';
+import { ListeningScreen } from './index';
+
+// Stub the heavy children; this test covers ListeningScreen's own wiring
+// (mode-driven feeling filter, and opening the create dialog from the select).
+vi.mock('../header', () => ({ Header: () => <div>Header</div> }));
+vi.mock('../home/settings', () => ({
+  SettingsPanel: () => <div>SettingsPanel</div>,
+}));
+vi.mock('../home/audio-list', () => ({
+  AudioList: () => <div>AudioList</div>,
+}));
+vi.mock('../home/feeling-list', () => ({
+  FeelingList: () => <div>FeelingList</div>,
+}));
+vi.mock('../collection-select', () => ({
+  CollectionSelect: (props: { value: string; onCreateNew: () => void }) => (
+    <div>
+      <span>collection:{props.value}</span>
+      <button type="button" onClick={props.onCreateNew}>
+        new
+      </button>
+    </div>
+  ),
+}));
+
+type AudiosQueryRs = ReturnType<typeof listenQueryHooks.useLoadAudios>;
+const allQueryRs = {
+  isLoading: false,
+  data: { audios: [], tags: [] },
+} as unknown as AudiosQueryRs;
+
+const baseProps = {
+  sites: { listen: '', watch: '', play: '', til: '' },
+  user: null,
+  onSignIn: vi.fn(),
+  onLogout: vi.fn(),
+  playlists: [{ id: 'p1', title: 'Hakuoki' }],
+  onSelectCollection: vi.fn(),
+  onCreate: vi.fn(),
+  audios: [],
+};
+
+describe('ListeningScreen', () => {
+  it('shows the feeling filter in All mode', () => {
+    render(
+      <ListeningScreen
+        {...baseProps}
+        mode="all"
+        collectionValue="all"
+        queryRs={allQueryRs}
+      />,
+    );
+
+    expect(screen.getByText('FeelingList')).toBeInTheDocument();
+    expect(screen.getByText('collection:all')).toBeInTheDocument();
+  });
+
+  it('hides the feeling filter in playlist mode', () => {
+    render(
+      <ListeningScreen
+        {...baseProps}
+        mode="playlist"
+        collectionValue="p1"
+        isLoading={false}
+      />,
+    );
+
+    expect(screen.queryByText('FeelingList')).not.toBeInTheDocument();
+    expect(screen.getByText('collection:p1')).toBeInTheDocument();
+  });
+
+  it('opens the create dialog from the select New action', () => {
+    render(
+      <ListeningScreen
+        {...baseProps}
+        mode="all"
+        collectionValue="all"
+        queryRs={allQueryRs}
+      />,
+    );
+
+    expect(screen.queryByText('New playlist')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'new' }));
+    expect(screen.getByText('New playlist')).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/listen/minimalism/listening-screen/index.tsx
+++ b/packages/ui/src/listen/minimalism/listening-screen/index.tsx
@@ -1,0 +1,138 @@
+import Box from '@mui/material/Box';
+import type { Auth, listenQueryHooks } from 'core';
+import { useState } from 'react';
+import { FullWidthContainer } from '../../../universal';
+import {
+  CollectionSelect,
+  type CollectionSelectPlaylist,
+} from '../collection-select';
+import { Header } from '../header';
+import { AudioList } from '../home/audio-list';
+import { FeelingList } from '../home/feeling-list';
+import { MainContainer } from '../home/main-container';
+import { SettingsPanel } from '../home/settings';
+import { CreatePlaylistDialog } from '../playlists/create-dialog';
+
+type AudiosQueryRs = ReturnType<typeof listenQueryHooks.useLoadAudios>;
+
+interface HeaderSites {
+  listen: string;
+  watch: string;
+  play: string;
+  til: string;
+}
+
+interface CommonProps {
+  sites: HeaderSites;
+  user: Auth.CustomUser | null;
+  onSignIn: () => void;
+  onLogout: () => void;
+  // The collection select is route-driven: `value` reflects the current route,
+  // `onSelectCollection` navigates.
+  collectionValue: 'all' | string;
+  playlists: CollectionSelectPlaylist[];
+  onSelectCollection: (value: 'all' | string) => void;
+  onCreate: (title: string) => void;
+  // Raw audios for the player (AudioList maps them to player items).
+  audios: unknown[];
+}
+
+interface AllModeProps extends CommonProps {
+  mode: 'all';
+  // Full home query result — also feeds the feeling filter.
+  queryRs: AudiosQueryRs;
+}
+
+interface PlaylistModeProps extends CommonProps {
+  mode: 'playlist';
+  isLoading: boolean;
+}
+
+type ListeningScreenProps = AllModeProps | PlaylistModeProps;
+
+/**
+ * The single screen behind every listen page. Home and a playlist render the
+ * exact same layout — Header, a collection select (+ feeling filter on "All"),
+ * and the player — differing only in which audios feed it.
+ */
+const ListeningScreen = (props: ListeningScreenProps) => {
+  const {
+    mode,
+    sites,
+    user,
+    onSignIn,
+    onLogout,
+    collectionValue,
+    playlists,
+    onSelectCollection,
+    onCreate,
+    audios,
+  } = props;
+
+  const [settingOpen, setSettingOpen] = useState(false);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [activeFeelingId, setActiveFeelingId] = useState('');
+
+  const isLoading = mode === 'all' ? props.queryRs.isLoading : props.isLoading;
+
+  const onProfileClick = () => {
+    if (user) {
+      setSettingOpen(true);
+    } else {
+      onSignIn();
+    }
+  };
+
+  const handleCreate = (title: string) => {
+    onCreate(title);
+    setCreateOpen(false);
+  };
+
+  return (
+    <FullWidthContainer>
+      <Header sites={sites} onProfileClick={onProfileClick} user={user} />
+      <SettingsPanel
+        open={settingOpen}
+        toggle={setSettingOpen}
+        actions={{ logout: onLogout }}
+      />
+      <MainContainer>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 2,
+            flexWrap: 'wrap',
+          }}
+        >
+          <CollectionSelect
+            value={collectionValue}
+            playlists={playlists}
+            onSelect={onSelectCollection}
+            onCreateNew={() => setCreateOpen(true)}
+          />
+          {mode === 'all' && (
+            <FeelingList
+              activeId={activeFeelingId}
+              onSelect={setActiveFeelingId}
+              queryRs={props.queryRs}
+            />
+          )}
+        </Box>
+        <AudioList
+          queryRs={{ isLoading }}
+          list={audios}
+          activeFeelingId={mode === 'all' ? activeFeelingId : ''}
+        />
+      </MainContainer>
+      <CreatePlaylistDialog
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        onCreate={handleCreate}
+      />
+    </FullWidthContainer>
+  );
+};
+
+export { ListeningScreen };
+export type { ListeningScreenProps };


### PR DESCRIPTION
## Summary

The single presentational screen behind every listen page: `Header` + a route-driven `CollectionSelect` (+ the feeling filter only in **All** mode) + the existing `AudioList` player, owning the `CreatePlaylistDialog` open state. Home and a playlist render the *same* layout — only the audios differ. This is the keystone of the one-screen unification (SWO-292).

- `mode: 'all'` → collection value "All", feeling chips shown, fed by `useLoadAudios`.
- `mode: 'playlist'` → select shows the playlist name, no feelings.
- Relaxes `AudioList`'s `queryRs` prop to any `{ isLoading }` (it only reads that), so both a home query and a playlist query can drive the player.

Part of SWO-292. Closes SWO-295.

## Test plan

- [x] `vitest run src/listen/minimalism` — 47/47 pass, incl. 3 new ListeningScreen cases (feeling filter shown in All / hidden in playlist; New opens the create dialog)
- [x] biome clean on changed files
- [x] Storybook stories: All-with-feelings, Playlist-no-feelings
- [x] No new `tsc` errors in listen (pre-existing watch errors are unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)