### PR TITLE
fix(til): hide post action menu from anonymous visitors

### DIFF
--- a/apps/til/src/routes/posts.$slug.$id.tsx
+++ b/apps/til/src/routes/posts.$slug.$id.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, useBlocker } from '@tanstack/react-router';
+import { Auth } from 'core';
 import { POST_STATUS, POST_VISIBILITY } from 'core/til/constants';
 import { useUpdatePost } from 'core/til/mutation-hooks/updatePost';
 import { useLoadPostDetail } from 'core/til/query-hooks/post-detail';
@@ -28,6 +29,7 @@ const TipTapEditor = lazy(() => import('../components/editor/tiptap-editor'));
 
 const RouteComponent = () => {
   const { id: postId } = Route.useParams();
+  const { isSignedIn } = Auth.useAuthContext();
   const queryRs = useLoadPostDetail(postId);
   const { post, isLoading, refetch } = queryRs;
   const [isEditing, setIsEditing] = useState(false);
@@ -264,7 +266,7 @@ const RouteComponent = () => {
             menuAnchorEl={menuAnchorEl}
             onMenuOpen={handleMenuOpen}
             onMenuClose={handleMenuClose}
-            actions={menuActions}
+            actions={isSignedIn ? menuActions : []}
           />
           <PostContent>
             <MarkdownContent content={mContent} />

--- a/packages/ui/src/til/post-detail-page/actions-menu.tsx
+++ b/packages/ui/src/til/post-detail-page/actions-menu.tsx
@@ -18,6 +18,10 @@ interface PostActionsMenuProps {
 const PostActionsMenu = (props: PostActionsMenuProps) => {
   const { anchorEl, onOpen, onClose, actions } = props;
 
+  if (actions.length === 0) {
+    return null;
+  }
+
   return (
     <>
       <IconButton onClick={onOpen} size="small">


### PR DESCRIPTION
## Summary

On the TIL post detail page, the post actions menu (the `MoreVert` button → Edit / Publish / Make Public·Private / Pin) was shown to anonymous / logged-out visitors. These are owner-only management actions and must only appear for signed-in users. Fixes SWO-319.

The fix has two parts:
- `packages/ui/src/til/post-detail-page/actions-menu.tsx` — `PostActionsMenu` now returns `null` when `actions` is empty, so no `IconButton`/`MoreVert` renders.
- `apps/til/src/routes/posts.$slug.$id.tsx` — reads `isSignedIn` from `Auth.useAuthContext()` and passes `actions={isSignedIn ? menuActions : []}` to `PostViewHeader`.

Logged out → `isSignedIn` false → `actions=[]` → `PostActionsMenu` returns null → no MoreVert button. Signed in → menu shows as before.

## Test plan

- [x] `pnpm --filter ui build` → green
- [x] `pnpm --filter til build` → green
- [ ] Manually: open a public post while logged out → no MoreVert button; log in → menu appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)