### PR TITLE
feat(main): polish journal detail & edit dialog UI

### DIFF
--- a/packages/ui/src/journal/edit-dialog/index.tsx
+++ b/packages/ui/src/journal/edit-dialog/index.tsx
@@ -47,7 +47,7 @@ const EditDialog = (props: EditDialogProps) => {
             height: isMobile ? '100vh' : '80vh',
             display: 'flex',
             flexDirection: 'column',
-            borderRadius: isMobile ? 0 : undefined,
+            borderRadius: isMobile ? 0 : 3,
           },
         },
       }}

--- a/packages/ui/src/journal/journal-detail/index.test.tsx
+++ b/packages/ui/src/journal/journal-detail/index.test.tsx
@@ -1,4 +1,4 @@
-// packages/ui/src/journal/journal-detail.test.tsx
+// packages/ui/src/journal/journal-detail/index.test.tsx
 
 import { fireEvent, render, screen } from '@testing-library/react';
 import { formatDate, formatDateTime } from 'core/universal/common';
@@ -13,7 +13,12 @@ vi.mock('core/universal/common', () => ({
 }));
 
 vi.mock('../mood-icons', () => ({
-  MoodIcon: vi.fn(() => null), // Mocking the MoodIcon component
+  MoodIcon: vi.fn(() => null),
+  MOOD_CONFIG: {
+    happy: { label: 'Happy', color: 'success' },
+    neutral: { label: 'Neutral', color: 'info' },
+    sad: { label: 'Sad', color: 'error' },
+  },
 }));
 
 // Constants for testing
@@ -52,15 +57,12 @@ describe('JournalDetail', () => {
   it('should render loading skeleton when isLoading is true', () => {
     renderComponent({ isLoading: true });
 
-    // Check for skeletons using MUI class
     const skeletons = document.getElementsByClassName('MuiSkeleton-root');
     expect(skeletons.length).toBeGreaterThan(0);
 
-    // Back button should still be present during loading
     const backButton = screen.getByTestId('ArrowBackIcon').closest('button');
     expect(backButton).toBeInTheDocument();
 
-    // Content should not be visible
     expect(screen.queryByText(mockJournal.content)).not.toBeInTheDocument();
   });
 
@@ -69,13 +71,11 @@ describe('JournalDetail', () => {
 
     expect(screen.getByText(/Journal entry not found/i)).toBeInTheDocument();
 
-    // Back button should be present
     const backButton = screen.getByTestId('ArrowBackIcon').closest('button');
     expect(backButton).toBeInTheDocument();
 
-    // Edit and delete buttons should not be present
-    expect(screen.queryByTestId('EditIcon')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('DeleteOutlineIcon')).not.toBeInTheDocument();
+    // Actions menu should not be present in the not-found state
+    expect(screen.queryByTestId('MoreVertIcon')).not.toBeInTheDocument();
   });
 
   it('should render journal details correctly', () => {
@@ -90,31 +90,34 @@ describe('JournalDetail', () => {
     // Check content
     expect(screen.getByText(mockJournal.content)).toBeInTheDocument();
 
+    // Mood label chip
+    expect(screen.getByText('Happy')).toBeInTheDocument();
+
     // Check tags
     mockJournal.tags.forEach((tag) => {
       expect(screen.getByText(tag)).toBeInTheDocument();
     });
 
-    // Check timestamps
-    expect(formatDateTime).toHaveBeenCalledWith(mockJournal.createdAt);
+    // Timestamp collapses to a single "Edited" line when updatedAt differs
     expect(formatDateTime).toHaveBeenCalledWith(mockJournal.updatedAt);
-
-    // Check for the combined text of label and formatted datetime
     expect(
       screen.getByText(
         (content) =>
-          content.includes('Created:') &&
-          content.includes(`formatted-datetime-${mockJournal.createdAt}`),
-      ),
-    ).toBeInTheDocument();
-
-    expect(
-      screen.getByText(
-        (content) =>
-          content.includes('Updated:') &&
+          content.includes('Edited') &&
           content.includes(`formatted-datetime-${mockJournal.updatedAt}`),
       ),
     ).toBeInTheDocument();
+  });
+
+  it('should show the created timestamp when the entry was never edited', () => {
+    renderComponent({
+      journal: { ...mockJournal, updatedAt: mockJournal.createdAt },
+    });
+
+    expect(
+      screen.getByText(`formatted-datetime-${mockJournal.createdAt}`),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Edited/)).not.toBeInTheDocument();
   });
 
   it('should handle back button click', () => {
@@ -126,38 +129,26 @@ describe('JournalDetail', () => {
     expect(mockOnBackClick).toHaveBeenCalledTimes(1);
   });
 
-  it('should handle edit button click', () => {
+  it('should edit via the actions menu', () => {
     renderComponent();
 
-    // Using the EditIcon test ID since that's what's rendered
-    const editButton = screen.getByTestId('EditIcon').closest('button');
-    fireEvent.click(editButton!);
+    fireEvent.click(screen.getByLabelText('entry actions'));
+    fireEvent.click(screen.getByText('Edit'));
 
     expect(mockOnEditClick).toHaveBeenCalledTimes(1);
   });
 
-  it('should handle delete button click', () => {
+  it('should delete via the actions menu', () => {
     renderComponent();
 
-    // Using the DeleteOutlineIcon test ID since that's what's rendered
-    const deleteButton = screen
-      .getByTestId('DeleteOutlineIcon')
-      .closest('button');
-    fireEvent.click(deleteButton!);
+    fireEvent.click(screen.getByLabelText('entry actions'));
+    fireEvent.click(screen.getByText('Delete'));
 
     expect(mockOnDeleteClick).toHaveBeenCalledTimes(1);
   });
 
   it('should render MoodIcon with correct mood type', () => {
     renderComponent();
-
-    // We're not directly testing the MoodIcon component,
-    // but we can verify it receives the correct mood prop
-    // by checking the component structure
-    const actionButtons = screen.getAllByRole('button');
-
-    // At least 3 buttons should be present (back, edit, delete)
-    expect(actionButtons.length).toBeGreaterThanOrEqual(3);
 
     const mockMoodIcon = vi.mocked(MoodIcon);
     expect(mockMoodIcon).toHaveBeenCalledWith(

--- a/packages/ui/src/journal/journal-detail/index.tsx
+++ b/packages/ui/src/journal/journal-detail/index.tsx
@@ -1,19 +1,29 @@
-// packages/ui/src/journal/journal-detail.tsx
+// packages/ui/src/journal/journal-detail/index.tsx
 
 // MUI Icons imports
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
-import EditIcon from '@mui/icons-material/Edit';
+import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
+import Divider from '@mui/material/Divider';
 import IconButton from '@mui/material/IconButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
 import Paper from '@mui/material/Paper';
 import Skeleton from '@mui/material/Skeleton';
+import { alpha } from '@mui/material/styles';
+import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import type { Journal, MoodType } from 'core/src/journal';
 import { formatDate, formatDateTime } from 'core/universal/common';
 import type React from 'react';
-import { MoodIcon } from '../mood-icons';
+import { useState } from 'react';
+import { MOOD_CONFIG, MoodIcon } from '../mood-icons';
 
 interface JournalDetailProps {
   journal: Journal | null;
@@ -30,6 +40,27 @@ const JournalDetail: React.FC<JournalDetailProps> = ({
   onEditClick,
   onDeleteClick,
 }) => {
+  const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
+  const isMenuOpen = Boolean(menuAnchor);
+
+  const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
+    setMenuAnchor(event.currentTarget);
+  };
+
+  const handleMenuClose = () => {
+    setMenuAnchor(null);
+  };
+
+  const handleEdit = () => {
+    handleMenuClose();
+    onEditClick();
+  };
+
+  const handleDelete = () => {
+    handleMenuClose();
+    onDeleteClick();
+  };
+
   if (isLoading) {
     return (
       <Box sx={{ p: 2 }}>
@@ -40,35 +71,26 @@ const JournalDetail: React.FC<JournalDetailProps> = ({
           <Skeleton width={200} height={32} />
         </Box>
 
-        <Paper sx={{ p: 3, boxShadow: 1 }}>
+        <Paper sx={{ p: 3, borderRadius: 3 }}>
           <Box
             sx={{
               display: 'flex',
               justifyContent: 'space-between',
-              alignItems: 'flex-start',
+              alignItems: 'center',
               mb: 3,
             }}
           >
-            <Box sx={{ display: 'flex', gap: 0.5 }}>
-              <Skeleton width={60} height={24} />
-              <Skeleton width={80} height={24} />
-            </Box>
-            <Box sx={{ display: 'flex', gap: 1 }}>
-              <Skeleton variant="circular" width={24} height={24} />
-              <Skeleton variant="circular" width={24} height={24} />
-              <Skeleton variant="circular" width={24} height={24} />
-            </Box>
+            <Skeleton variant="rounded" width={96} height={32} />
+            <Skeleton variant="circular" width={32} height={32} />
           </Box>
 
-          <Skeleton height={24} />
           <Skeleton height={24} />
           <Skeleton height={24} />
           <Skeleton height={24} />
           <Skeleton height={24} width="60%" />
 
           <Box sx={{ mt: 4 }}>
-            <Skeleton width={200} height={16} />
-            <Skeleton width={200} height={16} sx={{ mt: 0.5 }} />
+            <Skeleton width={180} height={16} />
           </Box>
         </Paper>
       </Box>
@@ -85,13 +107,7 @@ const JournalDetail: React.FC<JournalDetailProps> = ({
           <Typography variant="h6">Journal Entry</Typography>
         </Box>
 
-        <Paper
-          sx={{
-            p: 3,
-            textAlign: 'center',
-            bgcolor: 'background.default',
-          }}
-        >
+        <Paper sx={{ p: 3, borderRadius: 3, textAlign: 'center' }}>
           <Typography variant="body1" color="text.secondary">
             Journal entry not found.
           </Typography>
@@ -100,60 +116,100 @@ const JournalDetail: React.FC<JournalDetailProps> = ({
     );
   }
 
+  const mood = MOOD_CONFIG[journal.mood as MoodType];
+  const isEdited = journal.updatedAt !== journal.createdAt;
+
   return (
     <Box sx={{ p: 2 }}>
-      <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
-        <IconButton onClick={onBackClick} sx={{ mr: 1 }}>
-          <ArrowBackIcon fontSize="medium" />
-        </IconButton>
-        <Typography variant="h6">{formatDate(journal.date)}</Typography>
-      </Box>
+      {/* Pin the date under the app bar so long entries never lose the "which
+          day am I reading" context. Rendered as an AppBar so it reuses the
+          theme's frosted header surface (light + dark) instead of a hardcoded
+          colour, reading as a seamless second row of the header. */}
+      <AppBar
+        position="sticky"
+        color="default"
+        elevation={0}
+        sx={{
+          // Full-bleed to match the full-width app bar exactly (the page
+          // Container is maxWidth=sm, so plain margins leave it inset and
+          // misaligned). No card-like border or radius — AppBar extends Paper,
+          // so we clear the theme's Paper border — it reads as a seamless
+          // second row of the header, flush beneath it.
+          top: { xs: 56, sm: 64 },
+          width: '100vw',
+          ml: 'calc(50% - 50vw)',
+          mt: -2,
+          mb: 2,
+          border: 'none',
+          borderRadius: 0,
+          borderBottom: (theme) => `1px solid ${theme.palette.divider}`,
+        }}
+      >
+        <Toolbar variant="dense" disableGutters sx={{ px: 2 }}>
+          <IconButton onClick={onBackClick} sx={{ mr: 1 }}>
+            <ArrowBackIcon fontSize="medium" />
+          </IconButton>
+          <Typography variant="h6" sx={{ fontWeight: 600 }}>
+            {formatDate(journal.date)}
+          </Typography>
+        </Toolbar>
+      </AppBar>
 
-      <Paper sx={{ p: 3, boxShadow: 1 }}>
+      <Paper sx={{ p: 3, borderRadius: 3 }}>
         <Box
           sx={{
             display: 'flex',
             justifyContent: 'space-between',
-            alignItems: 'flex-start',
-            mb: 3,
+            alignItems: 'center',
+            mb: 2.5,
           }}
         >
-          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
-            {journal.tags.map((tag: string) => (
-              <Chip
-                key={tag}
-                label={tag}
-                size="small"
-                sx={{
-                  height: 24,
-                  fontSize: '0.75rem',
-                  bgcolor: 'action.hover',
-                }}
-              />
-            ))}
-          </Box>
+          {mood ? (
+            <Chip
+              icon={<MoodIcon mood={journal.mood as MoodType} size={18} />}
+              label={mood.label}
+              sx={{
+                fontWeight: 600,
+                color: `${mood.color}.main`,
+                // The glassmorphism theme paints chips with a purple gradient
+                // (a background-image), so clear it before applying our tint.
+                backgroundImage: 'none',
+                bgcolor: (theme) => alpha(theme.palette[mood.color].main, 0.12),
+                border: 'none',
+                '& .MuiChip-icon': { color: 'inherit', ml: 0.5 },
+              }}
+            />
+          ) : (
+            <Box />
+          )}
 
-          <Box sx={{ display: 'flex', gap: 1 }}>
-            <MoodIcon mood={journal.mood as MoodType} size={20} />
-
-            <IconButton
-              size="small"
-              color="primary"
-              onClick={onEditClick}
-              sx={{ p: 0.5 }}
-            >
-              <EditIcon fontSize="small" />
-            </IconButton>
-
-            <IconButton
-              size="small"
-              color="error"
-              onClick={onDeleteClick}
-              sx={{ p: 0.5 }}
-            >
-              <DeleteOutlineIcon fontSize="small" />
-            </IconButton>
-          </Box>
+          <IconButton
+            aria-label="entry actions"
+            onClick={handleMenuOpen}
+            size="small"
+          >
+            <MoreVertIcon fontSize="small" />
+          </IconButton>
+          <Menu
+            anchorEl={menuAnchor}
+            open={isMenuOpen}
+            onClose={handleMenuClose}
+            anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+            transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+          >
+            <MenuItem onClick={handleEdit}>
+              <ListItemIcon>
+                <EditOutlinedIcon fontSize="small" />
+              </ListItemIcon>
+              <ListItemText>Edit</ListItemText>
+            </MenuItem>
+            <MenuItem onClick={handleDelete} sx={{ color: 'error.main' }}>
+              <ListItemIcon>
+                <DeleteOutlineIcon fontSize="small" color="error" />
+              </ListItemIcon>
+              <ListItemText>Delete</ListItemText>
+            </MenuItem>
+          </Menu>
         </Box>
 
         <Typography
@@ -162,20 +218,37 @@ const JournalDetail: React.FC<JournalDetailProps> = ({
           sx={{
             whiteSpace: 'pre-wrap',
             fontFamily: 'inherit',
-            lineHeight: 1.6,
+            fontSize: '1.05rem',
+            lineHeight: 1.7,
           }}
         >
           {journal.content}
         </Typography>
 
-        <Box sx={{ mt: 4 }}>
-          <Typography variant="caption" color="text.secondary" display="block">
-            Created: {formatDateTime(journal.createdAt)}
-          </Typography>
-          <Typography variant="caption" color="text.secondary" display="block">
-            Updated: {formatDateTime(journal.updatedAt)}
-          </Typography>
-        </Box>
+        {journal.tags.length > 0 && (
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75, mt: 2.5 }}>
+            {journal.tags.map((tag: string) => (
+              <Chip
+                key={tag}
+                label={tag}
+                size="small"
+                sx={{
+                  backgroundImage: 'none',
+                  bgcolor: 'action.hover',
+                  border: 'none',
+                }}
+              />
+            ))}
+          </Box>
+        )}
+
+        <Divider sx={{ mt: 3, mb: 1.5 }} />
+
+        <Typography variant="caption" color="text.secondary">
+          {isEdited
+            ? `Edited ${formatDateTime(journal.updatedAt)}`
+            : formatDateTime(journal.createdAt)}
+        </Typography>
       </Paper>
     </Box>
   );

--- a/packages/ui/src/journal/journal-edit/index.test.tsx
+++ b/packages/ui/src/journal/journal-edit/index.test.tsx
@@ -35,7 +35,6 @@ describe('JournalEdit', () => {
     expect(
       screen.getByPlaceholderText("What's on your mind today?"),
     ).toBeInTheDocument();
-    expect(screen.getByPlaceholderText('New tag...')).toBeInTheDocument();
   });
 
   it('renders edit form with journal data', () => {
@@ -43,9 +42,6 @@ describe('JournalEdit', () => {
 
     expect(screen.getByText('Edit Entry')).toBeInTheDocument();
     expect(screen.getByDisplayValue(mockJournal.content)).toBeInTheDocument();
-    mockJournal.tags.forEach((tag) => {
-      expect(screen.getByText(tag)).toBeInTheDocument();
-    });
   });
 
   it('handles content changes', () => {
@@ -73,26 +69,17 @@ describe('JournalEdit', () => {
     expect(sadButton).not.toHaveClass('Mui-selected');
   });
 
-  it('handles tag addition', () => {
-    render(<JournalEdit {...defaultProps} />);
+  it('preserves existing tags on save even though they are not editable', () => {
+    const onSave = vi.fn();
+    render(
+      <JournalEdit {...defaultProps} journal={mockJournal} onSave={onSave} />,
+    );
 
-    const tagInput = screen.getByPlaceholderText('New tag...');
-    fireEvent.change(tagInput, { target: { value: 'newtag' } });
-    fireEvent.keyDown(tagInput, { key: 'Enter' });
+    fireEvent.click(screen.getByText('Save'));
 
-    expect(screen.getByText('newtag')).toBeInTheDocument();
-    expect(tagInput).toHaveValue('');
-  });
-
-  it('handles tag removal', () => {
-    render(<JournalEdit {...defaultProps} journal={mockJournal} />);
-
-    // Find the Chip component with the tag text and click its delete button
-    const chip = screen.getByText(mockJournal.tags[0]).closest('.MuiChip-root');
-    const deleteButton = chip?.querySelector('.MuiChip-deleteIcon');
-    fireEvent.click(deleteButton!);
-
-    expect(screen.queryByText(mockJournal.tags[0])).not.toBeInTheDocument();
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ tags: mockJournal.tags }),
+    );
   });
 
   it('handles save button click', () => {
@@ -137,12 +124,11 @@ describe('JournalEdit', () => {
     expect(saveButton).toBeDisabled();
   });
 
-  it('handles back button click', () => {
+  it('handles cancel button click', () => {
     const onBackClick = vi.fn();
     render(<JournalEdit {...defaultProps} onBackClick={onBackClick} />);
 
-    const backButton = screen.getByTestId('ArrowBackIcon').closest('button');
-    fireEvent.click(backButton!);
+    fireEvent.click(screen.getByText('Cancel'));
 
     expect(onBackClick).toHaveBeenCalledTimes(1);
   });

--- a/packages/ui/src/journal/journal-edit/index.tsx
+++ b/packages/ui/src/journal/journal-edit/index.tsx
@@ -1,16 +1,9 @@
-import AddIcon from '@mui/icons-material/Add';
-import ArrowBackIcon from '@mui/icons-material/ArrowBack';
-import LocalOfferIcon from '@mui/icons-material/LocalOffer';
 import SentimentNeutralIcon from '@mui/icons-material/SentimentNeutral';
 import SentimentSatisfiedAltIcon from '@mui/icons-material/SentimentSatisfiedAlt';
 import SentimentVeryDissatisfiedIcon from '@mui/icons-material/SentimentVeryDissatisfied';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
-import Chip from '@mui/material/Chip';
 import CircularProgress from '@mui/material/CircularProgress';
-import IconButton from '@mui/material/IconButton';
-import InputBase from '@mui/material/InputBase';
-import Paper from '@mui/material/Paper';
 import TextField from '@mui/material/TextField';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
@@ -37,8 +30,9 @@ export const JournalEdit: React.FC<JournalEditProps> = ({
   const [content, setContent] = useState('');
   const [date, setDate] = useState('');
   const [mood, setMood] = useState<MoodType>('neutral');
+  // Tags are no longer editable in the form, but we keep any existing tags in
+  // state so editing an already-tagged entry preserves them on save.
   const [tags, setTags] = useState<string[]>([]);
-  const [newTag, setNewTag] = useState('');
 
   useEffect(() => {
     if (journal) {
@@ -65,25 +59,6 @@ export const JournalEdit: React.FC<JournalEditProps> = ({
     }
   };
 
-  const handleAddTag = () => {
-    const trimmedTag = newTag.trim();
-    if (trimmedTag !== '' && tags.indexOf(trimmedTag) === -1) {
-      setTags([...tags, trimmedTag]);
-      setNewTag('');
-    }
-  };
-
-  const handleRemoveTag = (tagToRemove: string) => {
-    setTags(tags.filter((tag) => tag !== tagToRemove));
-  };
-
-  const handleTagKeyDown = (event: React.KeyboardEvent) => {
-    if (event.key === 'Enter') {
-      event.preventDefault();
-      handleAddTag();
-    }
-  };
-
   const handleSave = () => {
     const input = {
       date,
@@ -98,9 +73,6 @@ export const JournalEdit: React.FC<JournalEditProps> = ({
     return (
       <Box sx={{ p: 2 }}>
         <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
-          <IconButton onClick={onBackClick} sx={{ mr: 1 }}>
-            <ArrowBackIcon fontSize="medium" />
-          </IconButton>
           <Typography variant="h6">
             {journal ? 'Edit Entry' : 'New Entry'}
           </Typography>
@@ -118,27 +90,16 @@ export const JournalEdit: React.FC<JournalEditProps> = ({
     >
       <Box
         sx={{
-          position: 'sticky',
-          top: 0,
-          zIndex: 2,
-          bgcolor: 'background.paper',
           display: 'flex',
-          justifyContent: 'space-between',
           alignItems: 'center',
           mb: 2,
+          pb: 1,
           borderBottom: (theme) => `1px solid ${theme.palette.divider}`,
-          pt: 0.5,
-          pb: 0.5,
         }}
       >
-        <Box sx={{ display: 'flex', alignItems: 'center' }}>
-          <IconButton onClick={onBackClick} sx={{ mr: 1 }}>
-            <ArrowBackIcon fontSize="medium" />
-          </IconButton>
-          <Typography variant="h6">
-            {journal ? 'Edit Entry' : 'New Entry'}
-          </Typography>
-        </Box>
+        <Typography variant="h6">
+          {journal ? 'Edit Entry' : 'New Entry'}
+        </Typography>
       </Box>
       {/* Non-scrollable date + mood controls */}
       <Box
@@ -215,7 +176,7 @@ export const JournalEdit: React.FC<JournalEditProps> = ({
         sx={{
           flex: 1,
           overflow: 'auto',
-          pb: { xs: '84px', sm: '76px' },
+          pb: 1,
           display: 'flex',
           flexDirection: 'column',
           // Custom scrollbar styling
@@ -241,91 +202,28 @@ export const JournalEdit: React.FC<JournalEditProps> = ({
           value={content}
           onChange={(e) => setContent(e.target.value)}
           sx={{
-            mb: 2,
             flex: 1, // Allow TextField to grow and fill space
             '& .MuiOutlinedInput-root': {
-              height: '100%',
+              // flex (not height:100%) fills the flex-column form control.
+              flex: 1,
               alignItems: 'flex-start',
+              bgcolor: 'action.hover',
+              fontSize: '1rem',
+              lineHeight: 1.7,
+            },
+            // Multiline textareas autosize to content, leaving dead space in a
+            // full-height field — force the textarea to fill and scroll itself.
+            '& .MuiInputBase-inputMultiline': {
+              height: '100% !important',
+              overflow: 'auto !important',
             },
           }}
         />
-
-        <Box sx={{ mb: 2 }}>
-          <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
-            <LocalOfferIcon sx={{ fontSize: 16, color: '#666' }} />
-            <Typography variant="body2" sx={{ ml: 1, color: 'text.secondary' }}>
-              Add tags
-            </Typography>
-          </Box>
-
-          <Paper
-            sx={{
-              p: 1,
-              display: 'flex',
-              alignItems: 'center',
-              flexWrap: 'wrap',
-              gap: 0.5,
-              mb: 1,
-            }}
-            variant="outlined"
-          >
-            {tags.map((tag) => (
-              <Chip
-                key={tag}
-                label={tag}
-                size="small"
-                onDelete={() => handleRemoveTag(tag)}
-                sx={{
-                  bgcolor: 'primary.light',
-                  color: 'primary.main',
-                  '& .MuiChip-deleteIcon': {
-                    color: 'primary.main',
-                    '&:hover': {
-                      color: 'primary.dark',
-                    },
-                  },
-                }}
-              />
-            ))}
-
-            <Box
-              sx={{
-                display: 'flex',
-                alignItems: 'center',
-                flexGrow: 1,
-                minWidth: 100,
-              }}
-            >
-              <InputBase
-                placeholder="New tag..."
-                value={newTag}
-                onChange={(e) => setNewTag(e.target.value)}
-                onKeyDown={handleTagKeyDown}
-                sx={{ ml: 1, flex: 1, fontSize: '0.875rem' }}
-              />
-              <IconButton
-                size="small"
-                onClick={handleAddTag}
-                disabled={!newTag.trim()}
-                sx={{ p: 0.5 }}
-              >
-                <AddIcon fontSize="small" />
-              </IconButton>
-            </Box>
-          </Paper>
-
-          <Typography variant="caption" color="text.secondary">
-            Press Enter to add a tag
-          </Typography>
-        </Box>
       </Box>
-      {/* Sticky bottom action bar */}
+      {/* Bottom action bar — blends into the dialog surface (the textarea
+          scrolls internally, so no opaque background is needed here). */}
       <Box
         sx={{
-          position: 'sticky',
-          bottom: 0,
-          zIndex: 2,
-          bgcolor: 'background.paper',
           borderTop: (theme) => `1px solid ${theme.palette.divider}`,
           pt: 1,
           pb: 'max(8px, env(safe-area-inset-bottom))',

--- a/packages/ui/src/journal/mood-icons/index.test.tsx
+++ b/packages/ui/src/journal/mood-icons/index.test.tsx
@@ -5,29 +5,29 @@ import { MoodIcon } from './index';
 describe('MoodIcon', () => {
   it('renders happy mood icon correctly', () => {
     render(<MoodIcon mood="happy" />);
-    const icon = screen.getByTestId('SentimentSatisfiedAltIcon');
-    expect(icon).toBeInTheDocument();
-    expect(icon).toHaveStyle({ color: 'rgb(0, 128, 0)' });
+    expect(
+      screen.getByTestId('SentimentVerySatisfiedRoundedIcon'),
+    ).toBeInTheDocument();
   });
 
   it('renders sad mood icon correctly', () => {
     render(<MoodIcon mood="sad" />);
-    const icon = screen.getByTestId('SentimentVeryDissatisfiedIcon');
-    expect(icon).toBeInTheDocument();
-    expect(icon).toHaveStyle({ color: 'rgb(255, 0, 0)' });
+    expect(
+      screen.getByTestId('SentimentDissatisfiedRoundedIcon'),
+    ).toBeInTheDocument();
   });
 
   it('renders neutral mood icon correctly', () => {
     render(<MoodIcon mood="neutral" />);
-    const icon = screen.getByTestId('SentimentNeutralIcon');
-    expect(icon).toBeInTheDocument();
-    expect(icon).toHaveStyle({ color: 'rgb(0, 0, 255)' });
+    expect(
+      screen.getByTestId('SentimentNeutralRoundedIcon'),
+    ).toBeInTheDocument();
   });
 
   it('applies custom size correctly', () => {
     const customSize = 32;
     render(<MoodIcon mood="happy" size={customSize} />);
-    const icon = screen.getByTestId('SentimentSatisfiedAltIcon');
+    const icon = screen.getByTestId('SentimentVerySatisfiedRoundedIcon');
     expect(icon).toHaveStyle({
       width: `${customSize}px`,
       height: `${customSize}px`,
@@ -37,7 +37,7 @@ describe('MoodIcon', () => {
   it('applies custom className correctly', () => {
     const customClass = 'custom-icon';
     render(<MoodIcon mood="happy" className={customClass} />);
-    const icon = screen.getByTestId('SentimentSatisfiedAltIcon');
+    const icon = screen.getByTestId('SentimentVerySatisfiedRoundedIcon');
     expect(icon).toHaveClass(customClass);
   });
 

--- a/packages/ui/src/journal/mood-icons/index.tsx
+++ b/packages/ui/src/journal/mood-icons/index.tsx
@@ -1,11 +1,36 @@
-// packages/ui/src/journal/mood-icon.tsx
+// packages/ui/src/journal/mood-icons/index.tsx
 
-import SentimentNeutralIcon from '@mui/icons-material/SentimentNeutral';
-import SentimentSatisfiedAltIcon from '@mui/icons-material/SentimentSatisfiedAlt';
-import SentimentVeryDissatisfiedIcon from '@mui/icons-material/SentimentVeryDissatisfied';
+import SentimentDissatisfiedRoundedIcon from '@mui/icons-material/SentimentDissatisfiedRounded';
+import SentimentNeutralRoundedIcon from '@mui/icons-material/SentimentNeutralRounded';
+import SentimentVerySatisfiedRoundedIcon from '@mui/icons-material/SentimentVerySatisfiedRounded';
 import type { SvgIconProps } from '@mui/material';
 import type { MoodType } from 'core/src/journal/types';
 import type React from 'react';
+
+interface MoodConfig {
+  Icon: React.ComponentType<SvgIconProps>;
+  label: string;
+  // Theme palette key so the mood reads consistently in light/dark.
+  color: 'success' | 'info' | 'error';
+}
+
+const MOOD_CONFIG: Record<MoodType, MoodConfig> = {
+  happy: {
+    Icon: SentimentVerySatisfiedRoundedIcon,
+    label: 'Happy',
+    color: 'success',
+  },
+  neutral: {
+    Icon: SentimentNeutralRoundedIcon,
+    label: 'Neutral',
+    color: 'info',
+  },
+  sad: {
+    Icon: SentimentDissatisfiedRoundedIcon,
+    label: 'Sad',
+    color: 'error',
+  },
+};
 
 interface MoodIconProps {
   mood: MoodType;
@@ -14,25 +39,18 @@ interface MoodIconProps {
 }
 
 const MoodIcon: React.FC<MoodIconProps> = ({ mood, size = 24, className }) => {
-  const iconProps: SvgIconProps = {
-    style: { width: size, height: size },
-    className,
-  };
-
-  switch (mood) {
-    case 'happy':
-      return (
-        <SentimentSatisfiedAltIcon {...iconProps} sx={{ color: 'green' }} />
-      );
-    case 'sad':
-      return (
-        <SentimentVeryDissatisfiedIcon {...iconProps} sx={{ color: 'red' }} />
-      );
-    case 'neutral':
-      return <SentimentNeutralIcon {...iconProps} sx={{ color: 'blue' }} />;
-    default:
-      return null;
+  const config = MOOD_CONFIG[mood];
+  if (!config) {
+    return null;
   }
+
+  const { Icon, color } = config;
+  return (
+    <Icon
+      className={className}
+      sx={{ width: size, height: size, color: `${color}.main` }}
+    />
+  );
 };
 
-export { MoodIcon };
+export { MoodIcon, MOOD_CONFIG };

--- a/packages/ui/src/universal/minimalism/themeGlassmorphism.ts
+++ b/packages/ui/src/universal/minimalism/themeGlassmorphism.ts
@@ -93,9 +93,10 @@ const glassmorphismTheme = createTheme({
     MuiDialog: {
       styleOverrides: {
         paper: {
-          backgroundColor: 'rgba(26, 26, 62, 0.8)',
-          backdropFilter: 'blur(20px)',
-          WebkitBackdropFilter: 'blur(20px)',
+          // Opaque enough to keep content legible over the backdrop scrim.
+          backgroundColor: 'rgba(26, 26, 62, 0.92)',
+          backdropFilter: 'blur(24px)',
+          WebkitBackdropFilter: 'blur(24px)',
           border: '1px solid rgba(255, 255, 255, 0.15)',
           boxShadow: '0 16px 64px rgba(0, 0, 0, 0.5)',
         },

--- a/packages/ui/src/universal/minimalism/themeGlassmorphismLight.ts
+++ b/packages/ui/src/universal/minimalism/themeGlassmorphismLight.ts
@@ -95,9 +95,12 @@ const lightGlassmorphismTheme = createTheme({
     MuiDialog: {
       styleOverrides: {
         paper: {
-          backgroundColor: 'rgba(255, 255, 255, 0.2)',
-          backdropFilter: 'blur(20px)',
-          WebkitBackdropFilter: 'blur(20px)',
+          // Opaque enough to stay legible: at low opacity the backdrop scrim
+          // bleeds through and content reads as muddy grey (worst as a
+          // fullscreen modal on mobile).
+          backgroundColor: 'rgba(255, 255, 255, 0.92)',
+          backdropFilter: 'blur(24px)',
+          WebkitBackdropFilter: 'blur(24px)',
           border: '1px solid rgba(255, 255, 255, 0.5)',
           boxShadow: '0 16px 64px rgba(0, 0, 0, 0.2)',
         },


### PR DESCRIPTION
## Summary

Polishes the journal reading + editing UI in the **main** app — driven by a round of design feedback on the detail page and edit dialog.

**Detail view**
- Mood is now a tinted, labeled chip (colour from the theme palette) instead of a tiny corner icon
- Edit/Delete collapsed into a single `⋯` overflow menu
- Timestamps collapsed to one line — shows "Edited …" only when it differs from created
- The date is pinned as a **full-bleed sticky sub-header** so long entries keep their day-context while scrolling (rendered as an `AppBar`, so it reuses the theme's header surface in light + dark)

**Mood icons**
- Softer rounded MUI variants, coloured via theme palette (`success`/`info`/`error`) instead of raw CSS colours
- Shared `MOOD_CONFIG` (icon + label + colour) reused by the detail chip

**Edit dialog**
- Fixes the muddy / dark-mode-broken glassmorphism by raising the dialog surface opacity **in the light + dark themes** (theme-level `MuiDialog`, so every dialog benefits) — removes the backdrop-scrim bleed-through and the dark-mode white-on-white
- Removes the unused tags input; the content textarea now fills full height
- Header/footer blend into the dialog surface (dropped the translucent `background.paper` bands); removed the redundant back button (Cancel closes it)

All colour choices are theme-driven; the only remaining literals are the two mode-aware dialog surface opacities in the theme files (the glass theme has no opaque surface token by design).

## Test plan
- [x] `packages/ui` full suite green (545 tests; 45 in `src/journal`)
- [x] Biome clean on changed files (no new violations)
- [x] Verified manually in the running app (light + dark): detail redesign, sticky date on long scroll, edit dialog surfaces, full-height editor, tags removed