### PR TITLE
feat(listen): beautify the music player and listening screen

### DIFF
--- a/packages/ui/src/listen/minimalism/collection-select/index.tsx
+++ b/packages/ui/src/listen/minimalism/collection-select/index.tsx
@@ -19,10 +19,12 @@ interface CollectionSelectProps {
   playlists: CollectionSelectPlaylist[];
   onSelect: (value: 'all' | string) => void;
   onCreateNew: () => void;
+  // Only signed-in users can create playlists; hide the option otherwise.
+  canCreate?: boolean;
 }
 
 const CollectionSelect = (props: CollectionSelectProps) => {
-  const { value, playlists, onSelect, onCreateNew } = props;
+  const { value, playlists, onSelect, onCreateNew, canCreate = true } = props;
 
   const handleChange = (event: SelectChangeEvent) => {
     const next = event.target.value;
@@ -57,13 +59,15 @@ const CollectionSelect = (props: CollectionSelectProps) => {
           {playlist.title}
         </MenuItem>
       ))}
-      <Divider />
-      <MenuItem value={NEW_VALUE}>
-        <ListItemIcon>
-          <AddIcon fontSize="small" />
-        </ListItemIcon>
-        <ListItemText>New playlist…</ListItemText>
-      </MenuItem>
+      {canCreate && <Divider />}
+      {canCreate && (
+        <MenuItem value={NEW_VALUE}>
+          <ListItemIcon>
+            <AddIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>New playlist…</ListItemText>
+        </MenuItem>
+      )}
     </Select>
   );
 };

--- a/packages/ui/src/listen/minimalism/listening-screen/index.tsx
+++ b/packages/ui/src/listen/minimalism/listening-screen/index.tsx
@@ -113,6 +113,7 @@ const ListeningScreen = (props: ListeningScreenProps) => {
               playlists={playlists}
               onSelect={onSelectCollection}
               onCreateNew={() => setCreateOpen(true)}
+              canCreate={Boolean(user)}
             />
           </Box>
           {mode === 'all' && (

--- a/packages/ui/src/listen/minimalism/music-widget/Controls.tsx
+++ b/packages/ui/src/listen/minimalism/music-widget/Controls.tsx
@@ -31,24 +31,34 @@ const getWrapperStyles = () => ({
 const getCenterControlsStyles = () => ({
   display: 'flex',
   alignItems: 'center',
-  gap: 2,
+  gap: 1,
 });
 
-const getMainButtonStyles = () => ({
-  fontSize: '3rem',
-  p: 0,
-  color: 'white',
+// The play/pause button is the one filled focal point.
+const getPlayButtonStyles = () => ({
+  width: 56,
+  height: 56,
+  bgcolor: 'primary.main',
+  color: 'primary.contrastText',
   '&:hover': {
-    bgcolor: 'rgba(255,255,255,0.1)',
+    bgcolor: 'primary.dark',
   },
 });
 
-const getSideButtonStyles = (isActive = false) => ({
-  color: isActive ? 'white' : 'rgba(255,255,255,0.7)',
-  fontSize: '1.75rem',
+// Prev / next — plain, quiet.
+const getStepButtonStyles = () => ({
+  color: 'text.primary',
   '&:hover': {
-    color: 'white',
-    bgcolor: 'rgba(255,255,255,0.1)',
+    bgcolor: 'action.hover',
+  },
+});
+
+// Loop / shuffle — secondary, dimmed until active.
+const getSideButtonStyles = (isActive = false) => ({
+  color: isActive ? 'primary.main' : 'text.secondary',
+  '&:hover': {
+    color: 'text.primary',
+    bgcolor: 'action.hover',
   },
 });
 
@@ -76,30 +86,22 @@ const Controls = (props: Props) => {
     handleNext,
   } = props;
 
-  const renderIcon = () => {
-    if (isPlay) {
-      return <PauseRounded sx={getMainButtonStyles()} />;
-    }
-
-    return <PlayArrowRounded sx={getMainButtonStyles()} />;
-  };
-
   const renderLoopMode = () => {
     if (loopMode === SAudioPlayerLoopMode.All) {
-      return <RepeatOnIcon fontSize="large" />;
+      return <RepeatOnIcon />;
     } else if (loopMode === SAudioPlayerLoopMode.One) {
-      return <RepeatOneIcon fontSize="large" />;
+      return <RepeatOneIcon />;
     } else {
-      return <RepeatIcon fontSize="large" />;
+      return <RepeatIcon />;
     }
   };
 
   const renderShuffle = () => {
     if (shuffle) {
-      return <ShuffleOnIcon fontSize="large" />;
+      return <ShuffleOnIcon />;
     }
 
-    return <ShuffleIcon fontSize="large" />;
+    return <ShuffleIcon />;
   };
 
   return (
@@ -108,32 +110,35 @@ const Controls = (props: Props) => {
         size="small"
         aria-label="toggle loop mode"
         onClick={onChangeLoopMode}
-        sx={getSideButtonStyles()}
+        sx={getSideButtonStyles(
+          loopMode !== undefined && loopMode !== SAudioPlayerLoopMode.None,
+        )}
       >
         {renderLoopMode()}
       </IconButton>
       <Box sx={getCenterControlsStyles()}>
         <IconButton
-          size="small"
           aria-label="previous audio"
           onClick={handlePrev}
-          sx={getMainButtonStyles()}
+          sx={getStepButtonStyles()}
         >
           <SkipPreviousRounded fontSize="large" />
         </IconButton>
         <IconButton
-          size="medium"
           aria-label={isPlay ? 'pause' : 'play'}
           onClick={handlePlay}
-          sx={getMainButtonStyles()}
+          sx={getPlayButtonStyles()}
         >
-          {renderIcon()}
+          {isPlay ? (
+            <PauseRounded fontSize="large" />
+          ) : (
+            <PlayArrowRounded fontSize="large" />
+          )}
         </IconButton>
         <IconButton
-          size="small"
           aria-label="next audio"
           onClick={handleNext}
-          sx={getMainButtonStyles()}
+          sx={getStepButtonStyles()}
         >
           <SkipNextRounded fontSize="large" />
         </IconButton>
@@ -142,7 +147,7 @@ const Controls = (props: Props) => {
         size="small"
         aria-label="shuffle"
         onClick={onShuffle}
-        sx={getSideButtonStyles()}
+        sx={getSideButtonStyles(shuffle)}
       >
         {renderShuffle()}
       </IconButton>

--- a/packages/ui/src/listen/minimalism/music-widget/Seeker.tsx
+++ b/packages/ui/src/listen/minimalism/music-widget/Seeker.tsx
@@ -1,4 +1,4 @@
-import { styled, type Theme, useTheme } from '@mui/material';
+import { styled, type Theme, useTheme } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Slider from '@mui/material/Slider';
 import Typography from '@mui/material/Typography';
@@ -13,26 +13,26 @@ interface Props {
 // https://mui.com/material-ui/react-slider/#music-player
 const getStyles = (theme: Theme) => {
   return {
-    color: theme.palette.mode === 'dark' ? '#fff' : 'rgba(0,0,0,0.87)',
-    height: 8,
+    color: theme.palette.primary.main,
+    height: 4,
     '& .MuiSlider-thumb': {
-      width: 16,
-      height: 16,
-      backgroundColor: '#fff',
+      width: 12,
+      height: 12,
+      backgroundColor: theme.palette.primary.main,
       transition: '0.3s cubic-bezier(.47,1.64,.41,.8)',
       '&:before': {
-        boxShadow: '0 2px 12px 0 rgba(0,0,0,0.4)',
+        boxShadow: '0 2px 12px 0 rgba(0,0,0,0.2)',
       },
       '&:hover, &.Mui-focusVisible': {
-        boxShadow: `0px 0px 0px 8px ${theme.palette.mode === 'dark' ? 'rgb(255 255 255 / 16%)' : 'rgb(0 0 0 / 16%)'}`,
+        boxShadow: `0px 0px 0px 8px ${theme.palette.primary.main}29`,
       },
       '&.Mui-active': {
-        width: 24,
-        height: 24,
+        width: 18,
+        height: 18,
       },
     },
     '& .MuiSlider-rail': {
-      opacity: 0.28,
+      opacity: 0.24,
     },
   };
 };
@@ -46,17 +46,11 @@ const getInfoStyles = () => {
 };
 
 const TinyText = styled(Typography)(({ theme }) => {
-  const { white } = theme.palette.common;
-
   return {
     fontSize: '0.75rem',
-    opacity: 0.38,
     fontWeight: 500,
     letterSpacing: 0.2,
-    color: white,
-    [theme.breakpoints.down('sm')]: {
-      color: white,
-    },
+    color: theme.palette.text.secondary,
   };
 });
 

--- a/packages/ui/src/listen/minimalism/music-widget/Styled.tsx
+++ b/packages/ui/src/listen/minimalism/music-widget/Styled.tsx
@@ -33,7 +33,7 @@ const StyledPlayingList = styled(Box)<BoxProps>(({ theme }) => {
     position: 'absolute',
     width: '100%',
     height: '244px',
-    top: 56,
+    bottom: 0,
     overflowY: 'auto',
     backgroundColor: theme.palette.common.white,
     color: theme.palette.common.black,

--- a/packages/ui/src/listen/minimalism/music-widget/Styled.tsx
+++ b/packages/ui/src/listen/minimalism/music-widget/Styled.tsx
@@ -1,6 +1,5 @@
-import type { BoxProps, CardProps } from '@mui/material';
-import Box from '@mui/material/Box';
-import Card from '@mui/material/Card';
+import Box, { type BoxProps } from '@mui/material/Box';
+import Card, { type CardProps } from '@mui/material/Card';
 import { keyframes, styled } from '@mui/material/styles';
 
 const cardWidth = 345;
@@ -14,8 +13,12 @@ const StyledCard = styled(Card)<CardProps>(({ theme }) => {
     [theme.breakpoints.down('sm')]: {
       width: '100%',
     },
-    background: `linear-gradient(to bottom, ${palette.grey[900]}, ${palette.grey[800]})`,
-    color: palette.common.white,
+    // One calm light surface that matches the page — no dark slab.
+    backgroundColor: palette.background.paper,
+    color: palette.text.primary,
+    borderRadius: 16,
+    boxShadow: '0 8px 30px rgba(0, 0, 0, 0.08)',
+    overflow: 'hidden',
   };
 }) as typeof Card;
 

--- a/packages/ui/src/listen/minimalism/music-widget/music-widget.tsx
+++ b/packages/ui/src/listen/minimalism/music-widget/music-widget.tsx
@@ -91,7 +91,7 @@ const MusicWidget = (props: MusicWidgetProps) => {
                 width: '100%',
                 height: '100%',
                 aspectRatio: '1 / 1',
-                objectFit: 'cover',
+                objectFit: 'contain',
               }}
             />
           </Box>
@@ -124,7 +124,7 @@ const MusicWidget = (props: MusicWidgetProps) => {
         </CardContent>
         {isMobile && (
           <Slide
-            direction="down"
+            direction="up"
             in={showPlayinglist}
             container={contentRef.current}
           >

--- a/packages/ui/src/listen/minimalism/music-widget/music-widget.tsx
+++ b/packages/ui/src/listen/minimalism/music-widget/music-widget.tsx
@@ -1,6 +1,5 @@
 import Box from '@mui/material/Box';
 import CardContent from '@mui/material/CardContent';
-import Grid from '@mui/material/Grid';
 import Slide from '@mui/material/Slide';
 import Typography from '@mui/material/Typography';
 import hooks, {
@@ -63,59 +62,59 @@ const MusicWidget = (props: MusicWidgetProps) => {
 
   return (
     <StyledCard role="region" aria-label="music widget">
-      <ResponsiveCardMedia
-        aria-label="audio thumbnail"
-        src={image || defaultAudioThumbnailUrl}
-        alt={name}
-      />
       <StyledContent ref={contentRef}>
-        <CardContent>
-          <Box
-            component={Grid}
-            container
-            justifyContent="space-between"
-            alignItems="center"
-            mb={1}
-          >
-            <Typography
-              role="text"
-              aria-label="now playing"
-              gutterBottom
-              variant="body2"
-              component="p"
-            >
-              {showPlayinglist ? 'Playing list' : 'Now playing'}
-            </Typography>
-            {isMobile && (
+        <CardContent sx={{ pt: 3 }}>
+          {isMobile && (
+            <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 1 }}>
               <PlaylistButton
                 onClick={() => setShowPlayinglist(!showPlayinglist)}
-                sx={{
-                  color: 'white',
-                }}
               />
-            )}
+            </Box>
+          )}
+          <Box
+            sx={{
+              width: 200,
+              maxWidth: '70%',
+              aspectRatio: '1 / 1',
+              mx: 'auto',
+              mb: 3,
+              borderRadius: 3,
+              overflow: 'hidden',
+              boxShadow: 3,
+            }}
+          >
+            <ResponsiveCardMedia
+              aria-label="audio thumbnail"
+              src={image || defaultAudioThumbnailUrl}
+              alt={name}
+            />
           </Box>
           <Typography
             aria-label="audio title"
-            gutterBottom
-            variant="h4"
+            variant="h6"
+            align="center"
             sx={{
-              display: '-webkit-Box',
+              display: '-webkit-box',
               WebkitLineClamp: '1',
               WebkitBoxOrient: 'vertical',
               overflow: 'hidden',
-              textOverflow: 'ellipsisBox',
             }}
           >
             {name}
           </Typography>
-          <Typography aria-label="audio artist" gutterBottom component="p">
+          <Typography
+            aria-label="audio artist"
+            variant="body2"
+            align="center"
+            color="text.secondary"
+            gutterBottom
+          >
             {artistName}
           </Typography>
-        </CardContent>
-        <CardContent>
-          <Seeker {...getSeekerProps()} />
-          <Controls {...controlProps} />
+          <Box sx={{ mt: 2 }}>
+            <Seeker {...getSeekerProps()} />
+            <Controls {...controlProps} />
+          </Box>
         </CardContent>
         {isMobile && (
           <Slide

--- a/packages/ui/src/listen/minimalism/music-widget/music-widget.tsx
+++ b/packages/ui/src/listen/minimalism/music-widget/music-widget.tsx
@@ -87,6 +87,12 @@ const MusicWidget = (props: MusicWidgetProps) => {
               aria-label="audio thumbnail"
               src={image || defaultAudioThumbnailUrl}
               alt={name}
+              sx={{
+                width: '100%',
+                height: '100%',
+                aspectRatio: '1 / 1',
+                objectFit: 'cover',
+              }}
             />
           </Box>
           <Typography
@@ -118,7 +124,7 @@ const MusicWidget = (props: MusicWidgetProps) => {
         </CardContent>
         {isMobile && (
           <Slide
-            direction="up"
+            direction="down"
             in={showPlayinglist}
             container={contentRef.current}
           >

--- a/packages/ui/src/listen/minimalism/music-widget/music-widget.tsx
+++ b/packages/ui/src/listen/minimalism/music-widget/music-widget.tsx
@@ -91,7 +91,7 @@ const MusicWidget = (props: MusicWidgetProps) => {
                 width: '100%',
                 height: '100%',
                 aspectRatio: '1 / 1',
-                objectFit: 'contain',
+                objectFit: 'cover',
               }}
             />
           </Box>


### PR DESCRIPTION
## Summary
- Polish the minimalism **music widget** — controls, seeker, and styling
- Refine the **collection select** and **listening screen** presentation
- Part of the Listen player redesign (SWO-302)

## Test plan
- [ ] Open the preview link and load the Listen home / listening screen
- [ ] Verify player controls (play/pause, seek) look and behave correctly
- [ ] Verify collection select spacing and layout on mobile + desktop

> Note: local `pnpm dev:listen` currently hits a flaky Vite 6 + MUI 5.17 esbuild dep-optimize bug (`createTheme_default is not a function`) that also affects `main` — it is dev-only and does **not** affect this production preview build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ANExKHexbDHFnvgPHnrMnP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Playlist creation is now shown only when available, so signed-out users won’t see the “New playlist…” option.
  * The music player layout has been refreshed for a cleaner, more centered now-playing view.

* **UI Improvements**
  * Playback controls, progress slider, and card styling now follow the app theme more closely.
  * Mobile controls and spacing were adjusted for a smoother, more consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->