### PR TITLE
[WIP] feat(watch): standalone-mode settings toggle + save flow (SWO-331)

### DIFF
--- a/apps/watch/src/components/layout/index.tsx
+++ b/apps/watch/src/components/layout/index.tsx
@@ -1,11 +1,15 @@
 import { Link } from '@tanstack/react-router';
 import { Auth } from 'core';
+import { useLoadUserSettings } from 'core/user-settings/query-hooks';
+import { useSaveUserSettings } from 'core/user-settings/mutation-hooks';
 import type React from 'react';
 import { useState } from 'react';
 import { FullPageContainer } from 'ui/universal/containers/full-page';
+import { Notification } from 'ui/universal/notification';
 import { Header } from 'ui/watch/header';
 import { SettingsPanel } from 'ui/watch/home-page/settings';
 import { appConfig } from '../../config';
+import { writeStandaloneCache } from '../../standalone-mode';
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -14,9 +18,34 @@ interface LayoutProps {
 const Layout = (props: LayoutProps) => {
   const { children } = props;
   const authContext = Auth.useAuthContext();
-  const { signOut, user } = authContext;
+  const { signOut, user, getAccessToken } = authContext;
   const [settingOpen, toggleSetting] = useState<boolean>(false);
+  const [saving, setSaving] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
   const { sites } = appConfig;
+
+  const { settings } = useLoadUserSettings({ getAccessToken });
+  const { saveUserSettings } = useSaveUserSettings({ getAccessToken });
+
+  // Settled order: persist to the DB (source of truth) first, then mirror into
+  // the boot cache, then hard-reload so the router picks up the new history. On
+  // failure, leave the cache untouched and surface the error — never reload into
+  // a state the DB didn't accept.
+  const handleStandaloneModeChange = async (next: boolean) => {
+    if (!settings || saving) {
+      return;
+    }
+
+    setSaving(true);
+    try {
+      await saveUserSettings(settings, { watch: { standaloneMode: next } });
+      writeStandaloneCache(next);
+      window.location.reload();
+    } catch {
+      setSaving(false);
+      setError('Failed to save setting. Please try again.');
+    }
+  };
 
   return (
     <FullPageContainer>
@@ -32,7 +61,16 @@ const Layout = (props: LayoutProps) => {
         actions={{
           logout: signOut,
         }}
+        standaloneMode={settings?.watch.standaloneMode ?? false}
+        onStandaloneModeChange={handleStandaloneModeChange}
+        saving={saving}
       />
+      {error && (
+        <Notification
+          notification={{ message: error, severity: 'error' }}
+          onClose={() => setError(null)}
+        />
+      )}
       {children}
     </FullPageContainer>
   );

--- a/apps/watch/src/standalone-mode.ts
+++ b/apps/watch/src/standalone-mode.ts
@@ -16,4 +16,17 @@ const readStandaloneCache = (): boolean => {
   }
 };
 
-export { STANDALONE_STORAGE_KEY, readStandaloneCache };
+// Mirror the resolved setting into the boot cache. Written after a successful DB
+// save (SWO-331) or conflict resolution (SWO-332); the next boot reads it to pick
+// the router history. Stored explicitly as `'true'`/`'false'` (not removed on
+// off) so the reconcile step (SWO-332) can tell an explicit off apart from a
+// never-set device — boot still treats `'false'` and absent identically.
+const writeStandaloneCache = (value: boolean): void => {
+  try {
+    localStorage.setItem(STANDALONE_STORAGE_KEY, value ? 'true' : 'false');
+  } catch {
+    // Ignore storage failures — the DB remains the source of truth.
+  }
+};
+
+export { STANDALONE_STORAGE_KEY, readStandaloneCache, writeStandaloneCache };

--- a/packages/ui/src/watch/home-page/settings/index.test.tsx
+++ b/packages/ui/src/watch/home-page/settings/index.test.tsx
@@ -47,6 +47,35 @@ describe('SettingsPanel', () => {
     expect(defaultProps.actions.logout).toHaveBeenCalledTimes(1);
   });
 
+  it('renders the standalone toggle reflecting the current value', () => {
+    render(<SettingsPanel {...defaultProps} standaloneMode={true} />);
+
+    const toggle = screen.getByLabelText('Standalone mode');
+    expect(toggle).toBeChecked();
+  });
+
+  it('reports standalone toggle changes', () => {
+    const onStandaloneModeChange = vi.fn();
+    render(
+      <SettingsPanel
+        {...defaultProps}
+        standaloneMode={false}
+        onStandaloneModeChange={onStandaloneModeChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText('Standalone mode'));
+    expect(onStandaloneModeChange).toHaveBeenCalledWith(true);
+  });
+
+  it('disables the standalone toggle while saving', () => {
+    render(
+      <SettingsPanel {...defaultProps} standaloneMode={false} saving={true} />,
+    );
+
+    expect(screen.getByLabelText('Standalone mode')).toBeDisabled();
+  });
+
   it('calls toggle function when drawer is closed', () => {
     render(<SettingsPanel {...defaultProps} />);
 

--- a/packages/ui/src/watch/home-page/settings/index.tsx
+++ b/packages/ui/src/watch/home-page/settings/index.tsx
@@ -1,11 +1,14 @@
 import Logout from '@mui/icons-material/Logout';
+import PhoneIphone from '@mui/icons-material/PhoneIphone';
 import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
 import Drawer from '@mui/material/Drawer';
 import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
+import Switch from '@mui/material/Switch';
 import { UploadButton } from './upload-button';
 
 interface SettingsPanelProps {
@@ -14,14 +17,26 @@ interface SettingsPanelProps {
   actions: {
     logout: () => void;
   };
+  standaloneMode?: boolean;
+  onStandaloneModeChange?: (value: boolean) => void;
+  saving?: boolean;
 }
 
 const texts = {
   logout: 'Logout',
+  standalone: 'Standalone mode',
+  standaloneHint: 'Hide the URL and act like an app',
 };
 
 const SettingsPanel = (props: SettingsPanelProps) => {
-  const { open, toggle, actions } = props;
+  const {
+    open,
+    toggle,
+    actions,
+    standaloneMode,
+    onStandaloneModeChange,
+    saving,
+  } = props;
   const { logout } = actions;
 
   return (
@@ -34,7 +49,27 @@ const SettingsPanel = (props: SettingsPanelProps) => {
           flexDirection: 'column',
         }}
       >
-        <List sx={{ flex: 1 }}>{<UploadButton />}</List>
+        <List sx={{ flex: 1 }}>
+          <UploadButton />
+          <ListItem>
+            <ListItemIcon>
+              <PhoneIphone />
+            </ListItemIcon>
+            <ListItemText
+              primary={texts.standalone}
+              secondary={texts.standaloneHint}
+            />
+            <Switch
+              edge="end"
+              checked={standaloneMode ?? false}
+              disabled={saving}
+              onChange={(event) =>
+                onStandaloneModeChange?.(event.target.checked)
+              }
+              inputProps={{ 'aria-label': texts.standalone }}
+            />
+          </ListItem>
+        </List>
         <Divider />
         <List>
           <ListItemButton onClick={logout}>


### PR DESCRIPTION
## Summary

The user-facing control for standalone mode (parent SWO-326). Off by default.

- **`SettingsPanel`** (ui) gains a presentational **Standalone mode** Switch row — `standaloneMode` / `onStandaloneModeChange` / `saving` props, MUI `Switch` + `ListItem`. Purely presentational; no data logic.
- **`Layout`** (watch) wires it: reads the current setting via `useLoadUserSettings`, and on toggle runs the settled order — **`await` DB save** (`useSaveUserSettings` + `mergeUserSettings`, so only `watch.standaloneMode` changes) → **write the localStorage boot cache** → **hard reload** so the router picks up the new history. On error it surfaces a notification and leaves the cache/reload untouched (never reload into a state the DB didn't accept).
- **`writeStandaloneCache()`** added to `standalone-mode.ts`, storing `'true'`/`'false'` explicitly so SWO-332's reconcile can distinguish an explicit off from a never-set device (boot still treats `'false'`/absent identically).

The DB→cache reconciliation + cross-device conflict popup is the final piece, SWO-332.

## Test plan
- [x] `SettingsPanel` tests (7) pass — toggle reflects value, reports changes, disabled while saving.
- [x] `turbo build --filter=ui --filter=watch` passes; new code typechecks (only the pre-existing `Header`/`linkProps` tsc error remains).

SWO-331