### PR TITLE
fix(listen): consume ui/core source in dev to fix MUI createTheme crash

### DIFF
--- a/apps/listen/vite.config.ts
+++ b/apps/listen/vite.config.ts
@@ -1,8 +1,21 @@
+import { fileURLToPath } from 'node:url';
 import { codecovVitePlugin } from '@codecov/vite-plugin';
 import { TanStackRouterVite } from '@tanstack/router-plugin/vite';
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 import { VitePWA } from 'vite-plugin-pwa';
+
+// In dev, consume the `ui`/`core` workspace packages from SOURCE instead of
+// their built dist. Importing the built dist makes MUI a transitive dep that
+// Vite's optimizer splits across circular chunks, so MUI's Box.js calls
+// createTheme() before its chunk initialises (`createTheme_default is not a
+// function`). From source, Vite optimizes MUI once in the app's own graph
+// (like a normal MUI app) and the circular init resolves. Also gives instant
+// HMR on ui/core edits. Prod build is untouched (see the `serve`-only guard).
+const workspaceSrc = (pkg: string) =>
+  fileURLToPath(new URL(`../../packages/${pkg}/src`, import.meta.url));
+const uiSrc = workspaceSrc('ui');
+const coreSrc = workspaceSrc('core');
 
 /**
  * For debug production build
@@ -17,10 +30,27 @@ import { VitePWA } from 'vite-plugin-pwa';
 const codecovToken = process.env.CODECOV_TOKEN;
 
 // https://github.com/vitejs/vite/issues/5308#issuecomment-1010652389
-export default defineConfig({
+export default defineConfig(({ command }) => ({
   server: {
     port: 3001,
     host: '0.0.0.0',
+  },
+  resolve: {
+    // Dev only: point the workspace packages at their source. The production
+    // build keeps using the built dist, so prod output is unchanged.
+    alias:
+      command === 'serve'
+        ? [
+            { find: /^ui\/(.*)$/, replacement: `${uiSrc}/$1` },
+            { find: /^ui$/, replacement: uiSrc },
+            { find: /^core\/(.*)$/, replacement: `${coreSrc}/$1` },
+            { find: /^core$/, replacement: coreSrc },
+          ]
+        : [],
+    dedupe:
+      command === 'serve'
+        ? ['react', 'react-dom', '@emotion/react', '@emotion/styled']
+        : [],
   },
   // https://stackoverflow.com/a/76694634/8270395
   build: {
@@ -108,4 +138,4 @@ export default defineConfig({
       uploadToken: codecovToken,
     }),
   ],
-});
+}));


### PR DESCRIPTION
## Summary

Local `vite` dev for the Listen app crashed on load with `Uncaught TypeError: createTheme_default is not a function`.

**Root cause:** the app imports the *built* `ui`/`core` dist, which makes MUI a **transitive** dep. Vite's dep-optimizer splits MUI across chunks, and MUI's `Box.js` calls `createTheme()` at module top-level **before** the createTheme chunk initialises (a MUI v5 circular-init issue — the dev twin of the `manualChunks` "App broken if bundle mui separately" note already in this config).

**Fix:** in **dev only** (`command === 'serve'`), alias `ui`/`core` to their **source**, so Vite optimizes MUI once inside the app's own graph (like a normal MUI app) and the circular init resolves. Also gives instant HMR on `ui`/`core` edits. No packages added.

**Prod build untouched:** the `resolve.alias`/`dedupe` apply only in `serve`; `vite build` still consumes the built dist.

## Test plan
- [x] Headless Playwright console probe on `localhost:3001`: **0 `createTheme` errors** (baseline reproduced 1), app renders (`#root` populated).
- [x] `pnpm --filter listen build` → **✓ built** (prod path unchanged).
- [x] Pushed without `--no-verify` (pre-push hook clean).
- [ ] CI green.

Note: this is a dev-DX fix. The permanent root-cause elimination is a MUI v6/v7 upgrade (separate, major) — noted on SWO-309.

SWO-309

🤖 Generated with [Claude Code](https://claude.com/claude-code)