### PR TITLE
fix(listen): keep select + feeling chips on one row on mobile

### DIFF
--- a/packages/ui/src/listen/minimalism/listening-screen/index.tsx
+++ b/packages/ui/src/listen/minimalism/listening-screen/index.tsx
@@ -103,24 +103,31 @@ const ListeningScreen = (props: ListeningScreenProps) => {
             display: 'flex',
             alignItems: 'center',
             gap: 2,
-            flexWrap: 'wrap',
-            // Owns the row's vertical spacing so it's identical whether the
-            // feeling chips are shown (All) or not (a playlist).
+            // Single row on every viewport — the chips never wrap below the
+            // select. Owns the row's vertical spacing so it's identical
+            // whether the feeling chips are shown (All) or not (a playlist).
             my: 2,
           }}
         >
-          <CollectionSelect
-            value={collectionValue}
-            playlists={playlists}
-            onSelect={onSelectCollection}
-            onCreateNew={() => setCreateOpen(true)}
-          />
-          {mode === 'all' && (
-            <FeelingList
-              activeId={activeFeelingId}
-              onSelect={setActiveFeelingId}
-              queryRs={props.queryRs}
+          {/* Select stays fixed — it's not part of the scrollable chips. */}
+          <Box sx={{ flexShrink: 0 }}>
+            <CollectionSelect
+              value={collectionValue}
+              playlists={playlists}
+              onSelect={onSelectCollection}
+              onCreateNew={() => setCreateOpen(true)}
             />
+          </Box>
+          {mode === 'all' && (
+            // Only the chips scroll horizontally; minWidth:0 lets this flex
+            // item shrink so FeelingList's own overflow activates.
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <FeelingList
+                activeId={activeFeelingId}
+                onSelect={setActiveFeelingId}
+                queryRs={props.queryRs}
+              />
+            </Box>
           )}
         </Box>
         <AudioList


### PR DESCRIPTION
## Summary

On mobile the top row wrapped the feeling chips onto a second line below the collection select. Removes `flexWrap` and splits the row into a **fixed** select (`flexShrink:0`) and a **flexible, scrollable** chips container (`flex:1, minWidth:0`) wrapping `FeelingList` (which already has `overflowX:auto`). Only the chips scroll horizontally; the select stays put and is never part of the scroll.

Follows the merged spacing fix (SWO-299). Closes SWO-300.

## Test plan

- [x] `vitest run …/listening-screen` pass; `turbo build --filter=listen...` green; biome clean
- [ ] Manual (mobile): select + chips on one row; chips scroll; select fixed; playlist mode unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)