### PR TITLE
fix(listen): keep collection select spacing consistent across modes

### DIFF
--- a/packages/ui/src/listen/minimalism/home/feeling-list/index.tsx
+++ b/packages/ui/src/listen/minimalism/home/feeling-list/index.tsx
@@ -35,7 +35,6 @@ const FeelingList = (props: FeelingListProps) => {
       aria-label="feeling list"
       direction="row"
       spacing={1}
-      my={2}
       sx={{ overflowX: 'auto' }}
     >
       <Chip

--- a/packages/ui/src/listen/minimalism/listening-screen/index.tsx
+++ b/packages/ui/src/listen/minimalism/listening-screen/index.tsx
@@ -104,6 +104,9 @@ const ListeningScreen = (props: ListeningScreenProps) => {
             alignItems: 'center',
             gap: 2,
             flexWrap: 'wrap',
+            // Owns the row's vertical spacing so it's identical whether the
+            // feeling chips are shown (All) or not (a playlist).
+            my: 2,
           }}
         >
           <CollectionSelect


### PR DESCRIPTION
## Summary

Selecting a playlist dropped the top-row vertical spacing (it came only from `FeelingList`'s `my={2}`, which isn't rendered in playlist mode), causing a layout shift between All and a playlist. Moved the vertical margin onto the row container so both modes match.

Closes SWO-299.

## Test plan

- [x] `vitest run src/listen/minimalism` — 47/47 pass
- [x] biome clean (pre-existing a11y warnings only)
- [ ] Manual: switching All ↔ a playlist no longer shifts the layout; select has consistent spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)