### PR TITLE
fix(main): repair journal edit dialog on mobile

### DIFF
--- a/packages/ui/src/journal/edit-dialog/index.tsx
+++ b/packages/ui/src/journal/edit-dialog/index.tsx
@@ -44,7 +44,11 @@ const EditDialog = (props: EditDialogProps) => {
       slotProps={{
         paper: {
           sx: {
-            height: isMobile ? '100vh' : '80vh',
+            // On mobile, `fullScreen` already sizes the paper to the visible
+            // viewport. Forcing `100vh` here uses the *large* viewport (behind
+            // the address bar), making the dialog taller than the screen and
+            // clipping the header — so only set an explicit height on desktop.
+            ...(isMobile ? {} : { height: '80vh' }),
             display: 'flex',
             flexDirection: 'column',
             borderRadius: isMobile ? 0 : 3,

--- a/packages/ui/src/journal/journal-edit/index.tsx
+++ b/packages/ui/src/journal/journal-edit/index.tsx
@@ -4,6 +4,7 @@ import SentimentVeryDissatisfiedIcon from '@mui/icons-material/SentimentVeryDiss
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
+import { alpha } from '@mui/material/styles';
 import TextField from '@mui/material/TextField';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
@@ -136,8 +137,13 @@ export const JournalEdit: React.FC<JournalEditProps> = ({
             sx={{
               color: 'error.main',
               '&.Mui-selected': {
-                backgroundColor: 'error.light',
+                backgroundColor: (theme) =>
+                  alpha(theme.palette.error.main, 0.16),
                 color: 'error.main',
+                '&:hover': {
+                  backgroundColor: (theme) =>
+                    alpha(theme.palette.error.main, 0.24),
+                },
               },
             }}
           >
@@ -149,8 +155,13 @@ export const JournalEdit: React.FC<JournalEditProps> = ({
             sx={{
               color: 'info.main',
               '&.Mui-selected': {
-                backgroundColor: 'info.light',
+                backgroundColor: (theme) =>
+                  alpha(theme.palette.info.main, 0.16),
                 color: 'info.main',
+                '&:hover': {
+                  backgroundColor: (theme) =>
+                    alpha(theme.palette.info.main, 0.24),
+                },
               },
             }}
           >
@@ -162,8 +173,13 @@ export const JournalEdit: React.FC<JournalEditProps> = ({
             sx={{
               color: 'success.main',
               '&.Mui-selected': {
-                backgroundColor: 'success.light',
+                backgroundColor: (theme) =>
+                  alpha(theme.palette.success.main, 0.16),
                 color: 'success.main',
+                '&:hover': {
+                  backgroundColor: (theme) =>
+                    alpha(theme.palette.success.main, 0.24),
+                },
               },
             }}
           >


### PR DESCRIPTION
## Summary

The journal **New Entry / Edit** dialog looked broken on mobile — the header was clipped and the default mood showed a garish bright-cyan block:

- **Clipped header / oversized dialog** — the mobile paper was forced to `height: '100vh'`. On mobile Chrome `100vh` is the *large* viewport (the area behind the address bar), so the dialog rendered taller than the visible screen and the `New Entry` header got scrolled out of view. `fullScreen` already sizes the paper to the real visible area, so the override is now dropped on mobile (desktop keeps its `80vh`).
- **Garish mood highlight** — the selected mood used a solid `*.light` fill, which in dark mode is a harsh flat block with square corners inside the rounded group. Swapped for a subtle `alpha(*.main, 0.16)` tint (hover `0.24`).

## Test plan

- [ ] Open the journal edit dialog on a mobile device — header fully visible, dialog fits the screen
- [ ] Selected mood shows a subtle tint, not a solid bright block (check dark mode)
- [ ] Desktop dialog unchanged (`80vh`, rounded corners)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ANExKHexbDHFnvgPHnrMnP