### PR TITLE
feat(ui): upgrade MUI v5 → v6, remove dev-alias workaround

### DIFF
--- a/apps/listen/vite.config.ts
+++ b/apps/listen/vite.config.ts
@@ -1,21 +1,8 @@
-import { fileURLToPath } from 'node:url';
 import { codecovVitePlugin } from '@codecov/vite-plugin';
 import { TanStackRouterVite } from '@tanstack/router-plugin/vite';
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 import { VitePWA } from 'vite-plugin-pwa';
-
-// In dev, consume the `ui`/`core` workspace packages from SOURCE instead of
-// their built dist. Importing the built dist makes MUI a transitive dep that
-// Vite's optimizer splits across circular chunks, so MUI's Box.js calls
-// createTheme() before its chunk initialises (`createTheme_default is not a
-// function`). From source, Vite optimizes MUI once in the app's own graph
-// (like a normal MUI app) and the circular init resolves. Also gives instant
-// HMR on ui/core edits. Prod build is untouched (see the `serve`-only guard).
-const workspaceSrc = (pkg: string) =>
-  fileURLToPath(new URL(`../../packages/${pkg}/src`, import.meta.url));
-const uiSrc = workspaceSrc('ui');
-const coreSrc = workspaceSrc('core');
 
 /**
  * For debug production build
@@ -30,27 +17,10 @@ const coreSrc = workspaceSrc('core');
 const codecovToken = process.env.CODECOV_TOKEN;
 
 // https://github.com/vitejs/vite/issues/5308#issuecomment-1010652389
-export default defineConfig(({ command }) => ({
+export default defineConfig({
   server: {
     port: 3001,
     host: '0.0.0.0',
-  },
-  resolve: {
-    // Dev only: point the workspace packages at their source. The production
-    // build keeps using the built dist, so prod output is unchanged.
-    alias:
-      command === 'serve'
-        ? [
-            { find: /^ui\/(.*)$/, replacement: `${uiSrc}/$1` },
-            { find: /^ui$/, replacement: uiSrc },
-            { find: /^core\/(.*)$/, replacement: `${coreSrc}/$1` },
-            { find: /^core$/, replacement: coreSrc },
-          ]
-        : [],
-    dedupe:
-      command === 'serve'
-        ? ['react', 'react-dom', '@emotion/react', '@emotion/styled']
-        : [],
   },
   // https://stackoverflow.com/a/76694634/8270395
   build: {
@@ -138,4 +108,4 @@ export default defineConfig(({ command }) => ({
       uploadToken: codecovToken,
     }),
   ],
-}));
+});

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -73,8 +73,8 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
-    "@mui/icons-material": "^5.10.9",
-    "@mui/material": "^5.10.12",
+    "@mui/icons-material": "^6.0.0",
+    "@mui/material": "^6.0.0",
     "@tanstack/react-router": "^1.78.2",
     "core": "workspace:*",
     "echarts": "^5.6.0",

--- a/packages/ui/src/journal/edit-dialog/index.tsx
+++ b/packages/ui/src/journal/edit-dialog/index.tsx
@@ -41,12 +41,14 @@ const EditDialog = (props: EditDialogProps) => {
       fullWidth
       fullScreen={isMobile}
       maxWidth="sm"
-      PaperProps={{
-        sx: {
-          height: isMobile ? '100vh' : '80vh',
-          display: 'flex',
-          flexDirection: 'column',
-          borderRadius: isMobile ? 0 : undefined,
+      slotProps={{
+        paper: {
+          sx: {
+            height: isMobile ? '100vh' : '80vh',
+            display: 'flex',
+            flexDirection: 'column',
+            borderRadius: isMobile ? 0 : undefined,
+          },
         },
       }}
     >

--- a/packages/ui/src/journal/journal-edit/index.tsx
+++ b/packages/ui/src/journal/journal-edit/index.tsx
@@ -140,7 +140,6 @@ export const JournalEdit: React.FC<JournalEditProps> = ({
           </Typography>
         </Box>
       </Box>
-
       {/* Non-scrollable date + mood controls */}
       <Box
         sx={{
@@ -156,8 +155,10 @@ export const JournalEdit: React.FC<JournalEditProps> = ({
           onChange={(e) => setDate(e.target.value)}
           size="small"
           sx={{ width: '50%' }}
-          InputProps={{
-            sx: { bgcolor: 'action.hover', borderRadius: 1 },
+          slotProps={{
+            input: {
+              sx: { bgcolor: 'action.hover', borderRadius: 1 },
+            },
           }}
         />
 
@@ -209,7 +210,6 @@ export const JournalEdit: React.FC<JournalEditProps> = ({
           </ToggleButton>
         </ToggleButtonGroup>
       </Box>
-
       {/* Scrollable content area */}
       <Box
         sx={{
@@ -319,7 +319,6 @@ export const JournalEdit: React.FC<JournalEditProps> = ({
           </Typography>
         </Box>
       </Box>
-
       {/* Sticky bottom action bar */}
       <Box
         sx={{

--- a/packages/ui/src/listen/minimalism/header/index.test.tsx
+++ b/packages/ui/src/listen/minimalism/header/index.test.tsx
@@ -77,7 +77,9 @@ describe('Header', () => {
     const appBar = screen.getByRole('banner');
     expect(appBar).toHaveClass('MuiAppBar-positionSticky');
     expect(appBar).toHaveClass('MuiAppBar-colorDefault');
-    expect(appBar).toHaveStyle({ boxShadow: 'none' }); // elevation={0}
+    // elevation={0} → MUI applies the Paper elevation-0 class (v6 renders it
+    // via an emotion class, not an inline box-shadow).
+    expect(appBar).toHaveClass('MuiPaper-elevation0');
   });
 
   it('has correct layout structure', () => {

--- a/packages/ui/src/listen/minimalism/listening-screen/index.tsx
+++ b/packages/ui/src/listen/minimalism/listening-screen/index.tsx
@@ -8,7 +8,7 @@ import {
 } from '../collection-select';
 import { Header } from '../header';
 import { AudioList } from '../home/audio-list';
-import { FeelingList, type Feeling } from '../home/feeling-list';
+import { type Feeling, FeelingList } from '../home/feeling-list';
 import { MainContainer } from '../home/main-container';
 import { SettingsPanel } from '../home/settings';
 import { CreatePlaylistDialog } from '../playlists/create-dialog';

--- a/packages/ui/src/listen/minimalism/music-widget/Seeker.tsx
+++ b/packages/ui/src/listen/minimalism/music-widget/Seeker.tsx
@@ -1,6 +1,6 @@
-import { styled, type Theme, useTheme } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Slider from '@mui/material/Slider';
+import { styled, type Theme, useTheme } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
 
 interface Props {

--- a/packages/ui/src/listen/minimalism/music-widget/playing-list.tsx
+++ b/packages/ui/src/listen/minimalism/music-widget/playing-list.tsx
@@ -49,11 +49,13 @@ const PlayingList = (
                 }}
               >
                 <ListItemText
-                  primaryTypographyProps={{
-                    sx: {
-                      whiteSpace: 'nowrap',
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
+                  slotProps={{
+                    primary: {
+                      sx: {
+                        whiteSpace: 'nowrap',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                      },
                     },
                   }}
                 >

--- a/packages/ui/src/main/home-page/add-button/index.tsx
+++ b/packages/ui/src/main/home-page/add-button/index.tsx
@@ -169,16 +169,17 @@ const AddExpenseButton = ({
           <AddIcon />
         </Fab>
       </Zoom>
-
       <Dialog
         open={open}
         onClose={handleClose}
         fullWidth
         maxWidth="xs"
         fullScreen={isMobile}
-        PaperProps={{
-          sx: {
-            borderRadius: isMobile ? 0 : 2,
+        slotProps={{
+          paper: {
+            sx: {
+              borderRadius: isMobile ? 0 : 2,
+            },
           },
         }}
       >
@@ -213,16 +214,18 @@ const AddExpenseButton = ({
                 label="Amount"
                 sx={{ width: '50%' }}
                 type="number"
-                InputProps={{
-                  startAdornment: (
-                    <InputAdornment position="start">$</InputAdornment>
-                  ),
-                }}
                 value={formData.amount}
                 onChange={handleChange}
                 error={!!errors.amount}
                 helperText={errors.amount}
                 disabled={loading}
+                slotProps={{
+                  input: {
+                    startAdornment: (
+                      <InputAdornment position="start">$</InputAdornment>
+                    ),
+                  },
+                }}
               />
 
               <FormControl

--- a/packages/ui/src/til/editor/write-form.tsx
+++ b/packages/ui/src/til/editor/write-form.tsx
@@ -45,10 +45,12 @@ const WriteForm = (props: WriteFormProps) => {
           }
           disabled={isSubmitting}
           variant="standard"
-          InputProps={{
-            style: {
-              fontSize: '1.5rem',
-              fontWeight: 600,
+          slotProps={{
+            input: {
+              style: {
+                fontSize: '1.5rem',
+                fontWeight: 600,
+              },
             },
           }}
         />
@@ -58,10 +60,8 @@ const WriteForm = (props: WriteFormProps) => {
           </Alert>
         )}
       </Container>
-
       {/* Editor */}
       {children}
-
       {/* Footer */}
       <Container
         maxWidth={false}

--- a/packages/ui/src/til/post-detail-page/title-field.tsx
+++ b/packages/ui/src/til/post-detail-page/title-field.tsx
@@ -23,7 +23,9 @@ const PostTitleField = (props: PostTitleFieldProps) => {
         }
         placeholder={placeholder}
         variant="standard"
-        InputProps={{ style: { fontSize: '1.5rem', fontWeight: 600 } }}
+        slotProps={{
+          input: { style: { fontSize: '1.5rem', fontWeight: 600 } },
+        }}
       />
     </Container>
   );

--- a/packages/ui/src/universal/dialogs/login/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/universal/dialogs/login/__snapshots__/index.test.tsx.snap
@@ -6,27 +6,27 @@ exports[`LoginDialog > matches snapshot 1`] = `
     data-testid="dialog"
   >
     <div
-      class="MuiDialogContent-root css-1ebihfo-MuiDialogContent-root"
+      class="MuiDialogContent-root css-10kiv34-MuiDialogContent-root"
     >
       <div
         class="MuiBox-root css-1h93ewi"
       >
         <h5
-          class="MuiTypography-root MuiTypography-h5 css-ag7rrr-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-h5 css-16xl4zq-MuiTypography-root"
         >
           Welcome Back
         </h5>
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary css-1poe5fq-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary css-orhv2b-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
           <span
-            class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1d6wzja-MuiButton-startIcon"
+            class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1sh91j5-MuiButton-startIcon"
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="GoogleIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -37,9 +37,6 @@ exports[`LoginDialog > matches snapshot 1`] = `
             </svg>
           </span>
           FLOW
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </div>
     </div>

--- a/packages/ui/src/watch/dialogs/upload/dialog.tsx
+++ b/packages/ui/src/watch/dialogs/upload/dialog.tsx
@@ -193,7 +193,6 @@ const DialogComponent = (props: DialogComponentProps) => {
           <CloseIcon />
         </StyledCloseButton>
       </DialogTitle>
-
       <DialogContent>
         <Box
           component="form"
@@ -259,14 +258,16 @@ const DialogComponent = (props: DialogComponentProps) => {
           )}
           <TextField
             type="number"
-            InputProps={{
-              inputProps: {
-                min: 0,
-              },
-            }}
             value={videoPositionInPlaylist || 0}
             onChange={onFormFieldChange('videoPositionInPlaylist')}
             {...videoPositionInPlaylistTextFieldProps}
+            slotProps={{
+              input: {
+                inputProps: {
+                  min: 0,
+                },
+              },
+            }}
           />
 
           <Grid container spacing={1} sx={{ mt: 2, mb: 2 }}>

--- a/packages/ui/src/watch/header/index.test.tsx
+++ b/packages/ui/src/watch/header/index.test.tsx
@@ -79,7 +79,9 @@ describe('Header', () => {
     render(<Header {...defaultProps} />);
 
     const appBar = screen.getByRole('banner');
-    expect(appBar).toHaveStyle({ boxShadow: 'none' });
+    // elevation={0} → MUI applies the Paper elevation-0 class (v6 renders it
+    // via an emotion class, not an inline box-shadow, so assert the class).
+    expect(appBar).toHaveClass('MuiPaper-elevation0');
   });
 
   it('uses default color', () => {

--- a/packages/ui/src/watch/home-page/search/index.tsx
+++ b/packages/ui/src/watch/home-page/search/index.tsx
@@ -27,15 +27,18 @@ const HomeSearch = (props: HomeSearchProps) => {
       placeholder="Search videos"
       size="small"
       fullWidth
-      inputProps={{ 'aria-label': 'Search videos' }}
-      InputProps={{
-        startAdornment: (
-          <InputAdornment position="start">
-            <SearchIcon fontSize="small" />
-          </InputAdornment>
-        ),
-      }}
       sx={{ maxWidth: 360 }}
+      slotProps={{
+        input: {
+          startAdornment: (
+            <InputAdornment position="start">
+              <SearchIcon fontSize="small" />
+            </InputAdornment>
+          ),
+        },
+
+        htmlInput: { 'aria-label': 'Search videos' },
+      }}
     />
   );
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,7 +260,7 @@ importers:
         version: 4.3.4(vite@6.2.2(@types/node@18.19.80)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
       rollup-plugin-visualizer:
         specifier: ^5.8.3
-        version: 5.14.0(rollup@2.79.2)
+        version: 5.14.0(rollup@4.36.0)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -544,11 +544,11 @@ importers:
         specifier: ^11.10.5
         version: 11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)
       '@mui/icons-material':
-        specifier: ^5.10.9
-        version: 5.17.1(@mui/material@5.17.1(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)
+        specifier: ^6.0.0
+        version: 6.5.0(@mui/material@6.5.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)
       '@mui/material':
-        specifier: ^5.10.12
-        version: 5.17.1(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^6.0.0
+        version: 6.5.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/react-router':
         specifier: ^1.78.2
         version: 1.114.25(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3410,26 +3410,27 @@ packages:
   '@mikewesthad/dungeon@2.0.1':
     resolution: {integrity: sha512-VfbXkueto+GpAWBk4IpAhDJ15ta/fctkfok4lK+Jxnvs2kUly3RALZnbriLwkez2N4lxaRWN3qrhyWzVWPIE0A==}
 
-  '@mui/core-downloads-tracker@5.17.1':
-    resolution: {integrity: sha512-OcZj+cs6EfUD39IoPBOgN61zf1XFVY+imsGoBDwXeSq2UHJZE3N59zzBOVjclck91Ne3e9gudONOeILvHCIhUA==}
+  '@mui/core-downloads-tracker@6.5.0':
+    resolution: {integrity: sha512-LGb8t8i6M2ZtS3Drn3GbTI1DVhDY6FJ9crEey2lZ0aN2EMZo8IZBZj9wRf4vqbZHaWjsYgtbOnJw5V8UWbmK2Q==}
 
-  '@mui/icons-material@5.17.1':
-    resolution: {integrity: sha512-CN86LocjkunFGG0yPlO4bgqHkNGgaEOEc3X/jG5Bzm401qYw79/SaLrofA7yAKCCXAGdIGnLoMHohc3+ubs95A==}
-    engines: {node: '>=12.0.0'}
+  '@mui/icons-material@6.5.0':
+    resolution: {integrity: sha512-VPuPqXqbBPlcVSA0BmnoE4knW4/xG6Thazo8vCLWkOKusko6DtwFV6B665MMWJ9j0KFohTIf3yx2zYtYacvG1g==}
+    engines: {node: '>=14.0.0'}
     peerDependencies:
-      '@mui/material': ^5.0.0
+      '@mui/material': ^6.5.0
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
 
-  '@mui/material@5.17.1':
-    resolution: {integrity: sha512-2B33kQf+GmPnrvXXweWAx+crbiUEsxCdCN979QDYnlH9ox4pd+0/IBriWLV+l6ORoBF60w39cWjFnJYGFdzXcw==}
-    engines: {node: '>=12.0.0'}
+  '@mui/material@6.5.0':
+    resolution: {integrity: sha512-yjvtXoFcrPLGtgKRxFaH6OQPtcLPhkloC0BML6rBG5UeldR0nPULR/2E2BfXdo5JNV7j7lOzrrLX2Qf/iSidow==}
+    engines: {node: '>=14.0.0'}
     peerDependencies:
       '@emotion/react': ^11.5.0
       '@emotion/styled': ^11.3.0
+      '@mui/material-pigment-css': ^6.5.0
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -3438,12 +3439,14 @@ packages:
         optional: true
       '@emotion/styled':
         optional: true
+      '@mui/material-pigment-css':
+        optional: true
       '@types/react':
         optional: true
 
-  '@mui/private-theming@5.17.1':
-    resolution: {integrity: sha512-XMxU0NTYcKqdsG8LRmSoxERPXwMbp16sIXPcLVgLGII/bVNagX0xaheWAwFv8+zDK7tI3ajllkuD3GZZE++ICQ==}
-    engines: {node: '>=12.0.0'}
+  '@mui/private-theming@6.4.9':
+    resolution: {integrity: sha512-LktcVmI5X17/Q5SkwjCcdOLBzt1hXuc14jYa7NPShog0GBDCDvKtcnP0V7a2s6EiVRlv7BzbWEJzH6+l/zaCxw==}
+    engines: {node: '>=14.0.0'}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -3451,9 +3454,9 @@ packages:
       '@types/react':
         optional: true
 
-  '@mui/styled-engine@5.16.14':
-    resolution: {integrity: sha512-UAiMPZABZ7p8mUW4akDV6O7N3+4DatStpXMZwPlt+H/dA0lt67qawN021MNND+4QTpjaiMYxbhKZeQcyWCbuKw==}
-    engines: {node: '>=12.0.0'}
+  '@mui/styled-engine@6.5.0':
+    resolution: {integrity: sha512-8woC2zAqF4qUDSPIBZ8v3sakj+WgweolpyM/FXf8jAx6FMls+IE4Y8VDZc+zS805J7PRz31vz73n2SovKGaYgw==}
+    engines: {node: '>=14.0.0'}
     peerDependencies:
       '@emotion/react': ^11.4.1
       '@emotion/styled': ^11.3.0
@@ -3464,9 +3467,9 @@ packages:
       '@emotion/styled':
         optional: true
 
-  '@mui/system@5.17.1':
-    resolution: {integrity: sha512-aJrmGfQpyF0U4D4xYwA6ueVtQcEMebET43CUmKMP7e7iFh3sMIF3sBR0l8Urb4pqx1CBjHAaWgB0ojpND4Q3Jg==}
-    engines: {node: '>=12.0.0'}
+  '@mui/system@6.5.0':
+    resolution: {integrity: sha512-XcbBYxDS+h/lgsoGe78ExXFZXtuIlSBpn/KsZq8PtZcIkUNJInkuDqcLd2rVBQrDC1u+rvVovdaWPf2FHKJf3w==}
+    engines: {node: '>=14.0.0'}
     peerDependencies:
       '@emotion/react': ^11.5.0
       '@emotion/styled': ^11.3.0
@@ -3488,9 +3491,9 @@ packages:
       '@types/react':
         optional: true
 
-  '@mui/utils@5.17.1':
-    resolution: {integrity: sha512-jEZ8FTqInt2WzxDV8bhImWBqeQRD99c/id/fq83H0ER9tFl+sfZlaAoCdznGvbSQQ9ividMxqSV2c7cC1vBcQg==}
-    engines: {node: '>=12.0.0'}
+  '@mui/utils@6.4.9':
+    resolution: {integrity: sha512-Y12Q9hbK9g+ZY0T3Rxrx9m2m10gaphDuUMgWxyV5kNJevVxXYCLclYUCC9vXaIk1/NdNDTcW2Yfr2OGvNFNmHg==}
+    engines: {node: '>=14.0.0'}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -16178,23 +16181,23 @@ snapshots:
       core-js: 3.41.0
       seedrandom: 3.0.5
 
-  '@mui/core-downloads-tracker@5.17.1': {}
+  '@mui/core-downloads-tracker@6.5.0': {}
 
-  '@mui/icons-material@5.17.1(@mui/material@5.17.1(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)':
+  '@mui/icons-material@6.5.0(@mui/material@6.5.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.26.10
-      '@mui/material': 5.17.1(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@mui/material': 6.5.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.18
 
-  '@mui/material@5.17.1(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@mui/material@6.5.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.26.10
-      '@mui/core-downloads-tracker': 5.17.1
-      '@mui/system': 5.17.1(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)
+      '@mui/core-downloads-tracker': 6.5.0
+      '@mui/system': 6.5.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)
       '@mui/types': 7.2.24(@types/react@18.3.18)
-      '@mui/utils': 5.17.1(@types/react@18.3.18)(react@18.3.1)
+      '@mui/utils': 6.4.9(@types/react@18.3.18)(react@18.3.1)
       '@popperjs/core': 2.11.8
       '@types/react-transition-group': 4.4.12(@types/react@18.3.18)
       clsx: 2.1.1
@@ -16209,19 +16212,21 @@ snapshots:
       '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)
       '@types/react': 18.3.18
 
-  '@mui/private-theming@5.17.1(@types/react@18.3.18)(react@18.3.1)':
+  '@mui/private-theming@6.4.9(@types/react@18.3.18)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.26.10
-      '@mui/utils': 5.17.1(@types/react@18.3.18)(react@18.3.1)
+      '@mui/utils': 6.4.9(@types/react@18.3.18)(react@18.3.1)
       prop-types: 15.8.1
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.18
 
-  '@mui/styled-engine@5.16.14(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)':
+  '@mui/styled-engine@6.5.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.26.10
       '@emotion/cache': 11.14.0
+      '@emotion/serialize': 1.3.3
+      '@emotion/sheet': 1.4.0
       csstype: 3.1.3
       prop-types: 15.8.1
       react: 18.3.1
@@ -16229,13 +16234,13 @@ snapshots:
       '@emotion/react': 11.14.0(@types/react@18.3.18)(react@18.3.1)
       '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)
 
-  '@mui/system@5.17.1(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)':
+  '@mui/system@6.5.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.26.10
-      '@mui/private-theming': 5.17.1(@types/react@18.3.18)(react@18.3.1)
-      '@mui/styled-engine': 5.16.14(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
+      '@mui/private-theming': 6.4.9(@types/react@18.3.18)(react@18.3.1)
+      '@mui/styled-engine': 6.5.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
       '@mui/types': 7.2.24(@types/react@18.3.18)
-      '@mui/utils': 5.17.1(@types/react@18.3.18)(react@18.3.1)
+      '@mui/utils': 6.4.9(@types/react@18.3.18)(react@18.3.1)
       clsx: 2.1.1
       csstype: 3.1.3
       prop-types: 15.8.1
@@ -16249,7 +16254,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.18
 
-  '@mui/utils@5.17.1(@types/react@18.3.18)(react@18.3.1)':
+  '@mui/utils@6.4.9(@types/react@18.3.18)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.26.10
       '@mui/types': 7.2.24(@types/react@18.3.18)
@@ -25189,15 +25194,6 @@ snapshots:
       rollup: 2.79.2
       serialize-javascript: 4.0.0
       terser: 5.39.0
-
-  rollup-plugin-visualizer@5.14.0(rollup@2.79.2):
-    dependencies:
-      open: 8.4.2
-      picomatch: 4.0.2
-      source-map: 0.7.4
-      yargs: 17.7.2
-    optionalDependencies:
-      rollup: 2.79.2
 
   rollup-plugin-visualizer@5.14.0(rollup@4.36.0):
     dependencies:


### PR DESCRIPTION
## Summary
Upgrade `@mui/material` + `@mui/icons-material` **v5.17.1 → v6** in `packages/ui` — the sole MUI owner after SWO-313. v6 removed the circular-init behind the local-dev `createTheme_default is not a function` crash (SWO-309), so the **#337 dev-only source-alias is removed** from `apps/listen/vite.config.ts` — the upgrade is the real fix.

Ran the official `deprecations/all` codemod (9 `ui` files: `InputProps` → `slotProps.input` etc.). `@emotion` stays v11, React stays 18.

## Verification (evidence-based)
- `ui` `tsc --noEmit`: **0 new type errors** (124 pre-existing baseline unchanged — v6 deprecated, didn't remove, v5 APIs).
- `ui` build green; **all 5 ui-consuming apps build green** (listen/main/watch/game/til).
- Single `@mui@6.5.0` in the tree (no mixed majors).
- **Local dev without the alias** (headless Playwright probe): **0 `createTheme` errors**, app renders.

## Please eyeball
v6 has minor default-style changes that builds/types don't catch — a visual smoke of the main screens is worth a look; CI prod_deploy previews + Listen e2e cover a lot.

SWO-312

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the app to use newer UI library components, helping keep the interface aligned with the latest design system updates.

* **Bug Fixes**
  * Preserved existing dialog, form, search, and list behavior while improving compatibility with newer UI patterns.
  * Kept text truncation, input styling, and dialog layout behavior consistent across screens.

* **Chores**
  * Simplified the app’s local development configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->