### PR TITLE
feat(main): persist light/dark theme choice in localStorage (SWO-336)

### DIFF
--- a/packages/ui/src/universal/minimalism/themeContext.test.tsx
+++ b/packages/ui/src/universal/minimalism/themeContext.test.tsx
@@ -1,0 +1,66 @@
+import { act, renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  GlassmorphismThemeContextProvider,
+  useGlassmorphismTheme,
+} from './themeContext';
+
+const STORAGE_KEY = 'sworld-theme-mode';
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <GlassmorphismThemeContextProvider>
+    {children}
+  </GlassmorphismThemeContextProvider>
+);
+
+describe('GlassmorphismThemeContextProvider persistence', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('defaults to light when nothing is stored', () => {
+    const { result } = renderHook(() => useGlassmorphismTheme(), { wrapper });
+    expect(result.current.mode).toBe('light');
+  });
+
+  it('hydrates the initial mode from localStorage', () => {
+    window.localStorage.setItem(STORAGE_KEY, 'dark');
+
+    const { result } = renderHook(() => useGlassmorphismTheme(), { wrapper });
+
+    expect(result.current.mode).toBe('dark');
+  });
+
+  it('ignores an invalid stored value and falls back to the default', () => {
+    window.localStorage.setItem(STORAGE_KEY, 'purple');
+
+    const { result } = renderHook(() => useGlassmorphismTheme(), { wrapper });
+
+    expect(result.current.mode).toBe('light');
+  });
+
+  it('persists the mode to localStorage when toggled', () => {
+    const { result } = renderHook(() => useGlassmorphismTheme(), { wrapper });
+
+    act(() => {
+      result.current.toggleTheme();
+    });
+
+    expect(result.current.mode).toBe('dark');
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('dark');
+  });
+
+  it('persists an explicit setTheme call', () => {
+    const { result } = renderHook(() => useGlassmorphismTheme(), { wrapper });
+
+    act(() => {
+      result.current.setTheme('dark');
+    });
+    act(() => {
+      result.current.setTheme('light');
+    });
+
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('light');
+  });
+});

--- a/packages/ui/src/universal/minimalism/themeContext.tsx
+++ b/packages/ui/src/universal/minimalism/themeContext.tsx
@@ -2,11 +2,41 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useState,
 } from 'react';
 
 type ThemeMode = 'light' | 'dark';
+
+const STORAGE_KEY = 'sworld-theme-mode';
+
+const isThemeMode = (value: unknown): value is ThemeMode =>
+  value === 'light' || value === 'dark';
+
+const readStoredMode = (): ThemeMode | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    return isThemeMode(stored) ? stored : null;
+  } catch {
+    // localStorage can throw (private mode, blocked cookies) — treat as absent.
+    return null;
+  }
+};
+
+const writeStoredMode = (mode: ThemeMode): void => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    window.localStorage.setItem(STORAGE_KEY, mode);
+  } catch {
+    // Ignore write failures — persistence is best-effort.
+  }
+};
 
 interface ThemeContextValue {
   mode: ThemeMode;
@@ -23,7 +53,15 @@ interface ThemeProviderProps {
 
 const GlassmorphismThemeContextProvider = (props: ThemeProviderProps) => {
   const { children, defaultMode = 'light' } = props;
-  const [mode, setMode] = useState<ThemeMode>(defaultMode);
+  // Hydrate from localStorage so the user's choice survives reloads, falling
+  // back to defaultMode when nothing valid is stored.
+  const [mode, setMode] = useState<ThemeMode>(
+    () => readStoredMode() ?? defaultMode,
+  );
+
+  useEffect(() => {
+    writeStoredMode(mode);
+  }, [mode]);
 
   const toggleTheme = useCallback(() => {
     setMode((prev) => (prev === 'light' ? 'dark' : 'light'));


### PR DESCRIPTION
## Summary
The glassmorphism theme mode was plain `useState` defaulting to `light`, so dark mode was forgotten on reload. Now the provider:
- hydrates `mode` from `localStorage` on init (lazy initializer), falling back to `defaultMode` for missing/invalid values;
- writes `mode` back to `localStorage` on every change;
- guards `typeof window` and try/catches storage access (private mode / blocked cookies) so it can't throw.

Key: `sworld-theme-mode`.

Closes SWO-336.

## Test plan
- [x] New `themeContext` tests pass (5): default, hydrate-from-storage, invalid-value fallback, persist-on-toggle, persist-on-setTheme
- [x] Biome clean