### PR TITLE
refactor(til): drop direct @mui/@emotion deps (ui owns MUI)

### DIFF
--- a/apps/til/package.json
+++ b/apps/til/package.json
@@ -13,10 +13,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@emotion/react": "^11.10.5",
-    "@emotion/styled": "^11.10.5",
-    "@mui/icons-material": "^5.10.9",
-    "@mui/material": "^5.10.12",
     "@tanstack/react-router": "^1.78.2",
     "@tiptap/core": "^3.0.0",
     "@tiptap/extension-code-block": "^3.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,18 +322,6 @@ importers:
 
   apps/til:
     dependencies:
-      '@emotion/react':
-        specifier: ^11.10.5
-        version: 11.14.0(@types/react@18.3.18)(react@18.3.1)
-      '@emotion/styled':
-        specifier: ^11.10.5
-        version: 11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)
-      '@mui/icons-material':
-        specifier: ^5.10.9
-        version: 5.17.1(@mui/material@5.17.1(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)
-      '@mui/material':
-        specifier: ^5.10.12
-        version: 5.17.1(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/react-router':
         specifier: ^1.78.2
         version: 1.114.25(react-dom@18.3.1(react@18.3.1))(react@18.3.1)


### PR DESCRIPTION
## Summary
Final step of SWO-313. `apps/til/src` no longer imports `@mui` directly (SWO-315 moved the editor into `ui/til/editor`; SWO-316 routed header/markdown/post-detail through `ui`). Remove til's now-unused direct deps: `@mui/material`, `@mui/icons-material`, `@emotion/react`, `@emotion/styled`. til gets MUI transitively via `ui`.

Together with docs (SWO-314, merged), **MUI is now declared only in `packages/ui`** → unblocks the single-place MUI upgrade (SWO-312).

## Test plan
- [x] `grep -rn "from '@mui" apps/til/src` → no matches (on main).
- [x] `pnpm --filter til build` → green without the deps.
- [ ] CI green.

SWO-317

🤖 Generated with [Claude Code](https://claude.com/claude-code)