### PR TITLE
refactor(listen): remove per-track delete from the listening screen

### DIFF
--- a/apps/listen/src/routes/playlists.$id.lazy.tsx
+++ b/apps/listen/src/routes/playlists.$id.lazy.tsx
@@ -34,7 +34,6 @@ const Content = () => {
   });
   const { playlists } = listenQueryHooks.useLoadPlaylists({ getAccessToken });
   const createPlaylist = listenMutationHooks.useCreatePlaylist();
-  const removeAudio = listenMutationHooks.useRemoveAudioFromPlaylist();
   const onSelectCollection = useCollectionNavigate();
 
   return (
@@ -52,7 +51,6 @@ const Content = () => {
       }
       isLoading={queryRs.isLoading}
       audios={queryRs.audios}
-      onRemove={(audioId) => removeAudio({ playlistId: id, audioId })}
     />
   );
 };

--- a/packages/ui/src/listen/minimalism/home/audio-list.tsx
+++ b/packages/ui/src/listen/minimalism/home/audio-list.tsx
@@ -20,8 +20,6 @@ interface AudioListProps {
   queryRs: { isLoading: boolean };
   list: unknown[];
   activeFeelingId: string;
-  // Playlist mode: remove a track from the playlist.
-  onRemove?: (id: string) => void;
 }
 
 const toAudioItem = (item: any) => {
@@ -38,7 +36,7 @@ const toAudioItem = (item: any) => {
 const PlayingList = lazy(() => import('./playing-list'));
 
 const Content = (props: AudioListProps) => {
-  const { list: originalList, activeFeelingId, onRemove } = props;
+  const { list: originalList, activeFeelingId } = props;
   // TODO
   // memorize on parent
   const list = useMemo(() => {
@@ -99,7 +97,6 @@ const Content = (props: AudioListProps) => {
                 audioList={list}
                 onItemSelect={onItemSelect}
                 currentId={currentAudio.id}
-                onRemove={onRemove}
               />
             </Suspense>
           </Card>

--- a/packages/ui/src/listen/minimalism/home/playing-list.tsx
+++ b/packages/ui/src/listen/minimalism/home/playing-list.tsx
@@ -1,6 +1,4 @@
-import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import Box from '@mui/material/Box';
-import IconButton from '@mui/material/IconButton';
 import List from '@mui/material/List';
 import ListItemAvatar from '@mui/material/ListItemAvatar';
 import ListItemButton from '@mui/material/ListItemButton';
@@ -14,19 +12,16 @@ interface PlayingListItemProps {
   audioList: SAudioPlayerAudioItem[];
   currentId: string;
   onItemSelect: (id: string) => void;
-  // When provided (playlist mode), each track shows a remove action.
-  onRemove?: (id: string) => void;
 }
 
 interface ItemProps {
   audio: SAudioPlayerAudioItem;
   isPlaying: boolean;
   onSelect: (id: string) => void;
-  onRemove?: (id: string) => void;
 }
 
 const Item = (props: ItemProps) => {
-  const { audio, isPlaying, onSelect, onRemove } = props;
+  const { audio, isPlaying, onSelect } = props;
   const { id, image, name, artistName } = audio;
 
   return (
@@ -65,24 +60,12 @@ const Item = (props: ItemProps) => {
           </Stack>
         }
       />
-      {onRemove && (
-        <IconButton
-          edge="end"
-          aria-label={`remove ${name}`}
-          onClick={(event) => {
-            event.stopPropagation();
-            onRemove(id);
-          }}
-        >
-          <DeleteOutlineIcon />
-        </IconButton>
-      )}
     </ListItemButton>
   );
 };
 
 const PlayingList = (props: PlayingListItemProps) => {
-  const { audioList, currentId, onItemSelect, onRemove } = props;
+  const { audioList, currentId, onItemSelect } = props;
 
   if (!audioList?.length) {
     return (
@@ -103,7 +86,6 @@ const PlayingList = (props: PlayingListItemProps) => {
             audio={a}
             isPlaying={id === currentId}
             onSelect={onItemSelect}
-            onRemove={onRemove}
           />
         );
       })}

--- a/packages/ui/src/listen/minimalism/listening-screen/index.tsx
+++ b/packages/ui/src/listen/minimalism/listening-screen/index.tsx
@@ -33,8 +33,6 @@ interface CommonProps {
   onCreate: (title: string) => void;
   // Raw audios for the player (AudioList maps them to player items).
   audios: unknown[];
-  // Playlist mode: remove a track from the playlist.
-  onRemove?: (id: string) => void;
 }
 
 interface AllModeProps extends CommonProps {
@@ -67,7 +65,6 @@ const ListeningScreen = (props: ListeningScreenProps) => {
     onSelectCollection,
     onCreate,
     audios,
-    onRemove,
   } = props;
 
   const [settingOpen, setSettingOpen] = useState(false);
@@ -134,7 +131,6 @@ const ListeningScreen = (props: ListeningScreenProps) => {
           queryRs={{ isLoading }}
           list={audios}
           activeFeelingId={mode === 'all' ? activeFeelingId : ''}
-          onRemove={onRemove}
         />
       </MainContainer>
       <CreatePlaylistDialog


### PR DESCRIPTION
## Summary

The listening screen should be for listening only — no management UI. Removes the per-track delete (remove-from-playlist) button and its now-dead `onRemove` plumbing across `playing-list`, `audio-list`, `listening-screen`, and the playlist route. The `useRemoveAudioFromPlaylist` core hook stays for a future dedicated management page.

Closes SWO-301.

## Test plan

- [x] `vitest run src/listen/minimalism` — 36/36 pass; `turbo build --filter=listen...` green; biome formatted
- [x] No `onRemove` / `DeleteOutline` references remain in listen UI
- [ ] Manual: playlist tracks show no delete button; playback unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Removed the option to remove individual tracks from playlist and “Now Playing” lists.
  * Simplified the listening screens by showing only selection and playback actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->