### PR TITLE
[WIP] test(listen): drop stale now-playing assertion after player redesign

### DIFF
--- a/apps/listen/e2e/home/common.spec.ts
+++ b/apps/listen/e2e/home/common.spec.ts
@@ -1,4 +1,3 @@
-import { argosScreenshot } from '@argos-ci/playwright';
 import { expect, test } from '@playwright/test';
 
 test.describe('home visual', () => {
@@ -39,10 +38,6 @@ test.describe('home visual', () => {
     await expect(
       widget.getByRole('img', { name: 'audio thumbnail' }),
     ).toBeVisible();
-
-    const nowPlaying = widget.getByLabel('now playing');
-    await expect(nowPlaying).toBeVisible();
-    await expect(nowPlaying).toContainText('Now playing');
 
     await expect(widget.getByLabel('audio title')).toBeVisible();
     await expect(widget.getByLabel('audio artist')).toBeVisible();


### PR DESCRIPTION
## Summary

SWO-302's player beautification (#331) removed the "Now playing" caption from the music widget. The home E2E `music widget visual` test in `apps/listen/e2e/home/common.spec.ts` still asserted `aria-label="now playing"` was visible, so the **Listen E2E job now fails on `main`**.

The redesign shows the current track via the centered **title + artist** — still covered by the adjacent `audio title` / `audio artist` assertions two lines down. So the fix is to drop the three stale `now playing` assertions for the deleted element (not loosen or mask them). Also removed a pre-existing unused `argosScreenshot` import in the same file.

Verified every other handle the three specs reference (thumbnail, title, artist, seeker + start/end/time-indicator, playback-controls group + all buttons, play/pause, mobile toggle-playing-list) is still present in the components — this was the only break.

SWO-303 · follow-up to SWO-302.

## Test plan

- [ ] Listen E2E job green on this PR (runs against the Firebase preview).

🤖 Generated with [Claude Code](https://claude.com/claude-code)