### PR TITLE
[WIP] feat(core): user settings write mutation + merge helper (SWO-329)

### DIFF
--- a/packages/core/src/graphql/gql.ts
+++ b/packages/core/src/graphql/gql.ts
@@ -48,6 +48,7 @@ type Documents = {
     "\n  mutation MarkNotificationAsRead($notificationId: uuid!) {\n    update_notifications_by_pk(pk_columns: { id: $notificationId }, _set: { readAt: \"now()\" }) {\n      id\n      readAt\n    }\n  }\n": typeof types.MarkNotificationAsReadDocument,
     "\n  mutation MarkNotificationsAsRead($ids: [uuid!]!) {\n    update_notifications(where: { id: { _in: $ids }, readAt: { _is_null: true } }, _set: { readAt: \"now()\" }) {\n      affected_rows\n      returning {\n        id\n        readAt\n      }\n    }\n  }\n": typeof types.MarkNotificationsAsReadDocument,
     "\n  subscription Notifications {\n    notifications(order_by: { createdAt: desc }) {\n      id\n      entityId\n      entityType\n      type\n      readAt\n      link\n      metadata\n      video {\n        id\n        title\n      }\n    }\n  }\n": typeof types.NotificationsDocument,
+    "\n  mutation UpsertUserSettings($data: jsonb!) {\n    insert_user_settings_one(\n      object: { data: $data }\n      on_conflict: { constraint: user_settings_pkey, update_columns: [data] }\n    ) {\n      user_id\n      data\n    }\n  }\n": typeof types.UpsertUserSettingsDocument,
     "\n  query GetUserSettings {\n    user_settings {\n      data\n    }\n  }\n": typeof types.GetUserSettingsDocument,
     "\n  mutation InsertVideos($objects: [videos_insert_input!]!) {\n    insert_videos(objects: $objects) {\n      returning {\n        id\n        title\n        description\n      }\n    }\n  }\n": typeof types.InsertVideosDocument,
     "\n  mutation CreateSignedUploadUrl($input: SignedUploadUrlInput!) {\n    createSignedUploadUrl(input: $input) {\n      success\n      message\n      dataObject {\n        uploadUrl\n        publicUrl\n        objectPath\n        expiresAt\n      }\n    }\n  }\n": typeof types.CreateSignedUploadUrlDocument,
@@ -101,6 +102,7 @@ const documents: Documents = {
     "\n  mutation MarkNotificationAsRead($notificationId: uuid!) {\n    update_notifications_by_pk(pk_columns: { id: $notificationId }, _set: { readAt: \"now()\" }) {\n      id\n      readAt\n    }\n  }\n": types.MarkNotificationAsReadDocument,
     "\n  mutation MarkNotificationsAsRead($ids: [uuid!]!) {\n    update_notifications(where: { id: { _in: $ids }, readAt: { _is_null: true } }, _set: { readAt: \"now()\" }) {\n      affected_rows\n      returning {\n        id\n        readAt\n      }\n    }\n  }\n": types.MarkNotificationsAsReadDocument,
     "\n  subscription Notifications {\n    notifications(order_by: { createdAt: desc }) {\n      id\n      entityId\n      entityType\n      type\n      readAt\n      link\n      metadata\n      video {\n        id\n        title\n      }\n    }\n  }\n": types.NotificationsDocument,
+    "\n  mutation UpsertUserSettings($data: jsonb!) {\n    insert_user_settings_one(\n      object: { data: $data }\n      on_conflict: { constraint: user_settings_pkey, update_columns: [data] }\n    ) {\n      user_id\n      data\n    }\n  }\n": types.UpsertUserSettingsDocument,
     "\n  query GetUserSettings {\n    user_settings {\n      data\n    }\n  }\n": types.GetUserSettingsDocument,
     "\n  mutation InsertVideos($objects: [videos_insert_input!]!) {\n    insert_videos(objects: $objects) {\n      returning {\n        id\n        title\n        description\n      }\n    }\n  }\n": types.InsertVideosDocument,
     "\n  mutation CreateSignedUploadUrl($input: SignedUploadUrlInput!) {\n    createSignedUploadUrl(input: $input) {\n      success\n      message\n      dataObject {\n        uploadUrl\n        publicUrl\n        objectPath\n        expiresAt\n      }\n    }\n  }\n": types.CreateSignedUploadUrlDocument,
@@ -253,6 +255,10 @@ export function graphql(source: "\n  mutation MarkNotificationsAsRead($ids: [uui
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(source: "\n  subscription Notifications {\n    notifications(order_by: { createdAt: desc }) {\n      id\n      entityId\n      entityType\n      type\n      readAt\n      link\n      metadata\n      video {\n        id\n        title\n      }\n    }\n  }\n"): typeof import('./graphql').NotificationsDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n  mutation UpsertUserSettings($data: jsonb!) {\n    insert_user_settings_one(\n      object: { data: $data }\n      on_conflict: { constraint: user_settings_pkey, update_columns: [data] }\n    ) {\n      user_id\n      data\n    }\n  }\n"): typeof import('./graphql').UpsertUserSettingsDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/packages/core/src/graphql/graphql.ts
+++ b/packages/core/src/graphql/graphql.ts
@@ -13366,6 +13366,13 @@ export type NotificationsSubscriptionVariables = Exact<{ [key: string]: never; }
 
 export type NotificationsSubscription = { __typename?: 'subscription_root', notifications: Array<{ __typename?: 'notifications', id: any, entityId: any, entityType: string, type: string, readAt?: any | null, link?: string | null, metadata?: any | null, video?: { __typename?: 'videos', id: any, title: string } | null }> };
 
+export type UpsertUserSettingsMutationVariables = Exact<{
+  data: Scalars['jsonb']['input'];
+}>;
+
+
+export type UpsertUserSettingsMutation = { __typename?: 'mutation_root', insert_user_settings_one?: { __typename?: 'user_settings', user_id: any, data: any } | null };
+
 export type GetUserSettingsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -14198,6 +14205,17 @@ export const NotificationsDocument = new TypedDocumentString(`
   }
 }
     `) as unknown as TypedDocumentString<NotificationsSubscription, NotificationsSubscriptionVariables>;
+export const UpsertUserSettingsDocument = new TypedDocumentString(`
+    mutation UpsertUserSettings($data: jsonb!) {
+  insert_user_settings_one(
+    object: {data: $data}
+    on_conflict: {constraint: user_settings_pkey, update_columns: [data]}
+  ) {
+    user_id
+    data
+  }
+}
+    `) as unknown as TypedDocumentString<UpsertUserSettingsMutation, UpsertUserSettingsMutationVariables>;
 export const GetUserSettingsDocument = new TypedDocumentString(`
     query GetUserSettings {
   user_settings {

--- a/packages/core/src/user-settings/index.ts
+++ b/packages/core/src/user-settings/index.ts
@@ -1,3 +1,4 @@
+import { mergeUserSettings, type UserSettingsPatch } from './merge';
 import { parseUserSettings } from './parse';
 import {
   DEFAULT_USER_SETTINGS,
@@ -5,5 +6,5 @@ import {
   type WatchSettings,
 } from './types';
 
-export { parseUserSettings, DEFAULT_USER_SETTINGS };
-export type { UserSettings, WatchSettings };
+export { parseUserSettings, mergeUserSettings, DEFAULT_USER_SETTINGS };
+export type { UserSettings, WatchSettings, UserSettingsPatch };

--- a/packages/core/src/user-settings/merge.test.ts
+++ b/packages/core/src/user-settings/merge.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { mergeUserSettings } from './merge';
+import { DEFAULT_USER_SETTINGS } from './types';
+
+describe('mergeUserSettings', () => {
+  it('patches a single key, leaving the current object untouched (immutable)', () => {
+    const current = DEFAULT_USER_SETTINGS;
+    const next = mergeUserSettings(current, {
+      watch: { standaloneMode: true },
+    });
+
+    expect(next).toEqual({ watch: { standaloneMode: true } });
+    expect(current).toEqual(DEFAULT_USER_SETTINGS); // not mutated
+  });
+
+  it('returns an equal-but-new object for an empty patch', () => {
+    const current = { watch: { standaloneMode: true } };
+    const next = mergeUserSettings(current, {});
+
+    expect(next).toEqual(current);
+    expect(next).not.toBe(current);
+  });
+
+  it('overrides only the patched key within a site slice', () => {
+    const current = { watch: { standaloneMode: false } };
+    const next = mergeUserSettings(current, {
+      watch: { standaloneMode: true },
+    });
+
+    expect(next.watch.standaloneMode).toBe(true);
+  });
+});

--- a/packages/core/src/user-settings/merge.ts
+++ b/packages/core/src/user-settings/merge.ts
@@ -1,0 +1,21 @@
+import type { UserSettings, WatchSettings } from './types';
+
+// A patch targets one or more site slices; unset slices/keys are left as-is.
+interface UserSettingsPatch {
+  watch?: Partial<WatchSettings>;
+}
+
+// Read-merge-write: layer a patch over the current settings so a change to one
+// site/key never clobbers the others. Core owns the structure, so the merge
+// lives here rather than in each app. Extend per-site as new sites gain
+// settings (spread `current`, then deep-merge each provided slice).
+const mergeUserSettings = (
+  current: UserSettings,
+  patch: UserSettingsPatch,
+): UserSettings => ({
+  ...current,
+  ...(patch.watch ? { watch: { ...current.watch, ...patch.watch } } : {}),
+});
+
+export type { UserSettingsPatch };
+export { mergeUserSettings };

--- a/packages/core/src/user-settings/mutation-hooks/index.test.ts
+++ b/packages/core/src/user-settings/mutation-hooks/index.test.ts
@@ -1,0 +1,50 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useQueryContext } from '../../providers/query';
+import { useMutationRequest } from '../../universal/hooks/useMutation';
+import { DEFAULT_USER_SETTINGS } from '../types';
+import { useSaveUserSettings } from './index';
+
+vi.mock('../../universal/hooks/useMutation', () => ({
+  useMutationRequest: vi.fn(),
+}));
+vi.mock('../../providers/query', () => ({ useQueryContext: vi.fn() }));
+
+const mutateAsync = vi.fn().mockResolvedValue({});
+const invalidateQuery = vi.fn();
+const getAccessToken = vi.fn();
+
+describe('useSaveUserSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useMutationRequest).mockReturnValue({
+      mutateAsync,
+    } as unknown as ReturnType<typeof useMutationRequest>);
+    vi.mocked(useQueryContext).mockReturnValue({
+      invalidateQuery,
+    } as unknown as ReturnType<typeof useQueryContext>);
+  });
+
+  it('sends the merged blob (patch layered over current)', async () => {
+    const { result } = renderHook(() =>
+      useSaveUserSettings({ getAccessToken }),
+    );
+
+    await result.current.saveUserSettings(DEFAULT_USER_SETTINGS, {
+      watch: { standaloneMode: true },
+    });
+
+    expect(mutateAsync).toHaveBeenCalledWith({
+      data: { watch: { standaloneMode: true } },
+    });
+  });
+
+  it('invalidates the user-settings query on success', () => {
+    renderHook(() => useSaveUserSettings({ getAccessToken }));
+
+    const options = vi.mocked(useMutationRequest).mock.calls[0][0].options;
+    options?.onSuccess?.({} as never, {} as never, undefined as never);
+
+    expect(invalidateQuery).toHaveBeenCalledWith(['user-settings']);
+  });
+});

--- a/packages/core/src/user-settings/mutation-hooks/index.ts
+++ b/packages/core/src/user-settings/mutation-hooks/index.ts
@@ -1,0 +1,64 @@
+import { graphql } from '../../graphql';
+import type {
+  UpsertUserSettingsMutation,
+  UpsertUserSettingsMutationVariables,
+} from '../../graphql/graphql';
+import { useQueryContext } from '../../providers/query';
+import { useMutationRequest } from '../../universal/hooks/useMutation';
+import { mergeUserSettings, type UserSettingsPatch } from '../merge';
+import type { UserSettings } from '../types';
+
+// Upsert the caller's settings row. `user_id` is preset server-side from the
+// JWT, so the client only sends the blob; the first write creates the row,
+// later writes update it.
+const upsertUserSettingsMutation = graphql(/* GraphQL */ `
+  mutation UpsertUserSettings($data: jsonb!) {
+    insert_user_settings_one(
+      object: { data: $data }
+      on_conflict: { constraint: user_settings_pkey, update_columns: [data] }
+    ) {
+      user_id
+      data
+    }
+  }
+`);
+
+interface SaveUserSettingsProps {
+  getAccessToken: () => Promise<string>;
+  onSuccess?: () => void;
+  onError?: (error: unknown) => void;
+}
+
+const useSaveUserSettings = (props: SaveUserSettingsProps) => {
+  const { getAccessToken, onSuccess, onError } = props;
+  const { invalidateQuery } = useQueryContext();
+
+  const { mutateAsync } = useMutationRequest<
+    UpsertUserSettingsMutation,
+    unknown,
+    UpsertUserSettingsMutationVariables
+  >({
+    document: upsertUserSettingsMutation,
+    getAccessToken,
+    options: {
+      onSuccess: () => {
+        invalidateQuery(['user-settings']);
+        onSuccess?.();
+      },
+      onError: (error) => {
+        console.error('Save user settings failed:', error);
+        onError?.(error);
+      },
+    },
+  });
+
+  // Read-merge-write: patch the changed slice over current settings and send the
+  // merged blob, so unrelated sites/keys are never clobbered. Returns the
+  // promise so callers can await success before caching / reloading.
+  const saveUserSettings = (current: UserSettings, patch: UserSettingsPatch) =>
+    mutateAsync({ data: mergeUserSettings(current, patch) });
+
+  return { saveUserSettings };
+};
+
+export { useSaveUserSettings };


### PR DESCRIPTION
## Summary

The write side of the settings feature (parent SWO-326). Extends the `user-settings` core domain:

- **`mergeUserSettings(current, patch)`** — layers a patch over the current settings so changing one site/key never clobbers the others. Core owns the structure, so the read-merge-write lives here, not in each app.
- **`useSaveUserSettings()`** — upserts the caller's `user_settings` row via `insert_user_settings_one … on_conflict` (`user_id` is preset server-side from the JWT, so the client only sends the blob; first write creates the row, later writes update). `saveUserSettings(current, patch)` merges then sends the merged blob and returns the promise so callers can await success before caching/reloading. Invalidates `['user-settings']` on success.

No optimistic cache write here — the toggle (SWO-331) awaits success before touching localStorage / reloading.

## Test plan
- [x] `vitest run src/user-settings` → merge helper (3) + hook (2) + read hook/parse (15) all pass.
- [x] `pnpm build` emits the `user-settings/mutation-hooks` subpath entry; new code typechecks (pre-existing tsc noise in unrelated `*.test` files only).
- [x] Codegen run against **local** Hasura; `graphql.ts` gains `UpsertUserSettings` types, 0 unrelated deletions. `schema.graphql` left untouched (pre-existing version-format drift).

SWO-329