### PR TITLE
[WIP] fix(ui): Header requires only LinkComponent, not linkProps (SWO-338)

### DIFF
--- a/packages/ui/src/watch/header/index.tsx
+++ b/packages/ui/src/watch/header/index.tsx
@@ -9,11 +9,14 @@ import { lazy, Suspense } from 'react';
 import { ResponsiveAvatar } from '../../universal';
 import Logo from '../../universal/logo';
 import SiteChoices from '../../universal/site-choices';
-import type { RequiredLinkComponent } from '../videos/types';
+import type { RequiredLinkComponentWithoutLinkProps } from '../videos/types';
 
 const Notifications = lazy(() => import('./notifications'));
 
-interface HeaderProps extends RequiredLinkComponent {
+// Header only forwards LinkComponent (to Logo/Notifications) and never uses
+// linkProps, so it requires the LinkComponent-only variant — otherwise every
+// caller has to pass a dead linkProps.
+interface HeaderProps extends RequiredLinkComponentWithoutLinkProps {
   toggleSetting: React.Dispatch<React.SetStateAction<boolean>>;
   sites: {
     listen: string;


### PR DESCRIPTION
## Summary
Follow-up from SWO-326. `HeaderProps extends RequiredLinkComponent` required both `LinkComponent` and `linkProps`, but `Header` only ever forwards `LinkComponent` (to Logo/Notifications) — `linkProps` was dead. Every caller (the watch Layout) had to pass a phantom `linkProps` and tripped `tsc`. Switched to the existing `RequiredLinkComponentWithoutLinkProps` variant.

## Test plan
- [x] `tsc --noEmit` on the watch app no longer reports the `HeaderProps`/`linkProps` error.
- [x] `turbo build --filter=ui --filter=watch` passes; no runtime change (LinkComponent still forwarded).

SWO-338