### PR TITLE
refactor(docs): drop MUI from the landing page

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -19,11 +19,7 @@
   "dependencies": {
     "@docusaurus/core": "3.9.2",
     "@docusaurus/preset-classic": "3.9.2",
-    "@emotion/react": "^11.10.5",
-    "@emotion/styled": "^11.10.5",
     "@mdx-js/react": "3.1.1",
-    "@mui/icons-material": "^5.10.9",
-    "@mui/material": "^5.10.12",
     "clsx": "^1.2.1",
     "core": "workspace:*",
     "prism-react-renderer": "^2.1.0",

--- a/apps/docs/src/pages/index.module.css
+++ b/apps/docs/src/pages/index.module.css
@@ -1,11 +1,74 @@
 .techStackSection {
-  padding: 2rem 0;
-  background: #f8f9fa;
+  padding: 3rem 0;
+  background: var(--ifm-background-surface-color);
+}
+
+.techGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 2rem;
+}
+
+@media screen and (max-width: 996px) {
+  .techGrid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media screen and (max-width: 600px) {
+  .techGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.techCardLink {
+  display: block;
+  height: 100%;
+  text-decoration: none;
+  color: inherit;
+}
+
+.techCardLink:hover {
+  text-decoration: none;
+  color: inherit;
 }
 
 .techCard {
   height: 100%;
-  padding: 1.5rem;
+  padding: 2rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  border-radius: 8px;
+  background: var(--ifm-card-background-color, #fff);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+  transition:
+    transform 0.2s ease-in-out,
+    box-shadow 0.2s ease-in-out;
+}
+
+.techCard:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
+}
+
+.techIcon {
+  font-size: 2.5rem;
+  line-height: 1;
+  margin-bottom: 1rem;
+}
+
+.techTitle {
+  margin-bottom: 0.5rem;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.techDescription {
+  margin-bottom: 0;
+  color: var(--ifm-color-emphasis-700);
+  font-size: 0.875rem;
 }
 
 .heroBanner {

--- a/apps/docs/src/pages/index.tsx
+++ b/apps/docs/src/pages/index.tsx
@@ -1,13 +1,5 @@
 import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import AppsIcon from '@mui/icons-material/Apps';
-import ArchitectureIcon from '@mui/icons-material/Architecture';
-import CloudIcon from '@mui/icons-material/Cloud';
-import CodeIcon from '@mui/icons-material/Code';
-import DesignServicesIcon from '@mui/icons-material/DesignServices';
-import SecurityIcon from '@mui/icons-material/Security';
-import StorageIcon from '@mui/icons-material/Storage';
-import { Box, Grid, Paper, Typography } from '@mui/material';
 import Layout from '@theme/Layout';
 import clsx from 'clsx';
 import React from 'react';
@@ -17,33 +9,33 @@ import styles from './index.module.css';
 const techStack = [
   {
     title: 'Hasura GraphQL',
-    icon: <StorageIcon fontSize="large" />,
+    icon: '🗄️',
     description:
       'Instant GraphQL API for rapid development and real-time data access',
     link: '/blog/tags/hasura',
   },
   {
     title: 'Firebase',
-    icon: <CloudIcon fontSize="large" />,
+    icon: '☁️',
     description:
       'Scalable backend infrastructure for hosting, storage, and real-time features',
     link: '/blog/tags/firebase',
   },
   {
     title: 'Auth0',
-    icon: <SecurityIcon fontSize="large" />,
+    icon: '🔒',
     description: 'Enterprise-grade authentication and authorization',
     link: '/blog/tags/auth-0',
   },
   {
     title: 'Serverless',
-    icon: <CloudIcon fontSize="large" />,
+    icon: '⚡',
     description: 'Event-driven architecture with automatic scaling',
     link: '/blog/tags/serverless',
   },
   {
     title: 'PNPM',
-    icon: <AppsIcon fontSize="large" />,
+    icon: '📦',
     description:
       'Fast, disk space efficient package manager with built-in monorepo support',
     // Since there's no PNPM tag yet, we'll point to the docs section
@@ -51,25 +43,18 @@ const techStack = [
   },
   {
     title: 'Monorepo',
-    icon: <ArchitectureIcon fontSize="large" />,
+    icon: '🏗️',
     description:
       'High-performance monorepo management for optimal development workflow',
     link: '/blog/tags/monorepo',
   },
 ];
 
-function HomepageHeader() {
+const HomepageHeader = () => {
   const { siteConfig } = useDocusaurusContext();
   return (
     <header className={clsx('hero hero--primary', styles.heroBanner)}>
       <div className="container">
-        {/* Logo can be added here */}
-        {/* <div className={styles.logo}>
-          <img
-            src="https://res.cloudinary.com/shinabr2/image/upload/v1670251329/Public/Images/sworld-logo-72x72.png"
-            alt={siteConfig.title}
-          />
-        </div> */}
         <h1 className="hero__title">{siteConfig.title}</h1>
         <p className="hero__subtitle">
           Building Modern Web Applications with Enterprise-Grade Architecture
@@ -82,53 +67,29 @@ function HomepageHeader() {
       </div>
     </header>
   );
-}
+};
 
-function TechStackSection() {
+const TechStackSection = () => {
   return (
-    <div className={styles.techStackSection}>
-      <Grid container spacing={4} padding={4}>
-        {techStack.map((tech, idx) => (
-          <Grid item xs={12} sm={6} md={4} key={idx}>
-            <Link
-              to={tech.link}
-              className={styles.techCardLink}
-              style={{ textDecoration: 'none' }}
-            >
-              <Paper
-                elevation={3}
-                className={styles.techCard}
-                sx={{
-                  p: 3,
-                  height: '100%',
-                  display: 'flex',
-                  flexDirection: 'column',
-                  alignItems: 'center',
-                  textAlign: 'center',
-                  transition: 'all 0.2s ease-in-out',
-                  '&:hover': {
-                    transform: 'translateY(-5px)',
-                    boxShadow: '0 8px 16px rgba(0,0,0,0.1)',
-                  },
-                }}
-              >
-                <Box sx={{ color: 'primary.main', mb: 2 }}>{tech.icon}</Box>
-                <Typography variant="h6" component="h3" gutterBottom>
-                  {tech.title}
-                </Typography>
-                <Typography variant="body2" color="text.secondary">
-                  {tech.description}
-                </Typography>
-              </Paper>
-            </Link>
-          </Grid>
+    <section className={styles.techStackSection}>
+      <div className={clsx('container', styles.techGrid)}>
+        {techStack.map((tech) => (
+          <Link key={tech.title} to={tech.link} className={styles.techCardLink}>
+            <div className={styles.techCard}>
+              <span className={styles.techIcon} aria-hidden="true">
+                {tech.icon}
+              </span>
+              <h3 className={styles.techTitle}>{tech.title}</h3>
+              <p className={styles.techDescription}>{tech.description}</p>
+            </div>
+          </Link>
         ))}
-      </Grid>
-    </div>
+      </div>
+    </section>
   );
-}
+};
 
-export default function Home(): JSX.Element {
+const Home = (): JSX.Element => {
   const { siteConfig } = useDocusaurusContext();
   return (
     <Layout
@@ -141,4 +102,6 @@ export default function Home(): JSX.Element {
       </main>
     </Layout>
   );
-}
+};
+
+export default Home;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,21 +35,9 @@ importers:
       '@docusaurus/preset-classic':
         specifier: 3.9.2
         version: 3.9.2(@algolia/client-search@5.54.0)(@mdx-js/react@3.1.1(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.8.2)
-      '@emotion/react':
-        specifier: ^11.10.5
-        version: 11.14.0(@types/react@18.3.18)(react@18.3.1)
-      '@emotion/styled':
-        specifier: ^11.10.5
-        version: 11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)
       '@mdx-js/react':
         specifier: 3.1.1
         version: 3.1.1(@types/react@18.3.18)(react@18.3.1)
-      '@mui/icons-material':
-        specifier: ^5.10.9
-        version: 5.17.1(@mui/material@5.17.1(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)
-      '@mui/material':
-        specifier: ^5.10.12
-        version: 5.17.1(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx:
         specifier: ^1.2.1
         version: 1.2.1
@@ -272,7 +260,7 @@ importers:
         version: 4.3.4(vite@6.2.2(@types/node@18.19.80)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
       rollup-plugin-visualizer:
         specifier: ^5.8.3
-        version: 5.14.0(rollup@4.36.0)
+        version: 5.14.0(rollup@2.79.2)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -25213,6 +25201,15 @@ snapshots:
       rollup: 2.79.2
       serialize-javascript: 4.0.0
       terser: 5.39.0
+
+  rollup-plugin-visualizer@5.14.0(rollup@2.79.2):
+    dependencies:
+      open: 8.4.2
+      picomatch: 4.0.2
+      source-map: 0.7.4
+      yargs: 17.7.2
+    optionalDependencies:
+      rollup: 2.79.2
 
   rollup-plugin-visualizer@5.14.0(rollup@4.36.0):
     dependencies:


### PR DESCRIPTION
## Summary

`apps/docs` is a Docusaurus site that used MUI in exactly one place — the landing "tech stack" grid in `src/pages/index.tsx`. This drops MUI from docs entirely:

- Rewrote `src/pages/index.tsx` with plain Docusaurus + React + CSS modules — semantic HTML (`<section>`, `<h3>`, `<p>`) styled via `index.module.css`, a responsive card grid, and emoji icons in place of `@mui/icons-material`. Kept the existing `Layout`, `Link`, `useDocusaurusContext`, and `techStack` data.
- Removed `@mui/material`, `@mui/icons-material`, `@emotion/react`, and `@emotion/styled` from `apps/docs/package.json`.

Resolves SWO-314.

## Test plan

- [x] `grep -rn "from '@mui" apps/docs/src` → no matches
- [x] `pnpm --filter docs build` → green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Refreshed the docs homepage tech stack section with a cleaner card-based layout and updated icon presentation.
  * Improved responsiveness so the section adapts better across desktop, tablet, and mobile sizes.

* **Bug Fixes**
  * Updated spacing, hover states, and card styling for a more polished and consistent browsing experience.
  * Simplified the homepage structure to keep the page rendering stable while preserving the same visible content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->