### PR TITLE
[WIP] feat(watch): route via in-memory history in standalone mode (SWO-330)

### DIFF
--- a/apps/watch/src/main.tsx
+++ b/apps/watch/src/main.tsx
@@ -1,4 +1,8 @@
-import { createRouter, RouterProvider } from '@tanstack/react-router';
+import {
+  createMemoryHistory,
+  createRouter,
+  RouterProvider,
+} from '@tanstack/react-router';
 import { Auth, ErrorBoundary, Query } from 'core';
 import React, { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
@@ -11,13 +15,23 @@ import {
   validateEnvVars,
 } from './config';
 import { routeTree } from './routeTree.gen';
+import { readStandaloneCache } from './standalone-mode';
 
 // Trigger a production build to verify the Cloudflare Pages deploy pipeline.
 validateEnvVars();
 
+// In standalone mode the router runs on in-memory history so navigation never
+// changes the URL or grows the browser history stack, and a refresh always
+// lands on home (SWO-326). Decided synchronously at boot from the localStorage
+// cache; the default (browser history) is unchanged when off.
+const standalone = readStandaloneCache();
+
 // @ts-expect-error
 const router = createRouter({
   routeTree,
+  history: standalone
+    ? createMemoryHistory({ initialEntries: ['/'] })
+    : undefined,
   defaultViewTransition: true,
   defaultPreload: 'intent',
   scrollRestoration: true,

--- a/apps/watch/src/main.tsx
+++ b/apps/watch/src/main.tsx
@@ -17,7 +17,6 @@ import {
 import { routeTree } from './routeTree.gen';
 import { readStandaloneCache } from './standalone-mode';
 
-// Trigger a production build to verify the Cloudflare Pages deploy pipeline.
 validateEnvVars();
 
 // In standalone mode the router runs on in-memory history so navigation never

--- a/apps/watch/src/standalone-mode.ts
+++ b/apps/watch/src/standalone-mode.ts
@@ -1,0 +1,19 @@
+// Standalone mode runs the Watch app on in-memory router history so navigation
+// never touches the browser URL or history stack — the app behaves like a
+// native app (SWO-326). The DB (`users.settings.watch.standaloneMode`) is the
+// source of truth; this localStorage entry is a synchronous cache read at boot
+// to pick the router history before the async DB value can arrive. The DB value
+// reconciles into this cache after auth (SWO-332).
+const STANDALONE_STORAGE_KEY = 'watch:standalone';
+
+const readStandaloneCache = (): boolean => {
+  try {
+    return localStorage.getItem(STANDALONE_STORAGE_KEY) === 'true';
+  } catch {
+    // localStorage can throw (private mode, disabled storage) — fall back to
+    // the default (browser history) rather than break boot.
+    return false;
+  }
+};
+
+export { STANDALONE_STORAGE_KEY, readStandaloneCache };


### PR DESCRIPTION
## Summary

First slice of the Watch **standalone (no-URL) app mode** (parent SWO-326). When standalone mode is enabled, the TanStack router runs on **in-memory history** (`createMemoryHistory`) instead of browser history, so navigating between videos/playlists never changes the URL or grows the browser history stack, and a refresh always lands on home. This is a drop-in history swap — **no route/link/page changes**.

The mode is read **synchronously at boot** from a `localStorage` cache (`watch:standalone`). This PR only wires the mechanism; the settings toggle that writes the value (SWO-331) and the DB→cache reconciliation + conflict popup (SWO-332) come next. A new `standalone-mode.ts` holds the cache key + reader, shared by those follow-ups.

**Default is off** → behavior is identical to today.

## Test plan

- [x] `turbo build --filter=watch` passes; biome clean on new file.
- [x] Verified locally earlier: with `localStorage['watch:standalone']='true'`, clicking through videos/playlists keeps `location.pathname` at `/` and `history.length` flat; browser back does not leave the app.
- [x] With the flag absent, URL/history behavior unchanged.

SWO-330

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Watch app now supports a standalone startup mode and can launch with the appropriate navigation behavior automatically.
* **Bug Fixes**
  * Improved startup resilience by safely handling cases where browser storage is unavailable or restricted.
  * Ensured the app falls back to a default navigation setup when standalone mode is not enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->