### PR TITLE
feat(main): pin logout to the bottom of the settings drawer (SWO-335)

### DIFF
--- a/packages/ui/src/main/home-page/settings/index.tsx
+++ b/packages/ui/src/main/home-page/settings/index.tsx
@@ -1,5 +1,6 @@
 import Logout from '@mui/icons-material/Logout';
 import Box from '@mui/material/Box';
+import Divider from '@mui/material/Divider';
 import Drawer from '@mui/material/Drawer';
 import List from '@mui/material/List';
 import ListItemButton from '@mui/material/ListItemButton';
@@ -24,8 +25,18 @@ const SettingsPanel = (props: SettingsPanelProps) => {
 
   return (
     <Drawer anchor="right" open={open} onClose={() => toggle(false)}>
-      <Box sx={{ width: 250, height: '100%' }}>
-        <List>
+      <Box
+        sx={{
+          width: 250,
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        {/* Logout pinned to the bottom of the drawer (mt: auto pushes the
+            trailing list down as more items are added above). */}
+        <List sx={{ mt: 'auto' }}>
+          <Divider />
           <ListItemButton
             onClick={() => {
               toggle(false);


### PR DESCRIPTION
## Summary
Moves **Logout** to the bottom of the main app's settings drawer — the conventional place for a sign-out action. The drawer panel is now a full-height flex column with the logout list pushed to the bottom (`mt: auto`) and a divider above it. Behaviour is unchanged (closes the drawer + calls `logout()`).

Closes SWO-335.

## Test plan
- [x] `SettingsPanel` tests pass (4)
- [x] Biome clean
- [x] Logout renders at the bottom; click still closes drawer + logs out