### PR TITLE
fix(main): make finance note legible in dark mode (SWO-337)

### DIFF
--- a/packages/ui/src/main/home-page/transactions-dialog/index.tsx
+++ b/packages/ui/src/main/home-page/transactions-dialog/index.tsx
@@ -185,7 +185,10 @@ const TransactionsDialog = ({
                     sx={{
                       mt: 2,
                       p: 1.5,
-                      backgroundColor: theme.palette.grey[50],
+                      // Mode-aware surface: grey[50] is always near-white, so
+                      // in dark mode the secondary-coloured note text was
+                      // invisible. action.hover contrasts in both themes.
+                      backgroundColor: theme.palette.action.hover,
                       borderRadius: 1,
                     }}
                   >


### PR DESCRIPTION
## Summary
In the **/finance** category detail dialog (`TransactionsDialog`), an expense's **note** was rendered as light text on `theme.palette.grey[50]` — a fixed near-white background regardless of theme — so in **dark mode** it was white-on-white and unreadable.

Swapped the note box background to `theme.palette.action.hover`, MUI's mode-aware subtle surface, so it contrasts in both light and dark. No behaviour change.

Closes SWO-337.

## Test plan
- [x] `TransactionsDialog` tests pass (8)
- [x] Biome clean
- [x] Manually verified in the running app: note now legible in dark mode, still fine in light mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the visibility of transaction notes in the dialog, especially in dark mode, by adjusting the note background styling for better contrast.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->