### PR TITLE
feat(listen): polish homepage panels and placeholders

### DIFF
--- a/packages/ui/src/listen/minimalism/home/audio-list.tsx
+++ b/packages/ui/src/listen/minimalism/home/audio-list.tsx
@@ -6,6 +6,7 @@ import { lazy, Suspense, useEffect, useMemo, useState } from 'react';
 import { useIsMobile } from '../../../universal/responsive';
 import MusicWidget from '../music-widget';
 import { MusicWidgetSkeleton } from '../music-widget/music-widget-skeleton';
+import { panelSurface } from '../music-widget/Styled';
 import { PlayingListSkeleton } from './playing-list-skeleton';
 
 const { useSAudioPlayer } = hooks;
@@ -91,7 +92,16 @@ const Content = (props: AudioListProps) => {
     <Grid container spacing={2}>
       {showPlayingList && (
         <Grid item md={8} sm={6} xs={0}>
-          <Card sx={{ height: '100%', maxHeight: '462px', overflowY: 'auto' }}>
+          <Card
+            elevation={0}
+            sx={{
+              height: '100%',
+              maxHeight: '462px',
+              overflowY: 'auto',
+              // Same soft surface as the player card — one panel language.
+              ...panelSurface,
+            }}
+          >
             <Suspense fallback={<PlayingListSkeleton />}>
               <PlayingList
                 audioList={list}

--- a/packages/ui/src/listen/minimalism/home/playing-list.test.tsx
+++ b/packages/ui/src/listen/minimalism/home/playing-list.test.tsx
@@ -64,8 +64,8 @@ describe('PlayingList Component', () => {
       backgroundColor: 'action.selected',
     });
 
-    // Check "Now Playing" text appears for current track
-    expect(screen.getByText('• Now Playing')).toBeInTheDocument();
+    // The now-playing row shows the equalizer, labelled for screen readers.
+    expect(screen.getByText('Now Playing')).toBeInTheDocument();
   });
 
   it('calls onItemSelect when a track is clicked', () => {

--- a/packages/ui/src/listen/minimalism/home/playing-list.tsx
+++ b/packages/ui/src/listen/minimalism/home/playing-list.tsx
@@ -4,9 +4,68 @@ import ListItemAvatar from '@mui/material/ListItemAvatar';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemText from '@mui/material/ListItemText';
 import Stack from '@mui/material/Stack';
+import { keyframes } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
 import type { SAudioPlayerAudioItem } from 'core';
 import { ResponsiveAvatar } from '../../../universal';
+
+// Three bars dancing at their own tempo — the "this one is playing" signal that
+// reads without needing the text label. Purely decorative; the accessible
+// "Now Playing" label lives in visually-hidden text alongside it.
+const equalize = keyframes`
+  0%, 100% { transform: scaleY(0.35); }
+  50% { transform: scaleY(1); }
+`;
+
+// Off-screen but readable by screen readers — the standard sr-only pattern.
+const srOnly = {
+  position: 'absolute',
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: 'hidden',
+  clip: 'rect(0 0 0 0)',
+  whiteSpace: 'nowrap',
+  border: 0,
+} as const;
+
+const NowPlayingIndicator = () => (
+  <>
+    <Box
+      component="span"
+      aria-hidden
+      sx={{
+        display: 'inline-flex',
+        alignItems: 'flex-end',
+        gap: '2px',
+        height: 12,
+      }}
+    >
+      {[0, 1, 2].map((i) => (
+        <Box
+          key={i}
+          component="span"
+          sx={{
+            width: '3px',
+            height: '100%',
+            borderRadius: '2px',
+            bgcolor: 'primary.main',
+            transformOrigin: 'bottom',
+            animation: `${equalize} 0.9s ease-in-out ${i * 0.18}s infinite`,
+          }}
+        />
+      ))}
+    </Box>
+    <Box component="span" sx={srOnly}>
+      Now Playing
+    </Box>
+  </>
+);
+
+// A song with no artwork gets a theme-tinted tile with its initial — never the
+// grey silhouette that reads as "failed to load".
+const initialOf = (name: string) => name?.trim().charAt(0).toUpperCase() || '♪';
 
 interface PlayingListItemProps {
   audioList: SAudioPlayerAudioItem[];
@@ -35,10 +94,26 @@ const Item = (props: ItemProps) => {
       onClick={() => onSelect(id)}
     >
       <ListItemAvatar>
-        <ResponsiveAvatar src={image} alt={name} variant="rounded" />
+        <ResponsiveAvatar
+          src={image}
+          alt={name}
+          variant="rounded"
+          sx={{
+            bgcolor: image ? undefined : 'primary.light',
+            color: 'primary.dark',
+            fontWeight: 600,
+          }}
+        >
+          {initialOf(name)}
+        </ResponsiveAvatar>
       </ListItemAvatar>
       <ListItemText
         primary={name}
+        primaryTypographyProps={{
+          fontWeight: 600,
+          color: isPlaying ? 'primary.main' : 'text.primary',
+          noWrap: true,
+        }}
         secondary={
           <Stack
             component="span"
@@ -46,17 +121,10 @@ const Item = (props: ItemProps) => {
             spacing={1}
             alignItems="center"
           >
-            <Typography component="span" variant="body2">
+            <Typography component="span" variant="body2" color="text.secondary">
               {artistName}
             </Typography>
-            {isPlaying && (
-              <Box
-                component="span"
-                sx={{ display: 'inline-flex', alignItems: 'center' }}
-              >
-                • Now Playing
-              </Box>
-            )}
+            {isPlaying && <NowPlayingIndicator />}
           </Stack>
         }
       />

--- a/packages/ui/src/listen/minimalism/music-widget/Styled.tsx
+++ b/packages/ui/src/listen/minimalism/music-widget/Styled.tsx
@@ -4,6 +4,15 @@ import { keyframes, styled } from '@mui/material/styles';
 
 const cardWidth = 345;
 
+// The one panel language for the listen screen. Both the player card and the
+// song list share this soft surface so they read as the same app — string
+// literals so the identical values are valid in both a styled() block and an
+// sx prop (where a numeric borderRadius would be multiplied by the theme).
+const panelSurface = {
+  borderRadius: '16px',
+  boxShadow: '0 8px 30px rgba(0, 0, 0, 0.08)',
+} as const;
+
 const StyledCard = styled(Card)<CardProps>(({ theme }) => {
   const { palette } = theme;
 
@@ -16,8 +25,7 @@ const StyledCard = styled(Card)<CardProps>(({ theme }) => {
     // One calm light surface that matches the page — no dark slab.
     backgroundColor: palette.background.paper,
     color: palette.text.primary,
-    borderRadius: 16,
-    boxShadow: '0 8px 30px rgba(0, 0, 0, 0.08)',
+    ...panelSurface,
     overflow: 'hidden',
   };
 }) as typeof Card;
@@ -49,4 +57,10 @@ const pulseAnimation = keyframes`
   100% { opacity: 0.6 }
 `;
 
-export { StyledCard, StyledContent, StyledPlayingList, pulseAnimation };
+export {
+  StyledCard,
+  StyledContent,
+  StyledPlayingList,
+  pulseAnimation,
+  panelSurface,
+};

--- a/packages/ui/src/listen/minimalism/music-widget/music-widget.tsx
+++ b/packages/ui/src/listen/minimalism/music-widget/music-widget.tsx
@@ -1,3 +1,4 @@
+import MusicNoteRounded from '@mui/icons-material/MusicNoteRounded';
 import Box from '@mui/material/Box';
 import CardContent from '@mui/material/CardContent';
 import Slide from '@mui/material/Slide';
@@ -8,7 +9,6 @@ import hooks, {
 } from 'core';
 import { useRef, useState } from 'react';
 import { ResponsiveCardMedia } from '../../../universal';
-import { defaultAudioThumbnailUrl } from '../../../universal/images/default-thumbnail';
 import { useIsMobile } from '../../../universal/responsive';
 import Controls from './Controls';
 import PlaylistButton from './PlaylistButton';
@@ -61,7 +61,7 @@ const MusicWidget = (props: MusicWidgetProps) => {
   };
 
   return (
-    <StyledCard role="region" aria-label="music widget">
+    <StyledCard component="section" aria-label="music widget">
       <StyledContent ref={contentRef}>
         <CardContent sx={{ pt: 3 }}>
           {isMobile && (
@@ -83,17 +83,44 @@ const MusicWidget = (props: MusicWidgetProps) => {
               boxShadow: 3,
             }}
           >
-            <ResponsiveCardMedia
-              aria-label="audio thumbnail"
-              src={image || defaultAudioThumbnailUrl}
-              alt={name}
-              sx={{
-                width: '100%',
-                height: '100%',
-                aspectRatio: '1 / 1',
-                objectFit: 'cover',
-              }}
-            />
+            {image ? (
+              <ResponsiveCardMedia
+                aria-label="audio thumbnail"
+                src={image}
+                alt={name}
+                sx={{
+                  width: '100%',
+                  height: '100%',
+                  aspectRatio: '1 / 1',
+                  objectFit: 'cover',
+                }}
+              />
+            ) : (
+              // No artwork: a calm theme-tinted panel, never a grey hole. It's
+              // a composite graphic (gradient + note), so role="img" is correct
+              // here — there's no real <img> to use a semantic element for.
+              <Box
+                role="img"
+                aria-label="audio thumbnail"
+                sx={{
+                  width: '100%',
+                  height: '100%',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  background: (theme) =>
+                    `linear-gradient(135deg, ${theme.palette.primary.light}, ${theme.palette.primary.main})`,
+                }}
+              >
+                <MusicNoteRounded
+                  sx={{
+                    fontSize: 88,
+                    color: 'primary.contrastText',
+                    opacity: 0.9,
+                  }}
+                />
+              </Box>
+            )}
           </Box>
           <Typography
             aria-label="audio title"

--- a/packages/ui/src/universal/images/default-thumbnail.ts
+++ b/packages/ui/src/universal/images/default-thumbnail.ts
@@ -1,4 +1,3 @@
 const defaultThumbnailUrl = `data:image/svg+xml,${encodeURIComponent(`<svg viewBox="0 0 1920 1080" xmlns="http://www.w3.org/2000/svg"><rect width="1920" height="1080" fill="#f0f0f0"/><circle cx="960" cy="540" r="100" fill="#e0e0e0"/><path d="M920 480 L1020 540 L920 600 Z" fill="#9e9e9e"/><path d="M0 200 Q 480 400 960 200 T 1920 200" stroke="#e8e8e8" fill="none" stroke-width="40"/><path d="M0 800 Q 480 600 960 800 T 1920 800" stroke="#e8e8e8" fill="none" stroke-width="40"/></svg>`)}`;
-const defaultAudioThumbnailUrl = `data:image/svg+xml,${encodeURIComponent(`<svg viewBox="0 0 1920 1080" xmlns="http://www.w3.org/2000/svg"><rect width="1920" height="1080" fill="#f0f0f0"/><path d="M0 200 Q 480 400 960 200 T 1920 200" stroke="#e8e8e8" fill="none" stroke-width="40"/><path d="M0 800 Q 480 600 960 800 T 1920 800" stroke="#e8e8e8" fill="none" stroke-width="40"/></svg>`)}`;
 
-export { defaultAudioThumbnailUrl, defaultThumbnailUrl };
+export { defaultThumbnailUrl };


### PR DESCRIPTION
## Summary

Tightens the listen homepage so its generous spacing reads as intentional, not empty — without touching the layout, spacing, or primary color. Everything is theme-driven.

- **One panel language** — the song list now shares the player card's soft surface (`panelSurface`: 16px radius + soft shadow), instead of the harder default-elevation box.
- **No more placeholder holes** — songs with no artwork get a primary-tinted tile with their initial (rows) and a primary-gradient + music-note (player), replacing the grey "unloaded"-looking SVGs.
- **Type hierarchy** — bolder titles, muted artists; the now-playing row's title picks up the primary color with a small animated equalizer.
- **A11y preserved** — equalizer is decorative with a visually-hidden "Now Playing" label; the widget's `role="region"` becomes a semantic `<section>`. Removes the now-unused `defaultAudioThumbnailUrl`.

Before/after and rationale discussed with the owner; scope is `packages/ui` listen only.

## Test plan

- `pnpm test` — 36 listen unit tests pass (updated the now-playing assertion).
- `pnpm build --filter=listen` — typechecks and builds clean.
- E2E assertions preserved: `region: music widget`, `img: audio thumbnail` (placeholder now carries `role="img"`), and `Now Playing` text.
- Verified visually in a local dev build (see conversation screenshot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)