### PR TITLE
[WIP] chore(core): regenerate schema.graphql against local Hasura (SWO-339)

### DIFF
--- a/packages/core/schema.graphql
+++ b/packages/core/schema.graphql
@@ -4,17 +4,11 @@ schema {
   subscription: subscription_root
 }
 
-"""
-whether this query should be cached (Hasura Cloud only)
-"""
+"""whether this query should be cached (Hasura Cloud only)"""
 directive @cached(
-  """
-  refresh the cache entry
-  """
+  """refresh the cache entry"""
   refresh: Boolean! = false
-  """
-  measured in seconds
-  """
+  """measured in seconds"""
   ttl: Int! = 60
 ) on QUERY
 
@@ -114,9 +108,7 @@ input String_comparison_exp {
   _eq: String
   _gt: String
   _gte: String
-  """
-  does the column match the given case-insensitive pattern
-  """
+  """does the column match the given case-insensitive pattern"""
   _ilike: String
   _in: [String!]
   """
@@ -124,57 +116,41 @@ input String_comparison_exp {
   """
   _iregex: String
   _is_null: Boolean
-  """
-  does the column match the given pattern
-  """
+  """does the column match the given pattern"""
   _like: String
   _lt: String
   _lte: String
   _neq: String
-  """
-  does the column NOT match the given case-insensitive pattern
-  """
+  """does the column NOT match the given case-insensitive pattern"""
   _nilike: String
   _nin: [String!]
   """
   does the column NOT match the given POSIX regular expression, case insensitive
   """
   _niregex: String
-  """
-  does the column NOT match the given pattern
-  """
+  """does the column NOT match the given pattern"""
   _nlike: String
   """
   does the column NOT match the given POSIX regular expression, case sensitive
   """
   _nregex: String
-  """
-  does the column NOT match the given SQL regular expression
-  """
+  """does the column NOT match the given SQL regular expression"""
   _nsimilar: String
   """
   does the column match the given POSIX regular expression, case sensitive
   """
   _regex: String
-  """
-  does the column match the given SQL regular expression
-  """
+  """does the column match the given SQL regular expression"""
   _similar: String
 }
 
-"""
-Junction table between audios and tags, many to many relationship
-"""
+"""Junction table between audios and tags, many to many relationship"""
 type audio_tags {
-  """
-  An object relationship
-  """
+  """An object relationship"""
   audio: audios!
   audio_id: uuid!
   created_at: timestamptz!
-  """
-  An object relationship
-  """
+  """An object relationship"""
   tag: tags!
   tag_id: uuid!
   updated_at: timestamptz!
@@ -222,9 +198,7 @@ input type for inserting array relation for remote table "audio_tags"
 """
 input audio_tags_arr_rel_insert_input {
   data: [audio_tags_insert_input!]!
-  """
-  upsert condition
-  """
+  """upsert condition"""
   on_conflict: audio_tags_on_conflict
 }
 
@@ -265,9 +239,7 @@ input audio_tags_insert_input {
   updated_at: timestamptz
 }
 
-"""
-aggregate max on columns
-"""
+"""aggregate max on columns"""
 type audio_tags_max_fields {
   audio_id: uuid
   created_at: timestamptz
@@ -285,9 +257,7 @@ input audio_tags_max_order_by {
   updated_at: order_by
 }
 
-"""
-aggregate min on columns
-"""
+"""aggregate min on columns"""
 type audio_tags_min_fields {
   audio_id: uuid
   created_at: timestamptz
@@ -309,13 +279,9 @@ input audio_tags_min_order_by {
 response of any mutation on the table "audio_tags"
 """
 type audio_tags_mutation_response {
-  """
-  number of rows affected by the mutation
-  """
+  """number of rows affected by the mutation"""
   affected_rows: Int!
-  """
-  data from the rows affected by the mutation
-  """
+  """data from the rows affected by the mutation"""
   returning: [audio_tags!]!
 }
 
@@ -328,9 +294,7 @@ input audio_tags_on_conflict {
   where: audio_tags_bool_exp
 }
 
-"""
-Ordering options when selecting data from "audio_tags".
-"""
+"""Ordering options when selecting data from "audio_tags"."""
 input audio_tags_order_by {
   audio: audios_order_by
   audio_id: order_by
@@ -340,9 +304,7 @@ input audio_tags_order_by {
   updated_at: order_by
 }
 
-"""
-primary key columns input for table: audio_tags
-"""
+"""primary key columns input for table: audio_tags"""
 input audio_tags_pk_columns_input {
   audio_id: uuid!
   tag_id: uuid!
@@ -352,21 +314,13 @@ input audio_tags_pk_columns_input {
 select columns of table "audio_tags"
 """
 enum audio_tags_select_column {
-  """
-  column name
-  """
+  """column name"""
   audio_id
-  """
-  column name
-  """
+  """column name"""
   created_at
-  """
-  column name
-  """
+  """column name"""
   tag_id
-  """
-  column name
-  """
+  """column name"""
   updated_at
 }
 
@@ -384,19 +338,13 @@ input audio_tags_set_input {
 Streaming cursor of the table "audio_tags"
 """
 input audio_tags_stream_cursor_input {
-  """
-  Stream column input with initial value
-  """
+  """Stream column input with initial value"""
   initial_value: audio_tags_stream_cursor_value_input!
-  """
-  cursor ordering
-  """
+  """cursor ordering"""
   ordering: cursor_ordering
 }
 
-"""
-Initial value of the column from where the streaming should start
-"""
+"""Initial value of the column from where the streaming should start"""
 input audio_tags_stream_cursor_value_input {
   audio_id: uuid
   created_at: timestamptz
@@ -408,150 +356,86 @@ input audio_tags_stream_cursor_value_input {
 update columns of table "audio_tags"
 """
 enum audio_tags_update_column {
-  """
-  column name
-  """
+  """column name"""
   audio_id
-  """
-  column name
-  """
+  """column name"""
   created_at
-  """
-  column name
-  """
+  """column name"""
   tag_id
-  """
-  column name
-  """
+  """column name"""
   updated_at
 }
 
 input audio_tags_updates {
-  """
-  sets the columns of the filtered rows to the given values
-  """
+  """sets the columns of the filtered rows to the given values"""
   _set: audio_tags_set_input
-  """
-  filter the rows which have to be updated
-  """
+  """filter the rows which have to be updated"""
   where: audio_tags_bool_exp!
 }
 
-"""
-Audios for listen site
-"""
+"""Audios for listen site"""
 type audios {
   artistName: String!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   audio_tags(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [audio_tags_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [audio_tags_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: audio_tags_bool_exp
   ): [audio_tags!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   audio_tags_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [audio_tags_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [audio_tags_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: audio_tags_bool_exp
   ): audio_tags_aggregate!
   createdAt: timestamptz!
   id: uuid!
   name: String!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   playlist_audios(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [playlist_audios_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [playlist_audios_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: playlist_audios_bool_exp
   ): [playlist_audios!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   playlist_audios_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [playlist_audios_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [playlist_audios_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: playlist_audios_bool_exp
   ): playlist_audios_aggregate!
   public: Boolean!
   source: String!
   thumbnailUrl: String
   updatedAt: timestamptz!
-  """
-  An object relationship
-  """
+  """An object relationship"""
   user: users!
   user_id: uuid!
 }
@@ -614,9 +498,7 @@ input type for inserting array relation for remote table "audios"
 """
 input audios_arr_rel_insert_input {
   data: [audios_insert_input!]!
-  """
-  upsert condition
-  """
+  """upsert condition"""
   on_conflict: audios_on_conflict
 }
 
@@ -671,9 +553,7 @@ input audios_insert_input {
   user_id: uuid
 }
 
-"""
-aggregate max on columns
-"""
+"""aggregate max on columns"""
 type audios_max_fields {
   artistName: String
   createdAt: timestamptz
@@ -699,9 +579,7 @@ input audios_max_order_by {
   user_id: order_by
 }
 
-"""
-aggregate min on columns
-"""
+"""aggregate min on columns"""
 type audios_min_fields {
   artistName: String
   createdAt: timestamptz
@@ -731,13 +609,9 @@ input audios_min_order_by {
 response of any mutation on the table "audios"
 """
 type audios_mutation_response {
-  """
-  number of rows affected by the mutation
-  """
+  """number of rows affected by the mutation"""
   affected_rows: Int!
-  """
-  data from the rows affected by the mutation
-  """
+  """data from the rows affected by the mutation"""
   returning: [audios!]!
 }
 
@@ -746,9 +620,7 @@ input type for inserting object relation for remote table "audios"
 """
 input audios_obj_rel_insert_input {
   data: audios_insert_input!
-  """
-  upsert condition
-  """
+  """upsert condition"""
   on_conflict: audios_on_conflict
 }
 
@@ -761,9 +633,7 @@ input audios_on_conflict {
   where: audios_bool_exp
 }
 
-"""
-Ordering options when selecting data from "audios".
-"""
+"""Ordering options when selecting data from "audios"."""
 input audios_order_by {
   artistName: order_by
   audio_tags_aggregate: audio_tags_aggregate_order_by
@@ -779,9 +649,7 @@ input audios_order_by {
   user_id: order_by
 }
 
-"""
-primary key columns input for table: audios
-"""
+"""primary key columns input for table: audios"""
 input audios_pk_columns_input {
   id: uuid!
 }
@@ -790,41 +658,23 @@ input audios_pk_columns_input {
 select columns of table "audios"
 """
 enum audios_select_column {
-  """
-  column name
-  """
+  """column name"""
   artistName
-  """
-  column name
-  """
+  """column name"""
   createdAt
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   name
-  """
-  column name
-  """
+  """column name"""
   public
-  """
-  column name
-  """
+  """column name"""
   source
-  """
-  column name
-  """
+  """column name"""
   thumbnailUrl
-  """
-  column name
-  """
+  """column name"""
   updatedAt
-  """
-  column name
-  """
+  """column name"""
   user_id
 }
 
@@ -832,9 +682,7 @@ enum audios_select_column {
 select "audios_aggregate_bool_exp_bool_and_arguments_columns" columns of table "audios"
 """
 enum audios_select_column_audios_aggregate_bool_exp_bool_and_arguments_columns {
-  """
-  column name
-  """
+  """column name"""
   public
 }
 
@@ -842,9 +690,7 @@ enum audios_select_column_audios_aggregate_bool_exp_bool_and_arguments_columns {
 select "audios_aggregate_bool_exp_bool_or_arguments_columns" columns of table "audios"
 """
 enum audios_select_column_audios_aggregate_bool_exp_bool_or_arguments_columns {
-  """
-  column name
-  """
+  """column name"""
   public
 }
 
@@ -867,19 +713,13 @@ input audios_set_input {
 Streaming cursor of the table "audios"
 """
 input audios_stream_cursor_input {
-  """
-  Stream column input with initial value
-  """
+  """Stream column input with initial value"""
   initial_value: audios_stream_cursor_value_input!
-  """
-  cursor ordering
-  """
+  """cursor ordering"""
   ordering: cursor_ordering
 }
 
-"""
-Initial value of the column from where the streaming should start
-"""
+"""Initial value of the column from where the streaming should start"""
 input audios_stream_cursor_value_input {
   artistName: String
   createdAt: timestamptz
@@ -896,52 +736,30 @@ input audios_stream_cursor_value_input {
 update columns of table "audios"
 """
 enum audios_update_column {
-  """
-  column name
-  """
+  """column name"""
   artistName
-  """
-  column name
-  """
+  """column name"""
   createdAt
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   name
-  """
-  column name
-  """
+  """column name"""
   public
-  """
-  column name
-  """
+  """column name"""
   source
-  """
-  column name
-  """
+  """column name"""
   thumbnailUrl
-  """
-  column name
-  """
+  """column name"""
   updatedAt
-  """
-  column name
-  """
+  """column name"""
   user_id
 }
 
 input audios_updates {
-  """
-  sets the columns of the filtered rows to the given values
-  """
+  """sets the columns of the filtered rows to the given values"""
   _set: audios_set_input
-  """
-  filter the rows which have to be updated
-  """
+  """filter the rows which have to be updated"""
   where: audios_bool_exp!
 }
 
@@ -954,9 +772,7 @@ type book_comments {
   createdAt: timestamptz!
   id: uuid!
   updated_at: timestamptz!
-  """
-  An object relationship
-  """
+  """An object relationship"""
   user: users!
   userId: uuid!
 }
@@ -1003,9 +819,7 @@ input type for inserting array relation for remote table "book_comments"
 """
 input book_comments_arr_rel_insert_input {
   data: [book_comments_insert_input!]!
-  """
-  upsert condition
-  """
+  """upsert condition"""
   on_conflict: book_comments_on_conflict
 }
 
@@ -1048,9 +862,7 @@ input book_comments_insert_input {
   userId: uuid
 }
 
-"""
-aggregate max on columns
-"""
+"""aggregate max on columns"""
 type book_comments_max_fields {
   bookId: uuid
   content: String
@@ -1072,9 +884,7 @@ input book_comments_max_order_by {
   userId: order_by
 }
 
-"""
-aggregate min on columns
-"""
+"""aggregate min on columns"""
 type book_comments_min_fields {
   bookId: uuid
   content: String
@@ -1100,13 +910,9 @@ input book_comments_min_order_by {
 response of any mutation on the table "book_comments"
 """
 type book_comments_mutation_response {
-  """
-  number of rows affected by the mutation
-  """
+  """number of rows affected by the mutation"""
   affected_rows: Int!
-  """
-  data from the rows affected by the mutation
-  """
+  """data from the rows affected by the mutation"""
   returning: [book_comments!]!
 }
 
@@ -1119,9 +925,7 @@ input book_comments_on_conflict {
   where: book_comments_bool_exp
 }
 
-"""
-Ordering options when selecting data from "book_comments".
-"""
+"""Ordering options when selecting data from "book_comments"."""
 input book_comments_order_by {
   bookId: order_by
   content: order_by
@@ -1132,9 +936,7 @@ input book_comments_order_by {
   userId: order_by
 }
 
-"""
-primary key columns input for table: book_comments
-"""
+"""primary key columns input for table: book_comments"""
 input book_comments_pk_columns_input {
   id: uuid!
 }
@@ -1143,29 +945,17 @@ input book_comments_pk_columns_input {
 select columns of table "book_comments"
 """
 enum book_comments_select_column {
-  """
-  column name
-  """
+  """column name"""
   bookId
-  """
-  column name
-  """
+  """column name"""
   content
-  """
-  column name
-  """
+  """column name"""
   createdAt
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   updated_at
-  """
-  column name
-  """
+  """column name"""
   userId
 }
 
@@ -1185,19 +975,13 @@ input book_comments_set_input {
 Streaming cursor of the table "book_comments"
 """
 input book_comments_stream_cursor_input {
-  """
-  Stream column input with initial value
-  """
+  """Stream column input with initial value"""
   initial_value: book_comments_stream_cursor_value_input!
-  """
-  cursor ordering
-  """
+  """cursor ordering"""
   ordering: cursor_ordering
 }
 
-"""
-Initial value of the column from where the streaming should start
-"""
+"""Initial value of the column from where the streaming should start"""
 input book_comments_stream_cursor_value_input {
   bookId: uuid
   content: String
@@ -1211,40 +995,24 @@ input book_comments_stream_cursor_value_input {
 update columns of table "book_comments"
 """
 enum book_comments_update_column {
-  """
-  column name
-  """
+  """column name"""
   bookId
-  """
-  column name
-  """
+  """column name"""
   content
-  """
-  column name
-  """
+  """column name"""
   createdAt
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   updated_at
-  """
-  column name
-  """
+  """column name"""
   userId
 }
 
 input book_comments_updates {
-  """
-  sets the columns of the filtered rows to the given values
-  """
+  """sets the columns of the filtered rows to the given values"""
   _set: book_comments_set_input
-  """
-  filter the rows which have to be updated
-  """
+  """filter the rows which have to be updated"""
   where: book_comments_bool_exp!
 }
 
@@ -1254,59 +1022,33 @@ columns and relationships of "books"
 type books {
   author: String!
   createdAt: timestamptz!
-  """
-  User input url, NOT validated yet
-  """
+  """User input url, NOT validated yet"""
   fileUrl: String
   id: uuid!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   reading_progresses(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [reading_progresses_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [reading_progresses_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: reading_progresses_bool_exp
   ): [reading_progresses!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   reading_progresses_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [reading_progresses_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [reading_progresses_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: reading_progresses_bool_exp
   ): reading_progresses_aggregate!
   """
@@ -1321,13 +1063,9 @@ type books {
   title: String!
   totalPages: Int!
   updatedAt: timestamptz!
-  """
-  An object relationship
-  """
+  """An object relationship"""
   user: users!
-  """
-  Uploader, not the author of the book
-  """
+  """Uploader, not the author of the book"""
   userId: uuid!
 }
 
@@ -1389,15 +1127,11 @@ input type for inserting array relation for remote table "books"
 """
 input books_arr_rel_insert_input {
   data: [books_insert_input!]!
-  """
-  upsert condition
-  """
+  """upsert condition"""
   on_conflict: books_on_conflict
 }
 
-"""
-aggregate avg on columns
-"""
+"""aggregate avg on columns"""
 type books_avg_fields {
   totalPages: Float
 }
@@ -1455,9 +1189,7 @@ input type for inserting data into table "books"
 input books_insert_input {
   author: String
   createdAt: timestamptz
-  """
-  User input url, NOT validated yet
-  """
+  """User input url, NOT validated yet"""
   fileUrl: String
   id: uuid
   reading_progresses: reading_progresses_arr_rel_insert_input
@@ -1474,21 +1206,15 @@ input books_insert_input {
   totalPages: Int
   updatedAt: timestamptz
   user: users_obj_rel_insert_input
-  """
-  Uploader, not the author of the book
-  """
+  """Uploader, not the author of the book"""
   userId: uuid
 }
 
-"""
-aggregate max on columns
-"""
+"""aggregate max on columns"""
 type books_max_fields {
   author: String
   createdAt: timestamptz
-  """
-  User input url, NOT validated yet
-  """
+  """User input url, NOT validated yet"""
   fileUrl: String
   id: uuid
   """
@@ -1503,9 +1229,7 @@ type books_max_fields {
   title: String
   totalPages: Int
   updatedAt: timestamptz
-  """
-  Uploader, not the author of the book
-  """
+  """Uploader, not the author of the book"""
   userId: uuid
 }
 
@@ -1515,9 +1239,7 @@ order by max() on columns of table "books"
 input books_max_order_by {
   author: order_by
   createdAt: order_by
-  """
-  User input url, NOT validated yet
-  """
+  """User input url, NOT validated yet"""
   fileUrl: order_by
   id: order_by
   """
@@ -1532,21 +1254,15 @@ input books_max_order_by {
   title: order_by
   totalPages: order_by
   updatedAt: order_by
-  """
-  Uploader, not the author of the book
-  """
+  """Uploader, not the author of the book"""
   userId: order_by
 }
 
-"""
-aggregate min on columns
-"""
+"""aggregate min on columns"""
 type books_min_fields {
   author: String
   createdAt: timestamptz
-  """
-  User input url, NOT validated yet
-  """
+  """User input url, NOT validated yet"""
   fileUrl: String
   id: uuid
   """
@@ -1561,9 +1277,7 @@ type books_min_fields {
   title: String
   totalPages: Int
   updatedAt: timestamptz
-  """
-  Uploader, not the author of the book
-  """
+  """Uploader, not the author of the book"""
   userId: uuid
 }
 
@@ -1573,9 +1287,7 @@ order by min() on columns of table "books"
 input books_min_order_by {
   author: order_by
   createdAt: order_by
-  """
-  User input url, NOT validated yet
-  """
+  """User input url, NOT validated yet"""
   fileUrl: order_by
   id: order_by
   """
@@ -1590,9 +1302,7 @@ input books_min_order_by {
   title: order_by
   totalPages: order_by
   updatedAt: order_by
-  """
-  Uploader, not the author of the book
-  """
+  """Uploader, not the author of the book"""
   userId: order_by
 }
 
@@ -1600,13 +1310,9 @@ input books_min_order_by {
 response of any mutation on the table "books"
 """
 type books_mutation_response {
-  """
-  number of rows affected by the mutation
-  """
+  """number of rows affected by the mutation"""
   affected_rows: Int!
-  """
-  data from the rows affected by the mutation
-  """
+  """data from the rows affected by the mutation"""
   returning: [books!]!
 }
 
@@ -1615,9 +1321,7 @@ input type for inserting object relation for remote table "books"
 """
 input books_obj_rel_insert_input {
   data: books_insert_input!
-  """
-  upsert condition
-  """
+  """upsert condition"""
   on_conflict: books_on_conflict
 }
 
@@ -1630,9 +1334,7 @@ input books_on_conflict {
   where: books_bool_exp
 }
 
-"""
-Ordering options when selecting data from "books".
-"""
+"""Ordering options when selecting data from "books"."""
 input books_order_by {
   author: order_by
   createdAt: order_by
@@ -1649,9 +1351,7 @@ input books_order_by {
   userId: order_by
 }
 
-"""
-primary key columns input for table: books
-"""
+"""primary key columns input for table: books"""
 input books_pk_columns_input {
   id: uuid!
 }
@@ -1660,49 +1360,27 @@ input books_pk_columns_input {
 select columns of table "books"
 """
 enum books_select_column {
-  """
-  column name
-  """
+  """column name"""
   author
-  """
-  column name
-  """
+  """column name"""
   createdAt
-  """
-  column name
-  """
+  """column name"""
   fileUrl
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   source
-  """
-  column name
-  """
+  """column name"""
   status
-  """
-  column name
-  """
+  """column name"""
   thumbnailUrl
-  """
-  column name
-  """
+  """column name"""
   title
-  """
-  column name
-  """
+  """column name"""
   totalPages
-  """
-  column name
-  """
+  """column name"""
   updatedAt
-  """
-  column name
-  """
+  """column name"""
   userId
 }
 
@@ -1712,9 +1390,7 @@ input type for updating data in table "books"
 input books_set_input {
   author: String
   createdAt: timestamptz
-  """
-  User input url, NOT validated yet
-  """
+  """User input url, NOT validated yet"""
   fileUrl: String
   id: uuid
   """
@@ -1729,15 +1405,11 @@ input books_set_input {
   title: String
   totalPages: Int
   updatedAt: timestamptz
-  """
-  Uploader, not the author of the book
-  """
+  """Uploader, not the author of the book"""
   userId: uuid
 }
 
-"""
-aggregate stddev on columns
-"""
+"""aggregate stddev on columns"""
 type books_stddev_fields {
   totalPages: Float
 }
@@ -1749,9 +1421,7 @@ input books_stddev_order_by {
   totalPages: order_by
 }
 
-"""
-aggregate stddev_pop on columns
-"""
+"""aggregate stddev_pop on columns"""
 type books_stddev_pop_fields {
   totalPages: Float
 }
@@ -1763,9 +1433,7 @@ input books_stddev_pop_order_by {
   totalPages: order_by
 }
 
-"""
-aggregate stddev_samp on columns
-"""
+"""aggregate stddev_samp on columns"""
 type books_stddev_samp_fields {
   totalPages: Float
 }
@@ -1781,25 +1449,17 @@ input books_stddev_samp_order_by {
 Streaming cursor of the table "books"
 """
 input books_stream_cursor_input {
-  """
-  Stream column input with initial value
-  """
+  """Stream column input with initial value"""
   initial_value: books_stream_cursor_value_input!
-  """
-  cursor ordering
-  """
+  """cursor ordering"""
   ordering: cursor_ordering
 }
 
-"""
-Initial value of the column from where the streaming should start
-"""
+"""Initial value of the column from where the streaming should start"""
 input books_stream_cursor_value_input {
   author: String
   createdAt: timestamptz
-  """
-  User input url, NOT validated yet
-  """
+  """User input url, NOT validated yet"""
   fileUrl: String
   id: uuid
   """
@@ -1814,15 +1474,11 @@ input books_stream_cursor_value_input {
   title: String
   totalPages: Int
   updatedAt: timestamptz
-  """
-  Uploader, not the author of the book
-  """
+  """Uploader, not the author of the book"""
   userId: uuid
 }
 
-"""
-aggregate sum on columns
-"""
+"""aggregate sum on columns"""
 type books_sum_fields {
   totalPages: Int
 }
@@ -1838,70 +1494,40 @@ input books_sum_order_by {
 update columns of table "books"
 """
 enum books_update_column {
-  """
-  column name
-  """
+  """column name"""
   author
-  """
-  column name
-  """
+  """column name"""
   createdAt
-  """
-  column name
-  """
+  """column name"""
   fileUrl
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   source
-  """
-  column name
-  """
+  """column name"""
   status
-  """
-  column name
-  """
+  """column name"""
   thumbnailUrl
-  """
-  column name
-  """
+  """column name"""
   title
-  """
-  column name
-  """
+  """column name"""
   totalPages
-  """
-  column name
-  """
+  """column name"""
   updatedAt
-  """
-  column name
-  """
+  """column name"""
   userId
 }
 
 input books_updates {
-  """
-  increments the numeric columns with given value of the filtered values
-  """
+  """increments the numeric columns with given value of the filtered values"""
   _inc: books_inc_input
-  """
-  sets the columns of the filtered rows to the given values
-  """
+  """sets the columns of the filtered rows to the given values"""
   _set: books_set_input
-  """
-  filter the rows which have to be updated
-  """
+  """filter the rows which have to be updated"""
   where: books_bool_exp!
 }
 
-"""
-aggregate var_pop on columns
-"""
+"""aggregate var_pop on columns"""
 type books_var_pop_fields {
   totalPages: Float
 }
@@ -1913,9 +1539,7 @@ input books_var_pop_order_by {
   totalPages: order_by
 }
 
-"""
-aggregate var_samp on columns
-"""
+"""aggregate var_samp on columns"""
 type books_var_samp_fields {
   totalPages: Float
 }
@@ -1927,9 +1551,7 @@ input books_var_samp_order_by {
   totalPages: order_by
 }
 
-"""
-aggregate variance on columns
-"""
+"""aggregate variance on columns"""
 type books_variance_fields {
   totalPages: Float
 }
@@ -1941,9 +1563,7 @@ input books_variance_order_by {
   totalPages: order_by
 }
 
-"""
-Requests to crawl content from any sources
-"""
+"""Requests to crawl content from any sources"""
 type crawl_requests {
   created_at: timestamptz!
   get_single_video: Boolean
@@ -1953,9 +1573,7 @@ type crawl_requests {
   title: String!
   updated_at: timestamptz!
   url: String!
-  """
-  An object relationship
-  """
+  """An object relationship"""
   user: users!
   user_id: uuid!
 }
@@ -2018,9 +1636,7 @@ input type for inserting array relation for remote table "crawl_requests"
 """
 input crawl_requests_arr_rel_insert_input {
   data: [crawl_requests_insert_input!]!
-  """
-  upsert condition
-  """
+  """upsert condition"""
   on_conflict: crawl_requests_on_conflict
 }
 
@@ -2069,9 +1685,7 @@ input crawl_requests_insert_input {
   user_id: uuid
 }
 
-"""
-aggregate max on columns
-"""
+"""aggregate max on columns"""
 type crawl_requests_max_fields {
   created_at: timestamptz
   id: uuid
@@ -2097,9 +1711,7 @@ input crawl_requests_max_order_by {
   user_id: order_by
 }
 
-"""
-aggregate min on columns
-"""
+"""aggregate min on columns"""
 type crawl_requests_min_fields {
   created_at: timestamptz
   id: uuid
@@ -2129,13 +1741,9 @@ input crawl_requests_min_order_by {
 response of any mutation on the table "crawl_requests"
 """
 type crawl_requests_mutation_response {
-  """
-  number of rows affected by the mutation
-  """
+  """number of rows affected by the mutation"""
   affected_rows: Int!
-  """
-  data from the rows affected by the mutation
-  """
+  """data from the rows affected by the mutation"""
   returning: [crawl_requests!]!
 }
 
@@ -2148,9 +1756,7 @@ input crawl_requests_on_conflict {
   where: crawl_requests_bool_exp
 }
 
-"""
-Ordering options when selecting data from "crawl_requests".
-"""
+"""Ordering options when selecting data from "crawl_requests"."""
 input crawl_requests_order_by {
   created_at: order_by
   get_single_video: order_by
@@ -2164,9 +1770,7 @@ input crawl_requests_order_by {
   user_id: order_by
 }
 
-"""
-primary key columns input for table: crawl_requests
-"""
+"""primary key columns input for table: crawl_requests"""
 input crawl_requests_pk_columns_input {
   id: uuid!
 }
@@ -2175,41 +1779,23 @@ input crawl_requests_pk_columns_input {
 select columns of table "crawl_requests"
 """
 enum crawl_requests_select_column {
-  """
-  column name
-  """
+  """column name"""
   created_at
-  """
-  column name
-  """
+  """column name"""
   get_single_video
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   site
-  """
-  column name
-  """
+  """column name"""
   slug_prefix
-  """
-  column name
-  """
+  """column name"""
   title
-  """
-  column name
-  """
+  """column name"""
   updated_at
-  """
-  column name
-  """
+  """column name"""
   url
-  """
-  column name
-  """
+  """column name"""
   user_id
 }
 
@@ -2217,9 +1803,7 @@ enum crawl_requests_select_column {
 select "crawl_requests_aggregate_bool_exp_bool_and_arguments_columns" columns of table "crawl_requests"
 """
 enum crawl_requests_select_column_crawl_requests_aggregate_bool_exp_bool_and_arguments_columns {
-  """
-  column name
-  """
+  """column name"""
   get_single_video
 }
 
@@ -2227,9 +1811,7 @@ enum crawl_requests_select_column_crawl_requests_aggregate_bool_exp_bool_and_arg
 select "crawl_requests_aggregate_bool_exp_bool_or_arguments_columns" columns of table "crawl_requests"
 """
 enum crawl_requests_select_column_crawl_requests_aggregate_bool_exp_bool_or_arguments_columns {
-  """
-  column name
-  """
+  """column name"""
   get_single_video
 }
 
@@ -2252,19 +1834,13 @@ input crawl_requests_set_input {
 Streaming cursor of the table "crawl_requests"
 """
 input crawl_requests_stream_cursor_input {
-  """
-  Stream column input with initial value
-  """
+  """Stream column input with initial value"""
   initial_value: crawl_requests_stream_cursor_value_input!
-  """
-  cursor ordering
-  """
+  """cursor ordering"""
   ordering: cursor_ordering
 }
 
-"""
-Initial value of the column from where the streaming should start
-"""
+"""Initial value of the column from where the streaming should start"""
 input crawl_requests_stream_cursor_value_input {
   created_at: timestamptz
   get_single_video: Boolean
@@ -2281,66 +1857,38 @@ input crawl_requests_stream_cursor_value_input {
 update columns of table "crawl_requests"
 """
 enum crawl_requests_update_column {
-  """
-  column name
-  """
+  """column name"""
   created_at
-  """
-  column name
-  """
+  """column name"""
   get_single_video
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   site
-  """
-  column name
-  """
+  """column name"""
   slug_prefix
-  """
-  column name
-  """
+  """column name"""
   title
-  """
-  column name
-  """
+  """column name"""
   updated_at
-  """
-  column name
-  """
+  """column name"""
   url
-  """
-  column name
-  """
+  """column name"""
   user_id
 }
 
 input crawl_requests_updates {
-  """
-  sets the columns of the filtered rows to the given values
-  """
+  """sets the columns of the filtered rows to the given values"""
   _set: crawl_requests_set_input
-  """
-  filter the rows which have to be updated
-  """
+  """filter the rows which have to be updated"""
   where: crawl_requests_bool_exp!
 }
 
-"""
-ordering argument of a cursor
-"""
+"""ordering argument of a cursor"""
 enum cursor_ordering {
-  """
-  ascending ordering of the cursor
-  """
+  """ascending ordering of the cursor"""
   ASC
-  """
-  descending ordering of the cursor
-  """
+  """descending ordering of the cursor"""
   DESC
 }
 
@@ -2374,9 +1922,7 @@ type device_requests {
   ipAddress: inet!
   status: String!
   updatedAt: timestamptz!
-  """
-  An object relationship
-  """
+  """An object relationship"""
   user: users
   userAgent: String!
   userCode: String!
@@ -2425,9 +1971,7 @@ input type for inserting array relation for remote table "device_requests"
 """
 input device_requests_arr_rel_insert_input {
   data: [device_requests_insert_input!]!
-  """
-  upsert condition
-  """
+  """upsert condition"""
   on_conflict: device_requests_on_conflict
 }
 
@@ -2490,9 +2034,7 @@ input device_requests_insert_input {
   user_id: uuid
 }
 
-"""
-aggregate max on columns
-"""
+"""aggregate max on columns"""
 type device_requests_max_fields {
   authorizedAt: timestamptz
   createdAt: timestamptz
@@ -2524,9 +2066,7 @@ input device_requests_max_order_by {
   user_id: order_by
 }
 
-"""
-aggregate min on columns
-"""
+"""aggregate min on columns"""
 type device_requests_min_fields {
   authorizedAt: timestamptz
   createdAt: timestamptz
@@ -2562,13 +2102,9 @@ input device_requests_min_order_by {
 response of any mutation on the table "device_requests"
 """
 type device_requests_mutation_response {
-  """
-  number of rows affected by the mutation
-  """
+  """number of rows affected by the mutation"""
   affected_rows: Int!
-  """
-  data from the rows affected by the mutation
-  """
+  """data from the rows affected by the mutation"""
   returning: [device_requests!]!
 }
 
@@ -2581,9 +2117,7 @@ input device_requests_on_conflict {
   where: device_requests_bool_exp
 }
 
-"""
-Ordering options when selecting data from "device_requests".
-"""
+"""Ordering options when selecting data from "device_requests"."""
 input device_requests_order_by {
   authorizedAt: order_by
   createdAt: order_by
@@ -2600,9 +2134,7 @@ input device_requests_order_by {
   user_id: order_by
 }
 
-"""
-primary key columns input for table: device_requests
-"""
+"""primary key columns input for table: device_requests"""
 input device_requests_pk_columns_input {
   id: uuid!
 }
@@ -2611,53 +2143,29 @@ input device_requests_pk_columns_input {
 select columns of table "device_requests"
 """
 enum device_requests_select_column {
-  """
-  column name
-  """
+  """column name"""
   authorizedAt
-  """
-  column name
-  """
+  """column name"""
   createdAt
-  """
-  column name
-  """
+  """column name"""
   deviceCode
-  """
-  column name
-  """
+  """column name"""
   expiresAt
-  """
-  column name
-  """
+  """column name"""
   extensionId
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   ipAddress
-  """
-  column name
-  """
+  """column name"""
   status
-  """
-  column name
-  """
+  """column name"""
   updatedAt
-  """
-  column name
-  """
+  """column name"""
   userAgent
-  """
-  column name
-  """
+  """column name"""
   userCode
-  """
-  column name
-  """
+  """column name"""
   user_id
 }
 
@@ -2683,19 +2191,13 @@ input device_requests_set_input {
 Streaming cursor of the table "device_requests"
 """
 input device_requests_stream_cursor_input {
-  """
-  Stream column input with initial value
-  """
+  """Stream column input with initial value"""
   initial_value: device_requests_stream_cursor_value_input!
-  """
-  cursor ordering
-  """
+  """cursor ordering"""
   ordering: cursor_ordering
 }
 
-"""
-Initial value of the column from where the streaming should start
-"""
+"""Initial value of the column from where the streaming should start"""
 input device_requests_stream_cursor_value_input {
   authorizedAt: timestamptz
   createdAt: timestamptz
@@ -2715,64 +2217,36 @@ input device_requests_stream_cursor_value_input {
 update columns of table "device_requests"
 """
 enum device_requests_update_column {
-  """
-  column name
-  """
+  """column name"""
   authorizedAt
-  """
-  column name
-  """
+  """column name"""
   createdAt
-  """
-  column name
-  """
+  """column name"""
   deviceCode
-  """
-  column name
-  """
+  """column name"""
   expiresAt
-  """
-  column name
-  """
+  """column name"""
   extensionId
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   ipAddress
-  """
-  column name
-  """
+  """column name"""
   status
-  """
-  column name
-  """
+  """column name"""
   updatedAt
-  """
-  column name
-  """
+  """column name"""
   userAgent
-  """
-  column name
-  """
+  """column name"""
   userCode
-  """
-  column name
-  """
+  """column name"""
   user_id
 }
 
 input device_requests_updates {
-  """
-  sets the columns of the filtered rows to the given values
-  """
+  """sets the columns of the filtered rows to the given values"""
   _set: device_requests_set_input
-  """
-  filter the rows which have to be updated
-  """
+  """filter the rows which have to be updated"""
   where: device_requests_bool_exp!
 }
 
@@ -2781,9 +2255,7 @@ Feature flag system and we must leverage Hasura subscription to watch this
 """
 type feature_flag {
   conditions(
-    """
-    JSON select path
-    """
+    """JSON select path"""
     path: String
   ): jsonb
   created_at: timestamptz!
@@ -2812,9 +2284,7 @@ type feature_flag_aggregate_fields {
   min: feature_flag_min_fields
 }
 
-"""
-append existing jsonb value of filtered columns with new jsonb value
-"""
+"""append existing jsonb value of filtered columns with new jsonb value"""
 input feature_flag_append_input {
   conditions: jsonb
 }
@@ -2885,9 +2355,7 @@ input feature_flag_insert_input {
   updated_at: timestamptz
 }
 
-"""
-aggregate max on columns
-"""
+"""aggregate max on columns"""
 type feature_flag_max_fields {
   created_at: timestamptz
   description: String
@@ -2897,9 +2365,7 @@ type feature_flag_max_fields {
   updated_at: timestamptz
 }
 
-"""
-aggregate min on columns
-"""
+"""aggregate min on columns"""
 type feature_flag_min_fields {
   created_at: timestamptz
   description: String
@@ -2913,13 +2379,9 @@ type feature_flag_min_fields {
 response of any mutation on the table "feature_flag"
 """
 type feature_flag_mutation_response {
-  """
-  number of rows affected by the mutation
-  """
+  """number of rows affected by the mutation"""
   affected_rows: Int!
-  """
-  data from the rows affected by the mutation
-  """
+  """data from the rows affected by the mutation"""
   returning: [feature_flag!]!
 }
 
@@ -2932,9 +2394,7 @@ input feature_flag_on_conflict {
   where: feature_flag_bool_exp
 }
 
-"""
-Ordering options when selecting data from "feature_flag".
-"""
+"""Ordering options when selecting data from "feature_flag"."""
 input feature_flag_order_by {
   conditions: order_by
   created_at: order_by
@@ -2946,16 +2406,12 @@ input feature_flag_order_by {
   updated_at: order_by
 }
 
-"""
-primary key columns input for table: feature_flag
-"""
+"""primary key columns input for table: feature_flag"""
 input feature_flag_pk_columns_input {
   id: uuid!
 }
 
-"""
-prepend existing jsonb value of filtered columns with new jsonb value
-"""
+"""prepend existing jsonb value of filtered columns with new jsonb value"""
 input feature_flag_prepend_input {
   conditions: jsonb
 }
@@ -2964,37 +2420,21 @@ input feature_flag_prepend_input {
 select columns of table "feature_flag"
 """
 enum feature_flag_select_column {
-  """
-  column name
-  """
+  """column name"""
   conditions
-  """
-  column name
-  """
+  """column name"""
   created_at
-  """
-  column name
-  """
+  """column name"""
   description
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   name
-  """
-  column name
-  """
+  """column name"""
   require_auth
-  """
-  column name
-  """
+  """column name"""
   site
-  """
-  column name
-  """
+  """column name"""
   updated_at
 }
 
@@ -3016,19 +2456,13 @@ input feature_flag_set_input {
 Streaming cursor of the table "feature_flag"
 """
 input feature_flag_stream_cursor_input {
-  """
-  Stream column input with initial value
-  """
+  """Stream column input with initial value"""
   initial_value: feature_flag_stream_cursor_value_input!
-  """
-  cursor ordering
-  """
+  """cursor ordering"""
   ordering: cursor_ordering
 }
 
-"""
-Initial value of the column from where the streaming should start
-"""
+"""Initial value of the column from where the streaming should start"""
 input feature_flag_stream_cursor_value_input {
   conditions: jsonb
   created_at: timestamptz
@@ -3044,44 +2478,26 @@ input feature_flag_stream_cursor_value_input {
 update columns of table "feature_flag"
 """
 enum feature_flag_update_column {
-  """
-  column name
-  """
+  """column name"""
   conditions
-  """
-  column name
-  """
+  """column name"""
   created_at
-  """
-  column name
-  """
+  """column name"""
   description
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   name
-  """
-  column name
-  """
+  """column name"""
   require_auth
-  """
-  column name
-  """
+  """column name"""
   site
-  """
-  column name
-  """
+  """column name"""
   updated_at
 }
 
 input feature_flag_updates {
-  """
-  append existing jsonb value of filtered columns with new jsonb value
-  """
+  """append existing jsonb value of filtered columns with new jsonb value"""
   _append: feature_flag_append_input
   """
   delete the field or element with specified path (for JSON arrays, negative integers count from the end)
@@ -3095,28 +2511,18 @@ input feature_flag_updates {
   delete key/value pair or string element. key/value pairs are matched based on their key value
   """
   _delete_key: feature_flag_delete_key_input
-  """
-  prepend existing jsonb value of filtered columns with new jsonb value
-  """
+  """prepend existing jsonb value of filtered columns with new jsonb value"""
   _prepend: feature_flag_prepend_input
-  """
-  sets the columns of the filtered rows to the given values
-  """
+  """sets the columns of the filtered rows to the given values"""
   _set: feature_flag_set_input
-  """
-  filter the rows which have to be updated
-  """
+  """filter the rows which have to be updated"""
   where: feature_flag_bool_exp!
 }
 
-"""
-Transactions for personal finance management
-"""
+"""Transactions for personal finance management"""
 type finance_transactions {
   amount: numeric!
-  """
-  Should be either must, nice or waste
-  """
+  """Should be either must, nice or waste"""
   category: String!
   createdAt: timestamptz!
   id: uuid!
@@ -3124,9 +2530,7 @@ type finance_transactions {
   name: String!
   note: String
   updatedAt: timestamptz!
-  """
-  An object relationship
-  """
+  """An object relationship"""
   user: users!
   user_id: uuid!
   year: Int!
@@ -3190,15 +2594,11 @@ input type for inserting array relation for remote table "finance_transactions"
 """
 input finance_transactions_arr_rel_insert_input {
   data: [finance_transactions_insert_input!]!
-  """
-  upsert condition
-  """
+  """upsert condition"""
   on_conflict: finance_transactions_on_conflict
 }
 
-"""
-aggregate avg on columns
-"""
+"""aggregate avg on columns"""
 type finance_transactions_avg_fields {
   amount: Float
   month: Float
@@ -3258,9 +2658,7 @@ input type for inserting data into table "finance_transactions"
 """
 input finance_transactions_insert_input {
   amount: numeric
-  """
-  Should be either must, nice or waste
-  """
+  """Should be either must, nice or waste"""
   category: String
   createdAt: timestamptz
   id: uuid
@@ -3273,14 +2671,10 @@ input finance_transactions_insert_input {
   year: Int
 }
 
-"""
-aggregate max on columns
-"""
+"""aggregate max on columns"""
 type finance_transactions_max_fields {
   amount: numeric
-  """
-  Should be either must, nice or waste
-  """
+  """Should be either must, nice or waste"""
   category: String
   createdAt: timestamptz
   id: uuid
@@ -3297,9 +2691,7 @@ order by max() on columns of table "finance_transactions"
 """
 input finance_transactions_max_order_by {
   amount: order_by
-  """
-  Should be either must, nice or waste
-  """
+  """Should be either must, nice or waste"""
   category: order_by
   createdAt: order_by
   id: order_by
@@ -3311,14 +2703,10 @@ input finance_transactions_max_order_by {
   year: order_by
 }
 
-"""
-aggregate min on columns
-"""
+"""aggregate min on columns"""
 type finance_transactions_min_fields {
   amount: numeric
-  """
-  Should be either must, nice or waste
-  """
+  """Should be either must, nice or waste"""
   category: String
   createdAt: timestamptz
   id: uuid
@@ -3335,9 +2723,7 @@ order by min() on columns of table "finance_transactions"
 """
 input finance_transactions_min_order_by {
   amount: order_by
-  """
-  Should be either must, nice or waste
-  """
+  """Should be either must, nice or waste"""
   category: order_by
   createdAt: order_by
   id: order_by
@@ -3353,13 +2739,9 @@ input finance_transactions_min_order_by {
 response of any mutation on the table "finance_transactions"
 """
 type finance_transactions_mutation_response {
-  """
-  number of rows affected by the mutation
-  """
+  """number of rows affected by the mutation"""
   affected_rows: Int!
-  """
-  data from the rows affected by the mutation
-  """
+  """data from the rows affected by the mutation"""
   returning: [finance_transactions!]!
 }
 
@@ -3372,9 +2754,7 @@ input finance_transactions_on_conflict {
   where: finance_transactions_bool_exp
 }
 
-"""
-Ordering options when selecting data from "finance_transactions".
-"""
+"""Ordering options when selecting data from "finance_transactions"."""
 input finance_transactions_order_by {
   amount: order_by
   category: order_by
@@ -3389,9 +2769,7 @@ input finance_transactions_order_by {
   year: order_by
 }
 
-"""
-primary key columns input for table: finance_transactions
-"""
+"""primary key columns input for table: finance_transactions"""
 input finance_transactions_pk_columns_input {
   id: uuid!
 }
@@ -3400,45 +2778,25 @@ input finance_transactions_pk_columns_input {
 select columns of table "finance_transactions"
 """
 enum finance_transactions_select_column {
-  """
-  column name
-  """
+  """column name"""
   amount
-  """
-  column name
-  """
+  """column name"""
   category
-  """
-  column name
-  """
+  """column name"""
   createdAt
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   month
-  """
-  column name
-  """
+  """column name"""
   name
-  """
-  column name
-  """
+  """column name"""
   note
-  """
-  column name
-  """
+  """column name"""
   updatedAt
-  """
-  column name
-  """
+  """column name"""
   user_id
-  """
-  column name
-  """
+  """column name"""
   year
 }
 
@@ -3447,9 +2805,7 @@ input type for updating data in table "finance_transactions"
 """
 input finance_transactions_set_input {
   amount: numeric
-  """
-  Should be either must, nice or waste
-  """
+  """Should be either must, nice or waste"""
   category: String
   createdAt: timestamptz
   id: uuid
@@ -3461,9 +2817,7 @@ input finance_transactions_set_input {
   year: Int
 }
 
-"""
-aggregate stddev on columns
-"""
+"""aggregate stddev on columns"""
 type finance_transactions_stddev_fields {
   amount: Float
   month: Float
@@ -3479,9 +2833,7 @@ input finance_transactions_stddev_order_by {
   year: order_by
 }
 
-"""
-aggregate stddev_pop on columns
-"""
+"""aggregate stddev_pop on columns"""
 type finance_transactions_stddev_pop_fields {
   amount: Float
   month: Float
@@ -3497,9 +2849,7 @@ input finance_transactions_stddev_pop_order_by {
   year: order_by
 }
 
-"""
-aggregate stddev_samp on columns
-"""
+"""aggregate stddev_samp on columns"""
 type finance_transactions_stddev_samp_fields {
   amount: Float
   month: Float
@@ -3519,24 +2869,16 @@ input finance_transactions_stddev_samp_order_by {
 Streaming cursor of the table "finance_transactions"
 """
 input finance_transactions_stream_cursor_input {
-  """
-  Stream column input with initial value
-  """
+  """Stream column input with initial value"""
   initial_value: finance_transactions_stream_cursor_value_input!
-  """
-  cursor ordering
-  """
+  """cursor ordering"""
   ordering: cursor_ordering
 }
 
-"""
-Initial value of the column from where the streaming should start
-"""
+"""Initial value of the column from where the streaming should start"""
 input finance_transactions_stream_cursor_value_input {
   amount: numeric
-  """
-  Should be either must, nice or waste
-  """
+  """Should be either must, nice or waste"""
   category: String
   createdAt: timestamptz
   id: uuid
@@ -3548,9 +2890,7 @@ input finance_transactions_stream_cursor_value_input {
   year: Int
 }
 
-"""
-aggregate sum on columns
-"""
+"""aggregate sum on columns"""
 type finance_transactions_sum_fields {
   amount: numeric
   month: Int
@@ -3570,66 +2910,38 @@ input finance_transactions_sum_order_by {
 update columns of table "finance_transactions"
 """
 enum finance_transactions_update_column {
-  """
-  column name
-  """
+  """column name"""
   amount
-  """
-  column name
-  """
+  """column name"""
   category
-  """
-  column name
-  """
+  """column name"""
   createdAt
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   month
-  """
-  column name
-  """
+  """column name"""
   name
-  """
-  column name
-  """
+  """column name"""
   note
-  """
-  column name
-  """
+  """column name"""
   updatedAt
-  """
-  column name
-  """
+  """column name"""
   user_id
-  """
-  column name
-  """
+  """column name"""
   year
 }
 
 input finance_transactions_updates {
-  """
-  increments the numeric columns with given value of the filtered values
-  """
+  """increments the numeric columns with given value of the filtered values"""
   _inc: finance_transactions_inc_input
-  """
-  sets the columns of the filtered rows to the given values
-  """
+  """sets the columns of the filtered rows to the given values"""
   _set: finance_transactions_set_input
-  """
-  filter the rows which have to be updated
-  """
+  """filter the rows which have to be updated"""
   where: finance_transactions_bool_exp!
 }
 
-"""
-aggregate var_pop on columns
-"""
+"""aggregate var_pop on columns"""
 type finance_transactions_var_pop_fields {
   amount: Float
   month: Float
@@ -3645,9 +2957,7 @@ input finance_transactions_var_pop_order_by {
   year: order_by
 }
 
-"""
-aggregate var_samp on columns
-"""
+"""aggregate var_samp on columns"""
 type finance_transactions_var_samp_fields {
   amount: Float
   month: Float
@@ -3663,9 +2973,7 @@ input finance_transactions_var_samp_order_by {
   year: order_by
 }
 
-"""
-aggregate variance on columns
-"""
+"""aggregate variance on columns"""
 type finance_transactions_variance_fields {
   amount: Float
   month: Float
@@ -3698,9 +3006,7 @@ input inet_comparison_exp {
   _nin: [inet!]
 }
 
-"""
-Daily journal
-"""
+"""Daily journal"""
 type journals {
   content: String!
   createdAt: timestamptz!
@@ -3708,15 +3014,11 @@ type journals {
   id: uuid!
   mood: String!
   tags(
-    """
-    JSON select path
-    """
+    """JSON select path"""
     path: String
   ): jsonb!
   updatedAt: timestamptz!
-  """
-  An object relationship
-  """
+  """An object relationship"""
   user: users!
   user_id: uuid!
 }
@@ -3758,9 +3060,7 @@ input journals_aggregate_order_by {
   min: journals_min_order_by
 }
 
-"""
-append existing jsonb value of filtered columns with new jsonb value
-"""
+"""append existing jsonb value of filtered columns with new jsonb value"""
 input journals_append_input {
   tags: jsonb
 }
@@ -3770,9 +3070,7 @@ input type for inserting array relation for remote table "journals"
 """
 input journals_arr_rel_insert_input {
   data: [journals_insert_input!]!
-  """
-  upsert condition
-  """
+  """upsert condition"""
   on_conflict: journals_on_conflict
 }
 
@@ -3840,9 +3138,7 @@ input journals_insert_input {
   user_id: uuid
 }
 
-"""
-aggregate max on columns
-"""
+"""aggregate max on columns"""
 type journals_max_fields {
   content: String
   createdAt: timestamptz
@@ -3866,9 +3162,7 @@ input journals_max_order_by {
   user_id: order_by
 }
 
-"""
-aggregate min on columns
-"""
+"""aggregate min on columns"""
 type journals_min_fields {
   content: String
   createdAt: timestamptz
@@ -3896,13 +3190,9 @@ input journals_min_order_by {
 response of any mutation on the table "journals"
 """
 type journals_mutation_response {
-  """
-  number of rows affected by the mutation
-  """
+  """number of rows affected by the mutation"""
   affected_rows: Int!
-  """
-  data from the rows affected by the mutation
-  """
+  """data from the rows affected by the mutation"""
   returning: [journals!]!
 }
 
@@ -3915,9 +3205,7 @@ input journals_on_conflict {
   where: journals_bool_exp
 }
 
-"""
-Ordering options when selecting data from "journals".
-"""
+"""Ordering options when selecting data from "journals"."""
 input journals_order_by {
   content: order_by
   createdAt: order_by
@@ -3930,16 +3218,12 @@ input journals_order_by {
   user_id: order_by
 }
 
-"""
-primary key columns input for table: journals
-"""
+"""primary key columns input for table: journals"""
 input journals_pk_columns_input {
   id: uuid!
 }
 
-"""
-prepend existing jsonb value of filtered columns with new jsonb value
-"""
+"""prepend existing jsonb value of filtered columns with new jsonb value"""
 input journals_prepend_input {
   tags: jsonb
 }
@@ -3948,37 +3232,21 @@ input journals_prepend_input {
 select columns of table "journals"
 """
 enum journals_select_column {
-  """
-  column name
-  """
+  """column name"""
   content
-  """
-  column name
-  """
+  """column name"""
   createdAt
-  """
-  column name
-  """
+  """column name"""
   date
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   mood
-  """
-  column name
-  """
+  """column name"""
   tags
-  """
-  column name
-  """
+  """column name"""
   updatedAt
-  """
-  column name
-  """
+  """column name"""
   user_id
 }
 
@@ -4000,19 +3268,13 @@ input journals_set_input {
 Streaming cursor of the table "journals"
 """
 input journals_stream_cursor_input {
-  """
-  Stream column input with initial value
-  """
+  """Stream column input with initial value"""
   initial_value: journals_stream_cursor_value_input!
-  """
-  cursor ordering
-  """
+  """cursor ordering"""
   ordering: cursor_ordering
 }
 
-"""
-Initial value of the column from where the streaming should start
-"""
+"""Initial value of the column from where the streaming should start"""
 input journals_stream_cursor_value_input {
   content: String
   createdAt: timestamptz
@@ -4028,44 +3290,26 @@ input journals_stream_cursor_value_input {
 update columns of table "journals"
 """
 enum journals_update_column {
-  """
-  column name
-  """
+  """column name"""
   content
-  """
-  column name
-  """
+  """column name"""
   createdAt
-  """
-  column name
-  """
+  """column name"""
   date
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   mood
-  """
-  column name
-  """
+  """column name"""
   tags
-  """
-  column name
-  """
+  """column name"""
   updatedAt
-  """
-  column name
-  """
+  """column name"""
   user_id
 }
 
 input journals_updates {
-  """
-  append existing jsonb value of filtered columns with new jsonb value
-  """
+  """append existing jsonb value of filtered columns with new jsonb value"""
   _append: journals_append_input
   """
   delete the field or element with specified path (for JSON arrays, negative integers count from the end)
@@ -4079,17 +3323,11 @@ input journals_updates {
   delete key/value pair or string element. key/value pairs are matched based on their key value
   """
   _delete_key: journals_delete_key_input
-  """
-  prepend existing jsonb value of filtered columns with new jsonb value
-  """
+  """prepend existing jsonb value of filtered columns with new jsonb value"""
   _prepend: journals_prepend_input
-  """
-  sets the columns of the filtered rows to the given values
-  """
+  """sets the columns of the filtered rows to the given values"""
   _set: journals_set_input
-  """
-  filter the rows which have to be updated
-  """
+  """filter the rows which have to be updated"""
   where: journals_bool_exp!
 }
 
@@ -4104,28 +3342,18 @@ Boolean expression to compare columns of type "jsonb". All fields are combined w
 """
 input jsonb_comparison_exp {
   _cast: jsonb_cast_exp
-  """
-  is the column contained in the given json value
-  """
+  """is the column contained in the given json value"""
   _contained_in: jsonb
-  """
-  does the column contain the given json value at the top level
-  """
+  """does the column contain the given json value at the top level"""
   _contains: jsonb
   _eq: jsonb
   _gt: jsonb
   _gte: jsonb
-  """
-  does the string exist as a top-level key in the column
-  """
+  """does the string exist as a top-level key in the column"""
   _has_key: String
-  """
-  do all of these strings exist as top-level keys in the column
-  """
+  """do all of these strings exist as top-level keys in the column"""
   _has_keys_all: [String!]
-  """
-  do any of these strings exist as top-level keys in the column
-  """
+  """do any of these strings exist as top-level keys in the column"""
   _has_keys_any: [String!]
   _in: [jsonb!]
   _is_null: Boolean
@@ -4135,16 +3363,12 @@ input jsonb_comparison_exp {
   _nin: [jsonb!]
 }
 
-"""
-mutation root
-"""
+"""mutation root"""
 type mutation_root {
   """
   Request to generate code for next step authentication, called from other sources like smart tivi apps, extensions, etc.
   """
-  createDeviceRequest(
-    input: CreateDeviceRequestInput!
-  ): CreateDeviceRequestResponse!
+  createDeviceRequest(input: CreateDeviceRequestInput!): CreateDeviceRequestResponse!
   """
   Generate a V4 signed PUT URL for a direct browser-to-GCS upload (app-agnostic).
   """
@@ -4153,9 +3377,7 @@ type mutation_root {
   delete data from the table: "audio_tags"
   """
   delete_audio_tags(
-    """
-    filter the rows which have to be deleted
-    """
+    """filter the rows which have to be deleted"""
     where: audio_tags_bool_exp!
   ): audio_tags_mutation_response
   """
@@ -4166,9 +3388,7 @@ type mutation_root {
   delete data from the table: "audios"
   """
   delete_audios(
-    """
-    filter the rows which have to be deleted
-    """
+    """filter the rows which have to be deleted"""
     where: audios_bool_exp!
   ): audios_mutation_response
   """
@@ -4179,9 +3399,7 @@ type mutation_root {
   delete data from the table: "book_comments"
   """
   delete_book_comments(
-    """
-    filter the rows which have to be deleted
-    """
+    """filter the rows which have to be deleted"""
     where: book_comments_bool_exp!
   ): book_comments_mutation_response
   """
@@ -4192,9 +3410,7 @@ type mutation_root {
   delete data from the table: "books"
   """
   delete_books(
-    """
-    filter the rows which have to be deleted
-    """
+    """filter the rows which have to be deleted"""
     where: books_bool_exp!
   ): books_mutation_response
   """
@@ -4205,9 +3421,7 @@ type mutation_root {
   delete data from the table: "crawl_requests"
   """
   delete_crawl_requests(
-    """
-    filter the rows which have to be deleted
-    """
+    """filter the rows which have to be deleted"""
     where: crawl_requests_bool_exp!
   ): crawl_requests_mutation_response
   """
@@ -4218,9 +3432,7 @@ type mutation_root {
   delete data from the table: "device_requests"
   """
   delete_device_requests(
-    """
-    filter the rows which have to be deleted
-    """
+    """filter the rows which have to be deleted"""
     where: device_requests_bool_exp!
   ): device_requests_mutation_response
   """
@@ -4231,9 +3443,7 @@ type mutation_root {
   delete data from the table: "feature_flag"
   """
   delete_feature_flag(
-    """
-    filter the rows which have to be deleted
-    """
+    """filter the rows which have to be deleted"""
     where: feature_flag_bool_exp!
   ): feature_flag_mutation_response
   """
@@ -4244,9 +3454,7 @@ type mutation_root {
   delete data from the table: "finance_transactions"
   """
   delete_finance_transactions(
-    """
-    filter the rows which have to be deleted
-    """
+    """filter the rows which have to be deleted"""
     where: finance_transactions_bool_exp!
   ): finance_transactions_mutation_response
   """
@@ -4257,9 +3465,7 @@ type mutation_root {
   delete data from the table: "journals"
   """
   delete_journals(
-    """
-    filter the rows which have to be deleted
-    """
+    """filter the rows which have to be deleted"""
     where: journals_bool_exp!
   ): journals_mutation_response
   """
@@ -4270,9 +3476,7 @@ type mutation_root {
   delete data from the table: "notifications"
   """
   delete_notifications(
-    """
-    filter the rows which have to be deleted
-    """
+    """filter the rows which have to be deleted"""
     where: notifications_bool_exp!
   ): notifications_mutation_response
   """
@@ -4283,27 +3487,20 @@ type mutation_root {
   delete data from the table: "playlist"
   """
   delete_playlist(
-    """
-    filter the rows which have to be deleted
-    """
+    """filter the rows which have to be deleted"""
     where: playlist_bool_exp!
   ): playlist_mutation_response
   """
   delete data from the table: "playlist_audios"
   """
   delete_playlist_audios(
-    """
-    filter the rows which have to be deleted
-    """
+    """filter the rows which have to be deleted"""
     where: playlist_audios_bool_exp!
   ): playlist_audios_mutation_response
   """
   delete single row from the table: "playlist_audios"
   """
-  delete_playlist_audios_by_pk(
-    audio_id: uuid!
-    playlist_id: uuid!
-  ): playlist_audios
+  delete_playlist_audios_by_pk(audio_id: uuid!, playlist_id: uuid!): playlist_audios
   """
   delete single row from the table: "playlist"
   """
@@ -4312,25 +3509,18 @@ type mutation_root {
   delete data from the table: "playlist_videos"
   """
   delete_playlist_videos(
-    """
-    filter the rows which have to be deleted
-    """
+    """filter the rows which have to be deleted"""
     where: playlist_videos_bool_exp!
   ): playlist_videos_mutation_response
   """
   delete single row from the table: "playlist_videos"
   """
-  delete_playlist_videos_by_pk(
-    playlist_id: uuid!
-    video_id: uuid!
-  ): playlist_videos
+  delete_playlist_videos_by_pk(playlist_id: uuid!, video_id: uuid!): playlist_videos
   """
   delete data from the table: "posts"
   """
   delete_posts(
-    """
-    filter the rows which have to be deleted
-    """
+    """filter the rows which have to be deleted"""
     where: posts_bool_exp!
   ): posts_mutation_response
   """
@@ -4341,9 +3531,7 @@ type mutation_root {
   delete data from the table: "reading_progresses"
   """
   delete_reading_progresses(
-    """
-    filter the rows which have to be deleted
-    """
+    """filter the rows which have to be deleted"""
     where: reading_progresses_bool_exp!
   ): reading_progresses_mutation_response
   """
@@ -4354,9 +3542,7 @@ type mutation_root {
   delete data from the table: "shared_playlist_recipients"
   """
   delete_shared_playlist_recipients(
-    """
-    filter the rows which have to be deleted
-    """
+    """filter the rows which have to be deleted"""
     where: shared_playlist_recipients_bool_exp!
   ): shared_playlist_recipients_mutation_response
   """
@@ -4367,9 +3553,7 @@ type mutation_root {
   delete data from the table: "shared_video_recipients"
   """
   delete_shared_video_recipients(
-    """
-    filter the rows which have to be deleted
-    """
+    """filter the rows which have to be deleted"""
     where: shared_video_recipients_bool_exp!
   ): shared_video_recipients_mutation_response
   """
@@ -4380,9 +3564,7 @@ type mutation_root {
   delete data from the table: "subtitles"
   """
   delete_subtitles(
-    """
-    filter the rows which have to be deleted
-    """
+    """filter the rows which have to be deleted"""
     where: subtitles_bool_exp!
   ): subtitles_mutation_response
   """
@@ -4393,9 +3575,7 @@ type mutation_root {
   delete data from the table: "tags"
   """
   delete_tags(
-    """
-    filter the rows which have to be deleted
-    """
+    """filter the rows which have to be deleted"""
     where: tags_bool_exp!
   ): tags_mutation_response
   """
@@ -4406,9 +3586,7 @@ type mutation_root {
   delete data from the table: "tasks"
   """
   delete_tasks(
-    """
-    filter the rows which have to be deleted
-    """
+    """filter the rows which have to be deleted"""
     where: tasks_bool_exp!
   ): tasks_mutation_response
   """
@@ -4419,9 +3597,7 @@ type mutation_root {
   delete data from the table: "test"
   """
   delete_test(
-    """
-    filter the rows which have to be deleted
-    """
+    """filter the rows which have to be deleted"""
     where: test_bool_exp!
   ): test_mutation_response
   """
@@ -4429,12 +3605,21 @@ type mutation_root {
   """
   delete_test_by_pk(id: Int!): test
   """
+  delete data from the table: "user_settings"
+  """
+  delete_user_settings(
+    """filter the rows which have to be deleted"""
+    where: user_settings_bool_exp!
+  ): user_settings_mutation_response
+  """
+  delete single row from the table: "user_settings"
+  """
+  delete_user_settings_by_pk(user_id: uuid!): user_settings
+  """
   delete data from the table: "user_video_history"
   """
   delete_user_video_history(
-    """
-    filter the rows which have to be deleted
-    """
+    """filter the rows which have to be deleted"""
     where: user_video_history_bool_exp!
   ): user_video_history_mutation_response
   """
@@ -4445,9 +3630,7 @@ type mutation_root {
   delete data from the table: "users"
   """
   delete_users(
-    """
-    filter the rows which have to be deleted
-    """
+    """filter the rows which have to be deleted"""
     where: users_bool_exp!
   ): users_mutation_response
   """
@@ -4458,9 +3641,7 @@ type mutation_root {
   delete data from the table: "video_tags"
   """
   delete_video_tags(
-    """
-    filter the rows which have to be deleted
-    """
+    """filter the rows which have to be deleted"""
     where: video_tags_bool_exp!
   ): video_tags_mutation_response
   """
@@ -4471,9 +3652,7 @@ type mutation_root {
   delete data from the table: "video_views"
   """
   delete_video_views(
-    """
-    filter the rows which have to be deleted
-    """
+    """filter the rows which have to be deleted"""
     where: video_views_bool_exp!
   ): video_views_mutation_response
   """
@@ -4484,9 +3663,7 @@ type mutation_root {
   delete data from the table: "videos"
   """
   delete_videos(
-    """
-    filter the rows which have to be deleted
-    """
+    """filter the rows which have to be deleted"""
     where: videos_bool_exp!
   ): videos_mutation_response
   """
@@ -4497,704 +3674,506 @@ type mutation_root {
   insert data into the table: "audio_tags"
   """
   insert_audio_tags(
-    """
-    the rows to be inserted
-    """
+    """the rows to be inserted"""
     objects: [audio_tags_insert_input!]!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: audio_tags_on_conflict
   ): audio_tags_mutation_response
   """
   insert a single row into the table: "audio_tags"
   """
   insert_audio_tags_one(
-    """
-    the row to be inserted
-    """
+    """the row to be inserted"""
     object: audio_tags_insert_input!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: audio_tags_on_conflict
   ): audio_tags
   """
   insert data into the table: "audios"
   """
   insert_audios(
-    """
-    the rows to be inserted
-    """
+    """the rows to be inserted"""
     objects: [audios_insert_input!]!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: audios_on_conflict
   ): audios_mutation_response
   """
   insert a single row into the table: "audios"
   """
   insert_audios_one(
-    """
-    the row to be inserted
-    """
+    """the row to be inserted"""
     object: audios_insert_input!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: audios_on_conflict
   ): audios
   """
   insert data into the table: "book_comments"
   """
   insert_book_comments(
-    """
-    the rows to be inserted
-    """
+    """the rows to be inserted"""
     objects: [book_comments_insert_input!]!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: book_comments_on_conflict
   ): book_comments_mutation_response
   """
   insert a single row into the table: "book_comments"
   """
   insert_book_comments_one(
-    """
-    the row to be inserted
-    """
+    """the row to be inserted"""
     object: book_comments_insert_input!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: book_comments_on_conflict
   ): book_comments
   """
   insert data into the table: "books"
   """
   insert_books(
-    """
-    the rows to be inserted
-    """
+    """the rows to be inserted"""
     objects: [books_insert_input!]!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: books_on_conflict
   ): books_mutation_response
   """
   insert a single row into the table: "books"
   """
   insert_books_one(
-    """
-    the row to be inserted
-    """
+    """the row to be inserted"""
     object: books_insert_input!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: books_on_conflict
   ): books
   """
   insert data into the table: "crawl_requests"
   """
   insert_crawl_requests(
-    """
-    the rows to be inserted
-    """
+    """the rows to be inserted"""
     objects: [crawl_requests_insert_input!]!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: crawl_requests_on_conflict
   ): crawl_requests_mutation_response
   """
   insert a single row into the table: "crawl_requests"
   """
   insert_crawl_requests_one(
-    """
-    the row to be inserted
-    """
+    """the row to be inserted"""
     object: crawl_requests_insert_input!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: crawl_requests_on_conflict
   ): crawl_requests
   """
   insert data into the table: "device_requests"
   """
   insert_device_requests(
-    """
-    the rows to be inserted
-    """
+    """the rows to be inserted"""
     objects: [device_requests_insert_input!]!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: device_requests_on_conflict
   ): device_requests_mutation_response
   """
   insert a single row into the table: "device_requests"
   """
   insert_device_requests_one(
-    """
-    the row to be inserted
-    """
+    """the row to be inserted"""
     object: device_requests_insert_input!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: device_requests_on_conflict
   ): device_requests
   """
   insert data into the table: "feature_flag"
   """
   insert_feature_flag(
-    """
-    the rows to be inserted
-    """
+    """the rows to be inserted"""
     objects: [feature_flag_insert_input!]!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: feature_flag_on_conflict
   ): feature_flag_mutation_response
   """
   insert a single row into the table: "feature_flag"
   """
   insert_feature_flag_one(
-    """
-    the row to be inserted
-    """
+    """the row to be inserted"""
     object: feature_flag_insert_input!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: feature_flag_on_conflict
   ): feature_flag
   """
   insert data into the table: "finance_transactions"
   """
   insert_finance_transactions(
-    """
-    the rows to be inserted
-    """
+    """the rows to be inserted"""
     objects: [finance_transactions_insert_input!]!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: finance_transactions_on_conflict
   ): finance_transactions_mutation_response
   """
   insert a single row into the table: "finance_transactions"
   """
   insert_finance_transactions_one(
-    """
-    the row to be inserted
-    """
+    """the row to be inserted"""
     object: finance_transactions_insert_input!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: finance_transactions_on_conflict
   ): finance_transactions
   """
   insert data into the table: "journals"
   """
   insert_journals(
-    """
-    the rows to be inserted
-    """
+    """the rows to be inserted"""
     objects: [journals_insert_input!]!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: journals_on_conflict
   ): journals_mutation_response
   """
   insert a single row into the table: "journals"
   """
   insert_journals_one(
-    """
-    the row to be inserted
-    """
+    """the row to be inserted"""
     object: journals_insert_input!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: journals_on_conflict
   ): journals
   """
   insert data into the table: "notifications"
   """
   insert_notifications(
-    """
-    the rows to be inserted
-    """
+    """the rows to be inserted"""
     objects: [notifications_insert_input!]!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: notifications_on_conflict
   ): notifications_mutation_response
   """
   insert a single row into the table: "notifications"
   """
   insert_notifications_one(
-    """
-    the row to be inserted
-    """
+    """the row to be inserted"""
     object: notifications_insert_input!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: notifications_on_conflict
   ): notifications
   """
   insert data into the table: "playlist"
   """
   insert_playlist(
-    """
-    the rows to be inserted
-    """
+    """the rows to be inserted"""
     objects: [playlist_insert_input!]!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: playlist_on_conflict
   ): playlist_mutation_response
   """
   insert data into the table: "playlist_audios"
   """
   insert_playlist_audios(
-    """
-    the rows to be inserted
-    """
+    """the rows to be inserted"""
     objects: [playlist_audios_insert_input!]!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: playlist_audios_on_conflict
   ): playlist_audios_mutation_response
   """
   insert a single row into the table: "playlist_audios"
   """
   insert_playlist_audios_one(
-    """
-    the row to be inserted
-    """
+    """the row to be inserted"""
     object: playlist_audios_insert_input!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: playlist_audios_on_conflict
   ): playlist_audios
   """
   insert a single row into the table: "playlist"
   """
   insert_playlist_one(
-    """
-    the row to be inserted
-    """
+    """the row to be inserted"""
     object: playlist_insert_input!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: playlist_on_conflict
   ): playlist
   """
   insert data into the table: "playlist_videos"
   """
   insert_playlist_videos(
-    """
-    the rows to be inserted
-    """
+    """the rows to be inserted"""
     objects: [playlist_videos_insert_input!]!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: playlist_videos_on_conflict
   ): playlist_videos_mutation_response
   """
   insert a single row into the table: "playlist_videos"
   """
   insert_playlist_videos_one(
-    """
-    the row to be inserted
-    """
+    """the row to be inserted"""
     object: playlist_videos_insert_input!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: playlist_videos_on_conflict
   ): playlist_videos
   """
   insert data into the table: "posts"
   """
   insert_posts(
-    """
-    the rows to be inserted
-    """
+    """the rows to be inserted"""
     objects: [posts_insert_input!]!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: posts_on_conflict
   ): posts_mutation_response
   """
   insert a single row into the table: "posts"
   """
   insert_posts_one(
-    """
-    the row to be inserted
-    """
+    """the row to be inserted"""
     object: posts_insert_input!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: posts_on_conflict
   ): posts
   """
   insert data into the table: "reading_progresses"
   """
   insert_reading_progresses(
-    """
-    the rows to be inserted
-    """
+    """the rows to be inserted"""
     objects: [reading_progresses_insert_input!]!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: reading_progresses_on_conflict
   ): reading_progresses_mutation_response
   """
   insert a single row into the table: "reading_progresses"
   """
   insert_reading_progresses_one(
-    """
-    the row to be inserted
-    """
+    """the row to be inserted"""
     object: reading_progresses_insert_input!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: reading_progresses_on_conflict
   ): reading_progresses
   """
   insert data into the table: "shared_playlist_recipients"
   """
   insert_shared_playlist_recipients(
-    """
-    the rows to be inserted
-    """
+    """the rows to be inserted"""
     objects: [shared_playlist_recipients_insert_input!]!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: shared_playlist_recipients_on_conflict
   ): shared_playlist_recipients_mutation_response
   """
   insert a single row into the table: "shared_playlist_recipients"
   """
   insert_shared_playlist_recipients_one(
-    """
-    the row to be inserted
-    """
+    """the row to be inserted"""
     object: shared_playlist_recipients_insert_input!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: shared_playlist_recipients_on_conflict
   ): shared_playlist_recipients
   """
   insert data into the table: "shared_video_recipients"
   """
   insert_shared_video_recipients(
-    """
-    the rows to be inserted
-    """
+    """the rows to be inserted"""
     objects: [shared_video_recipients_insert_input!]!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: shared_video_recipients_on_conflict
   ): shared_video_recipients_mutation_response
   """
   insert a single row into the table: "shared_video_recipients"
   """
   insert_shared_video_recipients_one(
-    """
-    the row to be inserted
-    """
+    """the row to be inserted"""
     object: shared_video_recipients_insert_input!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: shared_video_recipients_on_conflict
   ): shared_video_recipients
   """
   insert data into the table: "subtitles"
   """
   insert_subtitles(
-    """
-    the rows to be inserted
-    """
+    """the rows to be inserted"""
     objects: [subtitles_insert_input!]!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: subtitles_on_conflict
   ): subtitles_mutation_response
   """
   insert a single row into the table: "subtitles"
   """
   insert_subtitles_one(
-    """
-    the row to be inserted
-    """
+    """the row to be inserted"""
     object: subtitles_insert_input!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: subtitles_on_conflict
   ): subtitles
   """
   insert data into the table: "tags"
   """
   insert_tags(
-    """
-    the rows to be inserted
-    """
+    """the rows to be inserted"""
     objects: [tags_insert_input!]!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: tags_on_conflict
   ): tags_mutation_response
   """
   insert a single row into the table: "tags"
   """
   insert_tags_one(
-    """
-    the row to be inserted
-    """
+    """the row to be inserted"""
     object: tags_insert_input!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: tags_on_conflict
   ): tags
   """
   insert data into the table: "tasks"
   """
   insert_tasks(
-    """
-    the rows to be inserted
-    """
+    """the rows to be inserted"""
     objects: [tasks_insert_input!]!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: tasks_on_conflict
   ): tasks_mutation_response
   """
   insert a single row into the table: "tasks"
   """
   insert_tasks_one(
-    """
-    the row to be inserted
-    """
+    """the row to be inserted"""
     object: tasks_insert_input!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: tasks_on_conflict
   ): tasks
   """
   insert data into the table: "test"
   """
   insert_test(
-    """
-    the rows to be inserted
-    """
+    """the rows to be inserted"""
     objects: [test_insert_input!]!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: test_on_conflict
   ): test_mutation_response
   """
   insert a single row into the table: "test"
   """
   insert_test_one(
-    """
-    the row to be inserted
-    """
+    """the row to be inserted"""
     object: test_insert_input!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: test_on_conflict
   ): test
+  """
+  insert data into the table: "user_settings"
+  """
+  insert_user_settings(
+    """the rows to be inserted"""
+    objects: [user_settings_insert_input!]!
+    """upsert condition"""
+    on_conflict: user_settings_on_conflict
+  ): user_settings_mutation_response
+  """
+  insert a single row into the table: "user_settings"
+  """
+  insert_user_settings_one(
+    """the row to be inserted"""
+    object: user_settings_insert_input!
+    """upsert condition"""
+    on_conflict: user_settings_on_conflict
+  ): user_settings
   """
   insert data into the table: "user_video_history"
   """
   insert_user_video_history(
-    """
-    the rows to be inserted
-    """
+    """the rows to be inserted"""
     objects: [user_video_history_insert_input!]!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: user_video_history_on_conflict
   ): user_video_history_mutation_response
   """
   insert a single row into the table: "user_video_history"
   """
   insert_user_video_history_one(
-    """
-    the row to be inserted
-    """
+    """the row to be inserted"""
     object: user_video_history_insert_input!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: user_video_history_on_conflict
   ): user_video_history
   """
   insert data into the table: "users"
   """
   insert_users(
-    """
-    the rows to be inserted
-    """
+    """the rows to be inserted"""
     objects: [users_insert_input!]!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: users_on_conflict
   ): users_mutation_response
   """
   insert a single row into the table: "users"
   """
   insert_users_one(
-    """
-    the row to be inserted
-    """
+    """the row to be inserted"""
     object: users_insert_input!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: users_on_conflict
   ): users
   """
   insert data into the table: "video_tags"
   """
   insert_video_tags(
-    """
-    the rows to be inserted
-    """
+    """the rows to be inserted"""
     objects: [video_tags_insert_input!]!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: video_tags_on_conflict
   ): video_tags_mutation_response
   """
   insert a single row into the table: "video_tags"
   """
   insert_video_tags_one(
-    """
-    the row to be inserted
-    """
+    """the row to be inserted"""
     object: video_tags_insert_input!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: video_tags_on_conflict
   ): video_tags
   """
   insert data into the table: "video_views"
   """
   insert_video_views(
-    """
-    the rows to be inserted
-    """
+    """the rows to be inserted"""
     objects: [video_views_insert_input!]!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: video_views_on_conflict
   ): video_views_mutation_response
   """
   insert a single row into the table: "video_views"
   """
   insert_video_views_one(
-    """
-    the row to be inserted
-    """
+    """the row to be inserted"""
     object: video_views_insert_input!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: video_views_on_conflict
   ): video_views
   """
   insert data into the table: "videos"
   """
   insert_videos(
-    """
-    the rows to be inserted
-    """
+    """the rows to be inserted"""
     objects: [videos_insert_input!]!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: videos_on_conflict
   ): videos_mutation_response
   """
   insert a single row into the table: "videos"
   """
   insert_videos_one(
-    """
-    the row to be inserted
-    """
+    """the row to be inserted"""
     object: videos_insert_input!
-    """
-    upsert condition
-    """
+    """upsert condition"""
     on_conflict: videos_on_conflict
   ): videos
   """
   Capture the frame at a given timestamp and persist it as the video's thumbnail; ownership enforced server-side against the session user.
   """
-  setVideoThumbnailAtTime(
-    input: SetVideoThumbnailAtTimeInput!
-  ): SetVideoThumbnailAtTimeResponse!
+  setVideoThumbnailAtTime(input: SetVideoThumbnailAtTimeInput!): SetVideoThumbnailAtTimeResponse!
   """
   update data of the table: "audio_tags"
   """
   update_audio_tags(
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: audio_tags_set_input
-    """
-    filter the rows which have to be updated
-    """
+    """filter the rows which have to be updated"""
     where: audio_tags_bool_exp!
   ): audio_tags_mutation_response
   """
   update single row of the table: "audio_tags"
   """
   update_audio_tags_by_pk(
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: audio_tags_set_input
     pk_columns: audio_tags_pk_columns_input!
   ): audio_tags
@@ -5202,31 +4181,23 @@ type mutation_root {
   update multiples rows of table: "audio_tags"
   """
   update_audio_tags_many(
-    """
-    updates to execute, in order
-    """
+    """updates to execute, in order"""
     updates: [audio_tags_updates!]!
   ): [audio_tags_mutation_response]
   """
   update data of the table: "audios"
   """
   update_audios(
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: audios_set_input
-    """
-    filter the rows which have to be updated
-    """
+    """filter the rows which have to be updated"""
     where: audios_bool_exp!
   ): audios_mutation_response
   """
   update single row of the table: "audios"
   """
   update_audios_by_pk(
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: audios_set_input
     pk_columns: audios_pk_columns_input!
   ): audios
@@ -5234,31 +4205,23 @@ type mutation_root {
   update multiples rows of table: "audios"
   """
   update_audios_many(
-    """
-    updates to execute, in order
-    """
+    """updates to execute, in order"""
     updates: [audios_updates!]!
   ): [audios_mutation_response]
   """
   update data of the table: "book_comments"
   """
   update_book_comments(
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: book_comments_set_input
-    """
-    filter the rows which have to be updated
-    """
+    """filter the rows which have to be updated"""
     where: book_comments_bool_exp!
   ): book_comments_mutation_response
   """
   update single row of the table: "book_comments"
   """
   update_book_comments_by_pk(
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: book_comments_set_input
     pk_columns: book_comments_pk_columns_input!
   ): book_comments
@@ -5266,39 +4229,27 @@ type mutation_root {
   update multiples rows of table: "book_comments"
   """
   update_book_comments_many(
-    """
-    updates to execute, in order
-    """
+    """updates to execute, in order"""
     updates: [book_comments_updates!]!
   ): [book_comments_mutation_response]
   """
   update data of the table: "books"
   """
   update_books(
-    """
-    increments the numeric columns with given value of the filtered values
-    """
+    """increments the numeric columns with given value of the filtered values"""
     _inc: books_inc_input
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: books_set_input
-    """
-    filter the rows which have to be updated
-    """
+    """filter the rows which have to be updated"""
     where: books_bool_exp!
   ): books_mutation_response
   """
   update single row of the table: "books"
   """
   update_books_by_pk(
-    """
-    increments the numeric columns with given value of the filtered values
-    """
+    """increments the numeric columns with given value of the filtered values"""
     _inc: books_inc_input
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: books_set_input
     pk_columns: books_pk_columns_input!
   ): books
@@ -5306,31 +4257,23 @@ type mutation_root {
   update multiples rows of table: "books"
   """
   update_books_many(
-    """
-    updates to execute, in order
-    """
+    """updates to execute, in order"""
     updates: [books_updates!]!
   ): [books_mutation_response]
   """
   update data of the table: "crawl_requests"
   """
   update_crawl_requests(
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: crawl_requests_set_input
-    """
-    filter the rows which have to be updated
-    """
+    """filter the rows which have to be updated"""
     where: crawl_requests_bool_exp!
   ): crawl_requests_mutation_response
   """
   update single row of the table: "crawl_requests"
   """
   update_crawl_requests_by_pk(
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: crawl_requests_set_input
     pk_columns: crawl_requests_pk_columns_input!
   ): crawl_requests
@@ -5338,31 +4281,23 @@ type mutation_root {
   update multiples rows of table: "crawl_requests"
   """
   update_crawl_requests_many(
-    """
-    updates to execute, in order
-    """
+    """updates to execute, in order"""
     updates: [crawl_requests_updates!]!
   ): [crawl_requests_mutation_response]
   """
   update data of the table: "device_requests"
   """
   update_device_requests(
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: device_requests_set_input
-    """
-    filter the rows which have to be updated
-    """
+    """filter the rows which have to be updated"""
     where: device_requests_bool_exp!
   ): device_requests_mutation_response
   """
   update single row of the table: "device_requests"
   """
   update_device_requests_by_pk(
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: device_requests_set_input
     pk_columns: device_requests_pk_columns_input!
   ): device_requests
@@ -5370,18 +4305,14 @@ type mutation_root {
   update multiples rows of table: "device_requests"
   """
   update_device_requests_many(
-    """
-    updates to execute, in order
-    """
+    """updates to execute, in order"""
     updates: [device_requests_updates!]!
   ): [device_requests_mutation_response]
   """
   update data of the table: "feature_flag"
   """
   update_feature_flag(
-    """
-    append existing jsonb value of filtered columns with new jsonb value
-    """
+    """append existing jsonb value of filtered columns with new jsonb value"""
     _append: feature_flag_append_input
     """
     delete the field or element with specified path (for JSON arrays, negative integers count from the end)
@@ -5395,26 +4326,18 @@ type mutation_root {
     delete key/value pair or string element. key/value pairs are matched based on their key value
     """
     _delete_key: feature_flag_delete_key_input
-    """
-    prepend existing jsonb value of filtered columns with new jsonb value
-    """
+    """prepend existing jsonb value of filtered columns with new jsonb value"""
     _prepend: feature_flag_prepend_input
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: feature_flag_set_input
-    """
-    filter the rows which have to be updated
-    """
+    """filter the rows which have to be updated"""
     where: feature_flag_bool_exp!
   ): feature_flag_mutation_response
   """
   update single row of the table: "feature_flag"
   """
   update_feature_flag_by_pk(
-    """
-    append existing jsonb value of filtered columns with new jsonb value
-    """
+    """append existing jsonb value of filtered columns with new jsonb value"""
     _append: feature_flag_append_input
     """
     delete the field or element with specified path (for JSON arrays, negative integers count from the end)
@@ -5428,13 +4351,9 @@ type mutation_root {
     delete key/value pair or string element. key/value pairs are matched based on their key value
     """
     _delete_key: feature_flag_delete_key_input
-    """
-    prepend existing jsonb value of filtered columns with new jsonb value
-    """
+    """prepend existing jsonb value of filtered columns with new jsonb value"""
     _prepend: feature_flag_prepend_input
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: feature_flag_set_input
     pk_columns: feature_flag_pk_columns_input!
   ): feature_flag
@@ -5442,39 +4361,27 @@ type mutation_root {
   update multiples rows of table: "feature_flag"
   """
   update_feature_flag_many(
-    """
-    updates to execute, in order
-    """
+    """updates to execute, in order"""
     updates: [feature_flag_updates!]!
   ): [feature_flag_mutation_response]
   """
   update data of the table: "finance_transactions"
   """
   update_finance_transactions(
-    """
-    increments the numeric columns with given value of the filtered values
-    """
+    """increments the numeric columns with given value of the filtered values"""
     _inc: finance_transactions_inc_input
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: finance_transactions_set_input
-    """
-    filter the rows which have to be updated
-    """
+    """filter the rows which have to be updated"""
     where: finance_transactions_bool_exp!
   ): finance_transactions_mutation_response
   """
   update single row of the table: "finance_transactions"
   """
   update_finance_transactions_by_pk(
-    """
-    increments the numeric columns with given value of the filtered values
-    """
+    """increments the numeric columns with given value of the filtered values"""
     _inc: finance_transactions_inc_input
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: finance_transactions_set_input
     pk_columns: finance_transactions_pk_columns_input!
   ): finance_transactions
@@ -5482,18 +4389,14 @@ type mutation_root {
   update multiples rows of table: "finance_transactions"
   """
   update_finance_transactions_many(
-    """
-    updates to execute, in order
-    """
+    """updates to execute, in order"""
     updates: [finance_transactions_updates!]!
   ): [finance_transactions_mutation_response]
   """
   update data of the table: "journals"
   """
   update_journals(
-    """
-    append existing jsonb value of filtered columns with new jsonb value
-    """
+    """append existing jsonb value of filtered columns with new jsonb value"""
     _append: journals_append_input
     """
     delete the field or element with specified path (for JSON arrays, negative integers count from the end)
@@ -5507,26 +4410,18 @@ type mutation_root {
     delete key/value pair or string element. key/value pairs are matched based on their key value
     """
     _delete_key: journals_delete_key_input
-    """
-    prepend existing jsonb value of filtered columns with new jsonb value
-    """
+    """prepend existing jsonb value of filtered columns with new jsonb value"""
     _prepend: journals_prepend_input
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: journals_set_input
-    """
-    filter the rows which have to be updated
-    """
+    """filter the rows which have to be updated"""
     where: journals_bool_exp!
   ): journals_mutation_response
   """
   update single row of the table: "journals"
   """
   update_journals_by_pk(
-    """
-    append existing jsonb value of filtered columns with new jsonb value
-    """
+    """append existing jsonb value of filtered columns with new jsonb value"""
     _append: journals_append_input
     """
     delete the field or element with specified path (for JSON arrays, negative integers count from the end)
@@ -5540,13 +4435,9 @@ type mutation_root {
     delete key/value pair or string element. key/value pairs are matched based on their key value
     """
     _delete_key: journals_delete_key_input
-    """
-    prepend existing jsonb value of filtered columns with new jsonb value
-    """
+    """prepend existing jsonb value of filtered columns with new jsonb value"""
     _prepend: journals_prepend_input
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: journals_set_input
     pk_columns: journals_pk_columns_input!
   ): journals
@@ -5554,18 +4445,14 @@ type mutation_root {
   update multiples rows of table: "journals"
   """
   update_journals_many(
-    """
-    updates to execute, in order
-    """
+    """updates to execute, in order"""
     updates: [journals_updates!]!
   ): [journals_mutation_response]
   """
   update data of the table: "notifications"
   """
   update_notifications(
-    """
-    append existing jsonb value of filtered columns with new jsonb value
-    """
+    """append existing jsonb value of filtered columns with new jsonb value"""
     _append: notifications_append_input
     """
     delete the field or element with specified path (for JSON arrays, negative integers count from the end)
@@ -5579,26 +4466,18 @@ type mutation_root {
     delete key/value pair or string element. key/value pairs are matched based on their key value
     """
     _delete_key: notifications_delete_key_input
-    """
-    prepend existing jsonb value of filtered columns with new jsonb value
-    """
+    """prepend existing jsonb value of filtered columns with new jsonb value"""
     _prepend: notifications_prepend_input
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: notifications_set_input
-    """
-    filter the rows which have to be updated
-    """
+    """filter the rows which have to be updated"""
     where: notifications_bool_exp!
   ): notifications_mutation_response
   """
   update single row of the table: "notifications"
   """
   update_notifications_by_pk(
-    """
-    append existing jsonb value of filtered columns with new jsonb value
-    """
+    """append existing jsonb value of filtered columns with new jsonb value"""
     _append: notifications_append_input
     """
     delete the field or element with specified path (for JSON arrays, negative integers count from the end)
@@ -5612,13 +4491,9 @@ type mutation_root {
     delete key/value pair or string element. key/value pairs are matched based on their key value
     """
     _delete_key: notifications_delete_key_input
-    """
-    prepend existing jsonb value of filtered columns with new jsonb value
-    """
+    """prepend existing jsonb value of filtered columns with new jsonb value"""
     _prepend: notifications_prepend_input
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: notifications_set_input
     pk_columns: notifications_pk_columns_input!
   ): notifications
@@ -5626,18 +4501,14 @@ type mutation_root {
   update multiples rows of table: "notifications"
   """
   update_notifications_many(
-    """
-    updates to execute, in order
-    """
+    """updates to execute, in order"""
     updates: [notifications_updates!]!
   ): [notifications_mutation_response]
   """
   update data of the table: "playlist"
   """
   update_playlist(
-    """
-    append existing jsonb value of filtered columns with new jsonb value
-    """
+    """append existing jsonb value of filtered columns with new jsonb value"""
     _append: playlist_append_input
     """
     delete the field or element with specified path (for JSON arrays, negative integers count from the end)
@@ -5651,47 +4522,31 @@ type mutation_root {
     delete key/value pair or string element. key/value pairs are matched based on their key value
     """
     _delete_key: playlist_delete_key_input
-    """
-    prepend existing jsonb value of filtered columns with new jsonb value
-    """
+    """prepend existing jsonb value of filtered columns with new jsonb value"""
     _prepend: playlist_prepend_input
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: playlist_set_input
-    """
-    filter the rows which have to be updated
-    """
+    """filter the rows which have to be updated"""
     where: playlist_bool_exp!
   ): playlist_mutation_response
   """
   update data of the table: "playlist_audios"
   """
   update_playlist_audios(
-    """
-    increments the numeric columns with given value of the filtered values
-    """
+    """increments the numeric columns with given value of the filtered values"""
     _inc: playlist_audios_inc_input
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: playlist_audios_set_input
-    """
-    filter the rows which have to be updated
-    """
+    """filter the rows which have to be updated"""
     where: playlist_audios_bool_exp!
   ): playlist_audios_mutation_response
   """
   update single row of the table: "playlist_audios"
   """
   update_playlist_audios_by_pk(
-    """
-    increments the numeric columns with given value of the filtered values
-    """
+    """increments the numeric columns with given value of the filtered values"""
     _inc: playlist_audios_inc_input
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: playlist_audios_set_input
     pk_columns: playlist_audios_pk_columns_input!
   ): playlist_audios
@@ -5699,18 +4554,14 @@ type mutation_root {
   update multiples rows of table: "playlist_audios"
   """
   update_playlist_audios_many(
-    """
-    updates to execute, in order
-    """
+    """updates to execute, in order"""
     updates: [playlist_audios_updates!]!
   ): [playlist_audios_mutation_response]
   """
   update single row of the table: "playlist"
   """
   update_playlist_by_pk(
-    """
-    append existing jsonb value of filtered columns with new jsonb value
-    """
+    """append existing jsonb value of filtered columns with new jsonb value"""
     _append: playlist_append_input
     """
     delete the field or element with specified path (for JSON arrays, negative integers count from the end)
@@ -5724,13 +4575,9 @@ type mutation_root {
     delete key/value pair or string element. key/value pairs are matched based on their key value
     """
     _delete_key: playlist_delete_key_input
-    """
-    prepend existing jsonb value of filtered columns with new jsonb value
-    """
+    """prepend existing jsonb value of filtered columns with new jsonb value"""
     _prepend: playlist_prepend_input
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: playlist_set_input
     pk_columns: playlist_pk_columns_input!
   ): playlist
@@ -5738,39 +4585,27 @@ type mutation_root {
   update multiples rows of table: "playlist"
   """
   update_playlist_many(
-    """
-    updates to execute, in order
-    """
+    """updates to execute, in order"""
     updates: [playlist_updates!]!
   ): [playlist_mutation_response]
   """
   update data of the table: "playlist_videos"
   """
   update_playlist_videos(
-    """
-    increments the numeric columns with given value of the filtered values
-    """
+    """increments the numeric columns with given value of the filtered values"""
     _inc: playlist_videos_inc_input
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: playlist_videos_set_input
-    """
-    filter the rows which have to be updated
-    """
+    """filter the rows which have to be updated"""
     where: playlist_videos_bool_exp!
   ): playlist_videos_mutation_response
   """
   update single row of the table: "playlist_videos"
   """
   update_playlist_videos_by_pk(
-    """
-    increments the numeric columns with given value of the filtered values
-    """
+    """increments the numeric columns with given value of the filtered values"""
     _inc: playlist_videos_inc_input
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: playlist_videos_set_input
     pk_columns: playlist_videos_pk_columns_input!
   ): playlist_videos
@@ -5778,39 +4613,27 @@ type mutation_root {
   update multiples rows of table: "playlist_videos"
   """
   update_playlist_videos_many(
-    """
-    updates to execute, in order
-    """
+    """updates to execute, in order"""
     updates: [playlist_videos_updates!]!
   ): [playlist_videos_mutation_response]
   """
   update data of the table: "posts"
   """
   update_posts(
-    """
-    increments the numeric columns with given value of the filtered values
-    """
+    """increments the numeric columns with given value of the filtered values"""
     _inc: posts_inc_input
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: posts_set_input
-    """
-    filter the rows which have to be updated
-    """
+    """filter the rows which have to be updated"""
     where: posts_bool_exp!
   ): posts_mutation_response
   """
   update single row of the table: "posts"
   """
   update_posts_by_pk(
-    """
-    increments the numeric columns with given value of the filtered values
-    """
+    """increments the numeric columns with given value of the filtered values"""
     _inc: posts_inc_input
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: posts_set_input
     pk_columns: posts_pk_columns_input!
   ): posts
@@ -5818,39 +4641,27 @@ type mutation_root {
   update multiples rows of table: "posts"
   """
   update_posts_many(
-    """
-    updates to execute, in order
-    """
+    """updates to execute, in order"""
     updates: [posts_updates!]!
   ): [posts_mutation_response]
   """
   update data of the table: "reading_progresses"
   """
   update_reading_progresses(
-    """
-    increments the numeric columns with given value of the filtered values
-    """
+    """increments the numeric columns with given value of the filtered values"""
     _inc: reading_progresses_inc_input
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: reading_progresses_set_input
-    """
-    filter the rows which have to be updated
-    """
+    """filter the rows which have to be updated"""
     where: reading_progresses_bool_exp!
   ): reading_progresses_mutation_response
   """
   update single row of the table: "reading_progresses"
   """
   update_reading_progresses_by_pk(
-    """
-    increments the numeric columns with given value of the filtered values
-    """
+    """increments the numeric columns with given value of the filtered values"""
     _inc: reading_progresses_inc_input
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: reading_progresses_set_input
     pk_columns: reading_progresses_pk_columns_input!
   ): reading_progresses
@@ -5858,31 +4669,23 @@ type mutation_root {
   update multiples rows of table: "reading_progresses"
   """
   update_reading_progresses_many(
-    """
-    updates to execute, in order
-    """
+    """updates to execute, in order"""
     updates: [reading_progresses_updates!]!
   ): [reading_progresses_mutation_response]
   """
   update data of the table: "shared_playlist_recipients"
   """
   update_shared_playlist_recipients(
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: shared_playlist_recipients_set_input
-    """
-    filter the rows which have to be updated
-    """
+    """filter the rows which have to be updated"""
     where: shared_playlist_recipients_bool_exp!
   ): shared_playlist_recipients_mutation_response
   """
   update single row of the table: "shared_playlist_recipients"
   """
   update_shared_playlist_recipients_by_pk(
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: shared_playlist_recipients_set_input
     pk_columns: shared_playlist_recipients_pk_columns_input!
   ): shared_playlist_recipients
@@ -5890,31 +4693,23 @@ type mutation_root {
   update multiples rows of table: "shared_playlist_recipients"
   """
   update_shared_playlist_recipients_many(
-    """
-    updates to execute, in order
-    """
+    """updates to execute, in order"""
     updates: [shared_playlist_recipients_updates!]!
   ): [shared_playlist_recipients_mutation_response]
   """
   update data of the table: "shared_video_recipients"
   """
   update_shared_video_recipients(
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: shared_video_recipients_set_input
-    """
-    filter the rows which have to be updated
-    """
+    """filter the rows which have to be updated"""
     where: shared_video_recipients_bool_exp!
   ): shared_video_recipients_mutation_response
   """
   update single row of the table: "shared_video_recipients"
   """
   update_shared_video_recipients_by_pk(
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: shared_video_recipients_set_input
     pk_columns: shared_video_recipients_pk_columns_input!
   ): shared_video_recipients
@@ -5922,31 +4717,23 @@ type mutation_root {
   update multiples rows of table: "shared_video_recipients"
   """
   update_shared_video_recipients_many(
-    """
-    updates to execute, in order
-    """
+    """updates to execute, in order"""
     updates: [shared_video_recipients_updates!]!
   ): [shared_video_recipients_mutation_response]
   """
   update data of the table: "subtitles"
   """
   update_subtitles(
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: subtitles_set_input
-    """
-    filter the rows which have to be updated
-    """
+    """filter the rows which have to be updated"""
     where: subtitles_bool_exp!
   ): subtitles_mutation_response
   """
   update single row of the table: "subtitles"
   """
   update_subtitles_by_pk(
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: subtitles_set_input
     pk_columns: subtitles_pk_columns_input!
   ): subtitles
@@ -5954,39 +4741,27 @@ type mutation_root {
   update multiples rows of table: "subtitles"
   """
   update_subtitles_many(
-    """
-    updates to execute, in order
-    """
+    """updates to execute, in order"""
     updates: [subtitles_updates!]!
   ): [subtitles_mutation_response]
   """
   update data of the table: "tags"
   """
   update_tags(
-    """
-    increments the numeric columns with given value of the filtered values
-    """
+    """increments the numeric columns with given value of the filtered values"""
     _inc: tags_inc_input
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: tags_set_input
-    """
-    filter the rows which have to be updated
-    """
+    """filter the rows which have to be updated"""
     where: tags_bool_exp!
   ): tags_mutation_response
   """
   update single row of the table: "tags"
   """
   update_tags_by_pk(
-    """
-    increments the numeric columns with given value of the filtered values
-    """
+    """increments the numeric columns with given value of the filtered values"""
     _inc: tags_inc_input
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: tags_set_input
     pk_columns: tags_pk_columns_input!
   ): tags
@@ -5994,18 +4769,14 @@ type mutation_root {
   update multiples rows of table: "tags"
   """
   update_tags_many(
-    """
-    updates to execute, in order
-    """
+    """updates to execute, in order"""
     updates: [tags_updates!]!
   ): [tags_mutation_response]
   """
   update data of the table: "tasks"
   """
   update_tasks(
-    """
-    append existing jsonb value of filtered columns with new jsonb value
-    """
+    """append existing jsonb value of filtered columns with new jsonb value"""
     _append: tasks_append_input
     """
     delete the field or element with specified path (for JSON arrays, negative integers count from the end)
@@ -6019,26 +4790,18 @@ type mutation_root {
     delete key/value pair or string element. key/value pairs are matched based on their key value
     """
     _delete_key: tasks_delete_key_input
-    """
-    prepend existing jsonb value of filtered columns with new jsonb value
-    """
+    """prepend existing jsonb value of filtered columns with new jsonb value"""
     _prepend: tasks_prepend_input
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: tasks_set_input
-    """
-    filter the rows which have to be updated
-    """
+    """filter the rows which have to be updated"""
     where: tasks_bool_exp!
   ): tasks_mutation_response
   """
   update single row of the table: "tasks"
   """
   update_tasks_by_pk(
-    """
-    append existing jsonb value of filtered columns with new jsonb value
-    """
+    """append existing jsonb value of filtered columns with new jsonb value"""
     _append: tasks_append_input
     """
     delete the field or element with specified path (for JSON arrays, negative integers count from the end)
@@ -6052,13 +4815,9 @@ type mutation_root {
     delete key/value pair or string element. key/value pairs are matched based on their key value
     """
     _delete_key: tasks_delete_key_input
-    """
-    prepend existing jsonb value of filtered columns with new jsonb value
-    """
+    """prepend existing jsonb value of filtered columns with new jsonb value"""
     _prepend: tasks_prepend_input
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: tasks_set_input
     pk_columns: tasks_pk_columns_input!
   ): tasks
@@ -6066,39 +4825,27 @@ type mutation_root {
   update multiples rows of table: "tasks"
   """
   update_tasks_many(
-    """
-    updates to execute, in order
-    """
+    """updates to execute, in order"""
     updates: [tasks_updates!]!
   ): [tasks_mutation_response]
   """
   update data of the table: "test"
   """
   update_test(
-    """
-    increments the numeric columns with given value of the filtered values
-    """
+    """increments the numeric columns with given value of the filtered values"""
     _inc: test_inc_input
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: test_set_input
-    """
-    filter the rows which have to be updated
-    """
+    """filter the rows which have to be updated"""
     where: test_bool_exp!
   ): test_mutation_response
   """
   update single row of the table: "test"
   """
   update_test_by_pk(
-    """
-    increments the numeric columns with given value of the filtered values
-    """
+    """increments the numeric columns with given value of the filtered values"""
     _inc: test_inc_input
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: test_set_input
     pk_columns: test_pk_columns_input!
   ): test
@@ -6106,39 +4853,83 @@ type mutation_root {
   update multiples rows of table: "test"
   """
   update_test_many(
-    """
-    updates to execute, in order
-    """
+    """updates to execute, in order"""
     updates: [test_updates!]!
   ): [test_mutation_response]
+  """
+  update data of the table: "user_settings"
+  """
+  update_user_settings(
+    """append existing jsonb value of filtered columns with new jsonb value"""
+    _append: user_settings_append_input
+    """
+    delete the field or element with specified path (for JSON arrays, negative integers count from the end)
+    """
+    _delete_at_path: user_settings_delete_at_path_input
+    """
+    delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array
+    """
+    _delete_elem: user_settings_delete_elem_input
+    """
+    delete key/value pair or string element. key/value pairs are matched based on their key value
+    """
+    _delete_key: user_settings_delete_key_input
+    """prepend existing jsonb value of filtered columns with new jsonb value"""
+    _prepend: user_settings_prepend_input
+    """sets the columns of the filtered rows to the given values"""
+    _set: user_settings_set_input
+    """filter the rows which have to be updated"""
+    where: user_settings_bool_exp!
+  ): user_settings_mutation_response
+  """
+  update single row of the table: "user_settings"
+  """
+  update_user_settings_by_pk(
+    """append existing jsonb value of filtered columns with new jsonb value"""
+    _append: user_settings_append_input
+    """
+    delete the field or element with specified path (for JSON arrays, negative integers count from the end)
+    """
+    _delete_at_path: user_settings_delete_at_path_input
+    """
+    delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array
+    """
+    _delete_elem: user_settings_delete_elem_input
+    """
+    delete key/value pair or string element. key/value pairs are matched based on their key value
+    """
+    _delete_key: user_settings_delete_key_input
+    """prepend existing jsonb value of filtered columns with new jsonb value"""
+    _prepend: user_settings_prepend_input
+    """sets the columns of the filtered rows to the given values"""
+    _set: user_settings_set_input
+    pk_columns: user_settings_pk_columns_input!
+  ): user_settings
+  """
+  update multiples rows of table: "user_settings"
+  """
+  update_user_settings_many(
+    """updates to execute, in order"""
+    updates: [user_settings_updates!]!
+  ): [user_settings_mutation_response]
   """
   update data of the table: "user_video_history"
   """
   update_user_video_history(
-    """
-    increments the numeric columns with given value of the filtered values
-    """
+    """increments the numeric columns with given value of the filtered values"""
     _inc: user_video_history_inc_input
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: user_video_history_set_input
-    """
-    filter the rows which have to be updated
-    """
+    """filter the rows which have to be updated"""
     where: user_video_history_bool_exp!
   ): user_video_history_mutation_response
   """
   update single row of the table: "user_video_history"
   """
   update_user_video_history_by_pk(
-    """
-    increments the numeric columns with given value of the filtered values
-    """
+    """increments the numeric columns with given value of the filtered values"""
     _inc: user_video_history_inc_input
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: user_video_history_set_input
     pk_columns: user_video_history_pk_columns_input!
   ): user_video_history
@@ -6146,31 +4937,23 @@ type mutation_root {
   update multiples rows of table: "user_video_history"
   """
   update_user_video_history_many(
-    """
-    updates to execute, in order
-    """
+    """updates to execute, in order"""
     updates: [user_video_history_updates!]!
   ): [user_video_history_mutation_response]
   """
   update data of the table: "users"
   """
   update_users(
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: users_set_input
-    """
-    filter the rows which have to be updated
-    """
+    """filter the rows which have to be updated"""
     where: users_bool_exp!
   ): users_mutation_response
   """
   update single row of the table: "users"
   """
   update_users_by_pk(
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: users_set_input
     pk_columns: users_pk_columns_input!
   ): users
@@ -6178,31 +4961,23 @@ type mutation_root {
   update multiples rows of table: "users"
   """
   update_users_many(
-    """
-    updates to execute, in order
-    """
+    """updates to execute, in order"""
     updates: [users_updates!]!
   ): [users_mutation_response]
   """
   update data of the table: "video_tags"
   """
   update_video_tags(
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: video_tags_set_input
-    """
-    filter the rows which have to be updated
-    """
+    """filter the rows which have to be updated"""
     where: video_tags_bool_exp!
   ): video_tags_mutation_response
   """
   update single row of the table: "video_tags"
   """
   update_video_tags_by_pk(
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: video_tags_set_input
     pk_columns: video_tags_pk_columns_input!
   ): video_tags
@@ -6210,31 +4985,23 @@ type mutation_root {
   update multiples rows of table: "video_tags"
   """
   update_video_tags_many(
-    """
-    updates to execute, in order
-    """
+    """updates to execute, in order"""
     updates: [video_tags_updates!]!
   ): [video_tags_mutation_response]
   """
   update data of the table: "video_views"
   """
   update_video_views(
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: video_views_set_input
-    """
-    filter the rows which have to be updated
-    """
+    """filter the rows which have to be updated"""
     where: video_views_bool_exp!
   ): video_views_mutation_response
   """
   update single row of the table: "video_views"
   """
   update_video_views_by_pk(
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: video_views_set_input
     pk_columns: video_views_pk_columns_input!
   ): video_views
@@ -6242,18 +5009,14 @@ type mutation_root {
   update multiples rows of table: "video_views"
   """
   update_video_views_many(
-    """
-    updates to execute, in order
-    """
+    """updates to execute, in order"""
     updates: [video_views_updates!]!
   ): [video_views_mutation_response]
   """
   update data of the table: "videos"
   """
   update_videos(
-    """
-    append existing jsonb value of filtered columns with new jsonb value
-    """
+    """append existing jsonb value of filtered columns with new jsonb value"""
     _append: videos_append_input
     """
     delete the field or element with specified path (for JSON arrays, negative integers count from the end)
@@ -6267,30 +5030,20 @@ type mutation_root {
     delete key/value pair or string element. key/value pairs are matched based on their key value
     """
     _delete_key: videos_delete_key_input
-    """
-    increments the numeric columns with given value of the filtered values
-    """
+    """increments the numeric columns with given value of the filtered values"""
     _inc: videos_inc_input
-    """
-    prepend existing jsonb value of filtered columns with new jsonb value
-    """
+    """prepend existing jsonb value of filtered columns with new jsonb value"""
     _prepend: videos_prepend_input
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: videos_set_input
-    """
-    filter the rows which have to be updated
-    """
+    """filter the rows which have to be updated"""
     where: videos_bool_exp!
   ): videos_mutation_response
   """
   update single row of the table: "videos"
   """
   update_videos_by_pk(
-    """
-    append existing jsonb value of filtered columns with new jsonb value
-    """
+    """append existing jsonb value of filtered columns with new jsonb value"""
     _append: videos_append_input
     """
     delete the field or element with specified path (for JSON arrays, negative integers count from the end)
@@ -6304,17 +5057,11 @@ type mutation_root {
     delete key/value pair or string element. key/value pairs are matched based on their key value
     """
     _delete_key: videos_delete_key_input
-    """
-    increments the numeric columns with given value of the filtered values
-    """
+    """increments the numeric columns with given value of the filtered values"""
     _inc: videos_inc_input
-    """
-    prepend existing jsonb value of filtered columns with new jsonb value
-    """
+    """prepend existing jsonb value of filtered columns with new jsonb value"""
     _prepend: videos_prepend_input
-    """
-    sets the columns of the filtered rows to the given values
-    """
+    """sets the columns of the filtered rows to the given values"""
     _set: videos_set_input
     pk_columns: videos_pk_columns_input!
   ): videos
@@ -6322,16 +5069,12 @@ type mutation_root {
   update multiples rows of table: "videos"
   """
   update_videos_many(
-    """
-    updates to execute, in order
-    """
+    """updates to execute, in order"""
     updates: [videos_updates!]!
   ): [videos_mutation_response]
 }
 
-"""
-Notification system
-"""
+"""Notification system"""
 type notifications {
   createdAt: timestamptz!
   entityId: uuid!
@@ -6339,22 +5082,16 @@ type notifications {
   id: uuid!
   link: String
   metadata(
-    """
-    JSON select path
-    """
+    """JSON select path"""
     path: String
   ): jsonb
   readAt: timestamptz
   type: String!
   updatedAt: timestamptz!
-  """
-  An object relationship
-  """
+  """An object relationship"""
   user: users!
   user_id: uuid!
-  """
-  An object relationship
-  """
+  """An object relationship"""
   video: videos
 }
 
@@ -6395,9 +5132,7 @@ input notifications_aggregate_order_by {
   min: notifications_min_order_by
 }
 
-"""
-append existing jsonb value of filtered columns with new jsonb value
-"""
+"""append existing jsonb value of filtered columns with new jsonb value"""
 input notifications_append_input {
   metadata: jsonb
 }
@@ -6407,9 +5142,7 @@ input type for inserting array relation for remote table "notifications"
 """
 input notifications_arr_rel_insert_input {
   data: [notifications_insert_input!]!
-  """
-  upsert condition
-  """
+  """upsert condition"""
   on_conflict: notifications_on_conflict
 }
 
@@ -6483,9 +5216,7 @@ input notifications_insert_input {
   video: videos_obj_rel_insert_input
 }
 
-"""
-aggregate max on columns
-"""
+"""aggregate max on columns"""
 type notifications_max_fields {
   createdAt: timestamptz
   entityId: uuid
@@ -6513,9 +5244,7 @@ input notifications_max_order_by {
   user_id: order_by
 }
 
-"""
-aggregate min on columns
-"""
+"""aggregate min on columns"""
 type notifications_min_fields {
   createdAt: timestamptz
   entityId: uuid
@@ -6547,13 +5276,9 @@ input notifications_min_order_by {
 response of any mutation on the table "notifications"
 """
 type notifications_mutation_response {
-  """
-  number of rows affected by the mutation
-  """
+  """number of rows affected by the mutation"""
   affected_rows: Int!
-  """
-  data from the rows affected by the mutation
-  """
+  """data from the rows affected by the mutation"""
   returning: [notifications!]!
 }
 
@@ -6566,9 +5291,7 @@ input notifications_on_conflict {
   where: notifications_bool_exp
 }
 
-"""
-Ordering options when selecting data from "notifications".
-"""
+"""Ordering options when selecting data from "notifications"."""
 input notifications_order_by {
   createdAt: order_by
   entityId: order_by
@@ -6584,16 +5307,12 @@ input notifications_order_by {
   video: videos_order_by
 }
 
-"""
-primary key columns input for table: notifications
-"""
+"""primary key columns input for table: notifications"""
 input notifications_pk_columns_input {
   id: uuid!
 }
 
-"""
-prepend existing jsonb value of filtered columns with new jsonb value
-"""
+"""prepend existing jsonb value of filtered columns with new jsonb value"""
 input notifications_prepend_input {
   metadata: jsonb
 }
@@ -6602,45 +5321,25 @@ input notifications_prepend_input {
 select columns of table "notifications"
 """
 enum notifications_select_column {
-  """
-  column name
-  """
+  """column name"""
   createdAt
-  """
-  column name
-  """
+  """column name"""
   entityId
-  """
-  column name
-  """
+  """column name"""
   entityType
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   link
-  """
-  column name
-  """
+  """column name"""
   metadata
-  """
-  column name
-  """
+  """column name"""
   readAt
-  """
-  column name
-  """
+  """column name"""
   type
-  """
-  column name
-  """
+  """column name"""
   updatedAt
-  """
-  column name
-  """
+  """column name"""
   user_id
 }
 
@@ -6664,19 +5363,13 @@ input notifications_set_input {
 Streaming cursor of the table "notifications"
 """
 input notifications_stream_cursor_input {
-  """
-  Stream column input with initial value
-  """
+  """Stream column input with initial value"""
   initial_value: notifications_stream_cursor_value_input!
-  """
-  cursor ordering
-  """
+  """cursor ordering"""
   ordering: cursor_ordering
 }
 
-"""
-Initial value of the column from where the streaming should start
-"""
+"""Initial value of the column from where the streaming should start"""
 input notifications_stream_cursor_value_input {
   createdAt: timestamptz
   entityId: uuid
@@ -6694,52 +5387,30 @@ input notifications_stream_cursor_value_input {
 update columns of table "notifications"
 """
 enum notifications_update_column {
-  """
-  column name
-  """
+  """column name"""
   createdAt
-  """
-  column name
-  """
+  """column name"""
   entityId
-  """
-  column name
-  """
+  """column name"""
   entityType
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   link
-  """
-  column name
-  """
+  """column name"""
   metadata
-  """
-  column name
-  """
+  """column name"""
   readAt
-  """
-  column name
-  """
+  """column name"""
   type
-  """
-  column name
-  """
+  """column name"""
   updatedAt
-  """
-  column name
-  """
+  """column name"""
   user_id
 }
 
 input notifications_updates {
-  """
-  append existing jsonb value of filtered columns with new jsonb value
-  """
+  """append existing jsonb value of filtered columns with new jsonb value"""
   _append: notifications_append_input
   """
   delete the field or element with specified path (for JSON arrays, negative integers count from the end)
@@ -6753,17 +5424,11 @@ input notifications_updates {
   delete key/value pair or string element. key/value pairs are matched based on their key value
   """
   _delete_key: notifications_delete_key_input
-  """
-  prepend existing jsonb value of filtered columns with new jsonb value
-  """
+  """prepend existing jsonb value of filtered columns with new jsonb value"""
   _prepend: notifications_prepend_input
-  """
-  sets the columns of the filtered rows to the given values
-  """
+  """sets the columns of the filtered rows to the given values"""
   _set: notifications_set_input
-  """
-  filter the rows which have to be updated
-  """
+  """filter the rows which have to be updated"""
   where: notifications_bool_exp!
 }
 
@@ -6784,214 +5449,120 @@ input numeric_comparison_exp {
   _nin: [numeric!]
 }
 
-"""
-column ordering options
-"""
+"""column ordering options"""
 enum order_by {
-  """
-  in ascending order, nulls last
-  """
+  """in ascending order, nulls last"""
   asc
-  """
-  in ascending order, nulls first
-  """
+  """in ascending order, nulls first"""
   asc_nulls_first
-  """
-  in ascending order, nulls last
-  """
+  """in ascending order, nulls last"""
   asc_nulls_last
-  """
-  in descending order, nulls first
-  """
+  """in descending order, nulls first"""
   desc
-  """
-  in descending order, nulls first
-  """
+  """in descending order, nulls first"""
   desc_nulls_first
-  """
-  in descending order, nulls last
-  """
+  """in descending order, nulls last"""
   desc_nulls_last
 }
 
-"""
-Playlist contain set of videos or audios
-"""
+"""Playlist contain set of videos or audios"""
 type playlist {
   createdAt: timestamptz!
   description: String
   id: uuid!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   playlist_audios(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [playlist_audios_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [playlist_audios_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: playlist_audios_bool_exp
   ): [playlist_audios!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   playlist_audios_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [playlist_audios_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [playlist_audios_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: playlist_audios_bool_exp
   ): playlist_audios_aggregate!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   playlist_videos(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [playlist_videos_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [playlist_videos_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: playlist_videos_bool_exp
   ): [playlist_videos!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   playlist_videos_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [playlist_videos_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [playlist_videos_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: playlist_videos_bool_exp
   ): playlist_videos_aggregate!
   public: Boolean!
-  """
-  Short id like Youtube video id
-  """
+  """Short id like Youtube video id"""
   sId: String
   """
   List of shared recipient emails after validated by the system, should use this field to show for end users. Only system can update this field. End user should NOT know the real shared user ids.
   """
   sharedRecipients(
-    """
-    JSON select path
-    """
+    """JSON select path"""
     path: String
   ): jsonb
   """
   List of recipient emails from user input, not validated yet. End user can update this.
   """
   sharedRecipientsInput(
-    """
-    JSON select path
-    """
+    """JSON select path"""
     path: String
   ): jsonb
-  """
-  An array relationship
-  """
+  """An array relationship"""
   shared_playlist_recipients(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [shared_playlist_recipients_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [shared_playlist_recipients_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: shared_playlist_recipients_bool_exp
   ): [shared_playlist_recipients!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   shared_playlist_recipients_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [shared_playlist_recipients_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [shared_playlist_recipients_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: shared_playlist_recipients_bool_exp
   ): shared_playlist_recipients_aggregate!
   site: String!
@@ -6999,9 +5570,7 @@ type playlist {
   thumbnailUrl: String
   title: String!
   updatedAt: timestamptz!
-  """
-  An object relationship
-  """
+  """An object relationship"""
   user: users!
   user_id: uuid!
 }
@@ -7059,9 +5628,7 @@ input playlist_aggregate_order_by {
   min: playlist_min_order_by
 }
 
-"""
-append existing jsonb value of filtered columns with new jsonb value
-"""
+"""append existing jsonb value of filtered columns with new jsonb value"""
 input playlist_append_input {
   """
   List of shared recipient emails after validated by the system, should use this field to show for end users. Only system can update this field. End user should NOT know the real shared user ids.
@@ -7078,25 +5645,17 @@ input type for inserting array relation for remote table "playlist"
 """
 input playlist_arr_rel_insert_input {
   data: [playlist_insert_input!]!
-  """
-  upsert condition
-  """
+  """upsert condition"""
   on_conflict: playlist_on_conflict
 }
 
-"""
-Junction table between audios and playlist
-"""
+"""Junction table between audios and playlist"""
 type playlist_audios {
-  """
-  An object relationship
-  """
+  """An object relationship"""
   audio: audios!
   audio_id: uuid!
   createdAt: timestamptz!
-  """
-  An object relationship
-  """
+  """An object relationship"""
   playlist: playlist!
   playlist_id: uuid!
   position: Int!
@@ -7161,15 +5720,11 @@ input type for inserting array relation for remote table "playlist_audios"
 """
 input playlist_audios_arr_rel_insert_input {
   data: [playlist_audios_insert_input!]!
-  """
-  upsert condition
-  """
+  """upsert condition"""
   on_conflict: playlist_audios_on_conflict
 }
 
-"""
-aggregate avg on columns
-"""
+"""aggregate avg on columns"""
 type playlist_audios_avg_fields {
   position: Float
 }
@@ -7227,9 +5782,7 @@ input playlist_audios_insert_input {
   updatedAt: timestamptz
 }
 
-"""
-aggregate max on columns
-"""
+"""aggregate max on columns"""
 type playlist_audios_max_fields {
   audio_id: uuid
   createdAt: timestamptz
@@ -7249,9 +5802,7 @@ input playlist_audios_max_order_by {
   updatedAt: order_by
 }
 
-"""
-aggregate min on columns
-"""
+"""aggregate min on columns"""
 type playlist_audios_min_fields {
   audio_id: uuid
   createdAt: timestamptz
@@ -7275,13 +5826,9 @@ input playlist_audios_min_order_by {
 response of any mutation on the table "playlist_audios"
 """
 type playlist_audios_mutation_response {
-  """
-  number of rows affected by the mutation
-  """
+  """number of rows affected by the mutation"""
   affected_rows: Int!
-  """
-  data from the rows affected by the mutation
-  """
+  """data from the rows affected by the mutation"""
   returning: [playlist_audios!]!
 }
 
@@ -7294,9 +5841,7 @@ input playlist_audios_on_conflict {
   where: playlist_audios_bool_exp
 }
 
-"""
-Ordering options when selecting data from "playlist_audios".
-"""
+"""Ordering options when selecting data from "playlist_audios"."""
 input playlist_audios_order_by {
   audio: audios_order_by
   audio_id: order_by
@@ -7307,9 +5852,7 @@ input playlist_audios_order_by {
   updatedAt: order_by
 }
 
-"""
-primary key columns input for table: playlist_audios
-"""
+"""primary key columns input for table: playlist_audios"""
 input playlist_audios_pk_columns_input {
   audio_id: uuid!
   playlist_id: uuid!
@@ -7319,25 +5862,15 @@ input playlist_audios_pk_columns_input {
 select columns of table "playlist_audios"
 """
 enum playlist_audios_select_column {
-  """
-  column name
-  """
+  """column name"""
   audio_id
-  """
-  column name
-  """
+  """column name"""
   createdAt
-  """
-  column name
-  """
+  """column name"""
   playlist_id
-  """
-  column name
-  """
+  """column name"""
   position
-  """
-  column name
-  """
+  """column name"""
   updatedAt
 }
 
@@ -7352,9 +5885,7 @@ input playlist_audios_set_input {
   updatedAt: timestamptz
 }
 
-"""
-aggregate stddev on columns
-"""
+"""aggregate stddev on columns"""
 type playlist_audios_stddev_fields {
   position: Float
 }
@@ -7366,9 +5897,7 @@ input playlist_audios_stddev_order_by {
   position: order_by
 }
 
-"""
-aggregate stddev_pop on columns
-"""
+"""aggregate stddev_pop on columns"""
 type playlist_audios_stddev_pop_fields {
   position: Float
 }
@@ -7380,9 +5909,7 @@ input playlist_audios_stddev_pop_order_by {
   position: order_by
 }
 
-"""
-aggregate stddev_samp on columns
-"""
+"""aggregate stddev_samp on columns"""
 type playlist_audios_stddev_samp_fields {
   position: Float
 }
@@ -7398,19 +5925,13 @@ input playlist_audios_stddev_samp_order_by {
 Streaming cursor of the table "playlist_audios"
 """
 input playlist_audios_stream_cursor_input {
-  """
-  Stream column input with initial value
-  """
+  """Stream column input with initial value"""
   initial_value: playlist_audios_stream_cursor_value_input!
-  """
-  cursor ordering
-  """
+  """cursor ordering"""
   ordering: cursor_ordering
 }
 
-"""
-Initial value of the column from where the streaming should start
-"""
+"""Initial value of the column from where the streaming should start"""
 input playlist_audios_stream_cursor_value_input {
   audio_id: uuid
   createdAt: timestamptz
@@ -7419,9 +5940,7 @@ input playlist_audios_stream_cursor_value_input {
   updatedAt: timestamptz
 }
 
-"""
-aggregate sum on columns
-"""
+"""aggregate sum on columns"""
 type playlist_audios_sum_fields {
   position: Int
 }
@@ -7437,46 +5956,28 @@ input playlist_audios_sum_order_by {
 update columns of table "playlist_audios"
 """
 enum playlist_audios_update_column {
-  """
-  column name
-  """
+  """column name"""
   audio_id
-  """
-  column name
-  """
+  """column name"""
   createdAt
-  """
-  column name
-  """
+  """column name"""
   playlist_id
-  """
-  column name
-  """
+  """column name"""
   position
-  """
-  column name
-  """
+  """column name"""
   updatedAt
 }
 
 input playlist_audios_updates {
-  """
-  increments the numeric columns with given value of the filtered values
-  """
+  """increments the numeric columns with given value of the filtered values"""
   _inc: playlist_audios_inc_input
-  """
-  sets the columns of the filtered rows to the given values
-  """
+  """sets the columns of the filtered rows to the given values"""
   _set: playlist_audios_set_input
-  """
-  filter the rows which have to be updated
-  """
+  """filter the rows which have to be updated"""
   where: playlist_audios_bool_exp!
 }
 
-"""
-aggregate var_pop on columns
-"""
+"""aggregate var_pop on columns"""
 type playlist_audios_var_pop_fields {
   position: Float
 }
@@ -7488,9 +5989,7 @@ input playlist_audios_var_pop_order_by {
   position: order_by
 }
 
-"""
-aggregate var_samp on columns
-"""
+"""aggregate var_samp on columns"""
 type playlist_audios_var_samp_fields {
   position: Float
 }
@@ -7502,9 +6001,7 @@ input playlist_audios_var_samp_order_by {
   position: order_by
 }
 
-"""
-aggregate variance on columns
-"""
+"""aggregate variance on columns"""
 type playlist_audios_variance_fields {
   position: Float
 }
@@ -7615,9 +6112,7 @@ input playlist_insert_input {
   playlist_audios: playlist_audios_arr_rel_insert_input
   playlist_videos: playlist_videos_arr_rel_insert_input
   public: Boolean
-  """
-  Short id like Youtube video id
-  """
+  """Short id like Youtube video id"""
   sId: String
   """
   List of shared recipient emails after validated by the system, should use this field to show for end users. Only system can update this field. End user should NOT know the real shared user ids.
@@ -7637,16 +6132,12 @@ input playlist_insert_input {
   user_id: uuid
 }
 
-"""
-aggregate max on columns
-"""
+"""aggregate max on columns"""
 type playlist_max_fields {
   createdAt: timestamptz
   description: String
   id: uuid
-  """
-  Short id like Youtube video id
-  """
+  """Short id like Youtube video id"""
   sId: String
   site: String
   slug: String
@@ -7663,9 +6154,7 @@ input playlist_max_order_by {
   createdAt: order_by
   description: order_by
   id: order_by
-  """
-  Short id like Youtube video id
-  """
+  """Short id like Youtube video id"""
   sId: order_by
   site: order_by
   slug: order_by
@@ -7675,16 +6164,12 @@ input playlist_max_order_by {
   user_id: order_by
 }
 
-"""
-aggregate min on columns
-"""
+"""aggregate min on columns"""
 type playlist_min_fields {
   createdAt: timestamptz
   description: String
   id: uuid
-  """
-  Short id like Youtube video id
-  """
+  """Short id like Youtube video id"""
   sId: String
   site: String
   slug: String
@@ -7701,9 +6186,7 @@ input playlist_min_order_by {
   createdAt: order_by
   description: order_by
   id: order_by
-  """
-  Short id like Youtube video id
-  """
+  """Short id like Youtube video id"""
   sId: order_by
   site: order_by
   slug: order_by
@@ -7717,13 +6200,9 @@ input playlist_min_order_by {
 response of any mutation on the table "playlist"
 """
 type playlist_mutation_response {
-  """
-  number of rows affected by the mutation
-  """
+  """number of rows affected by the mutation"""
   affected_rows: Int!
-  """
-  data from the rows affected by the mutation
-  """
+  """data from the rows affected by the mutation"""
   returning: [playlist!]!
 }
 
@@ -7732,9 +6211,7 @@ input type for inserting object relation for remote table "playlist"
 """
 input playlist_obj_rel_insert_input {
   data: playlist_insert_input!
-  """
-  upsert condition
-  """
+  """upsert condition"""
   on_conflict: playlist_on_conflict
 }
 
@@ -7747,9 +6224,7 @@ input playlist_on_conflict {
   where: playlist_bool_exp
 }
 
-"""
-Ordering options when selecting data from "playlist".
-"""
+"""Ordering options when selecting data from "playlist"."""
 input playlist_order_by {
   createdAt: order_by
   description: order_by
@@ -7770,16 +6245,12 @@ input playlist_order_by {
   user_id: order_by
 }
 
-"""
-primary key columns input for table: playlist
-"""
+"""primary key columns input for table: playlist"""
 input playlist_pk_columns_input {
   id: uuid!
 }
 
-"""
-prepend existing jsonb value of filtered columns with new jsonb value
-"""
+"""prepend existing jsonb value of filtered columns with new jsonb value"""
 input playlist_prepend_input {
   """
   List of shared recipient emails after validated by the system, should use this field to show for end users. Only system can update this field. End user should NOT know the real shared user ids.
@@ -7795,57 +6266,31 @@ input playlist_prepend_input {
 select columns of table "playlist"
 """
 enum playlist_select_column {
-  """
-  column name
-  """
+  """column name"""
   createdAt
-  """
-  column name
-  """
+  """column name"""
   description
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   public
-  """
-  column name
-  """
+  """column name"""
   sId
-  """
-  column name
-  """
+  """column name"""
   sharedRecipients
-  """
-  column name
-  """
+  """column name"""
   sharedRecipientsInput
-  """
-  column name
-  """
+  """column name"""
   site
-  """
-  column name
-  """
+  """column name"""
   slug
-  """
-  column name
-  """
+  """column name"""
   thumbnailUrl
-  """
-  column name
-  """
+  """column name"""
   title
-  """
-  column name
-  """
+  """column name"""
   updatedAt
-  """
-  column name
-  """
+  """column name"""
   user_id
 }
 
@@ -7853,9 +6298,7 @@ enum playlist_select_column {
 select "playlist_aggregate_bool_exp_bool_and_arguments_columns" columns of table "playlist"
 """
 enum playlist_select_column_playlist_aggregate_bool_exp_bool_and_arguments_columns {
-  """
-  column name
-  """
+  """column name"""
   public
 }
 
@@ -7863,9 +6306,7 @@ enum playlist_select_column_playlist_aggregate_bool_exp_bool_and_arguments_colum
 select "playlist_aggregate_bool_exp_bool_or_arguments_columns" columns of table "playlist"
 """
 enum playlist_select_column_playlist_aggregate_bool_exp_bool_or_arguments_columns {
-  """
-  column name
-  """
+  """column name"""
   public
 }
 
@@ -7877,9 +6318,7 @@ input playlist_set_input {
   description: String
   id: uuid
   public: Boolean
-  """
-  Short id like Youtube video id
-  """
+  """Short id like Youtube video id"""
   sId: String
   """
   List of shared recipient emails after validated by the system, should use this field to show for end users. Only system can update this field. End user should NOT know the real shared user ids.
@@ -7901,27 +6340,19 @@ input playlist_set_input {
 Streaming cursor of the table "playlist"
 """
 input playlist_stream_cursor_input {
-  """
-  Stream column input with initial value
-  """
+  """Stream column input with initial value"""
   initial_value: playlist_stream_cursor_value_input!
-  """
-  cursor ordering
-  """
+  """cursor ordering"""
   ordering: cursor_ordering
 }
 
-"""
-Initial value of the column from where the streaming should start
-"""
+"""Initial value of the column from where the streaming should start"""
 input playlist_stream_cursor_value_input {
   createdAt: timestamptz
   description: String
   id: uuid
   public: Boolean
-  """
-  Short id like Youtube video id
-  """
+  """Short id like Youtube video id"""
   sId: String
   """
   List of shared recipient emails after validated by the system, should use this field to show for end users. Only system can update this field. End user should NOT know the real shared user ids.
@@ -7943,64 +6374,36 @@ input playlist_stream_cursor_value_input {
 update columns of table "playlist"
 """
 enum playlist_update_column {
-  """
-  column name
-  """
+  """column name"""
   createdAt
-  """
-  column name
-  """
+  """column name"""
   description
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   public
-  """
-  column name
-  """
+  """column name"""
   sId
-  """
-  column name
-  """
+  """column name"""
   sharedRecipients
-  """
-  column name
-  """
+  """column name"""
   sharedRecipientsInput
-  """
-  column name
-  """
+  """column name"""
   site
-  """
-  column name
-  """
+  """column name"""
   slug
-  """
-  column name
-  """
+  """column name"""
   thumbnailUrl
-  """
-  column name
-  """
+  """column name"""
   title
-  """
-  column name
-  """
+  """column name"""
   updatedAt
-  """
-  column name
-  """
+  """column name"""
   user_id
 }
 
 input playlist_updates {
-  """
-  append existing jsonb value of filtered columns with new jsonb value
-  """
+  """append existing jsonb value of filtered columns with new jsonb value"""
   _append: playlist_append_input
   """
   delete the field or element with specified path (for JSON arrays, negative integers count from the end)
@@ -8014,35 +6417,23 @@ input playlist_updates {
   delete key/value pair or string element. key/value pairs are matched based on their key value
   """
   _delete_key: playlist_delete_key_input
-  """
-  prepend existing jsonb value of filtered columns with new jsonb value
-  """
+  """prepend existing jsonb value of filtered columns with new jsonb value"""
   _prepend: playlist_prepend_input
-  """
-  sets the columns of the filtered rows to the given values
-  """
+  """sets the columns of the filtered rows to the given values"""
   _set: playlist_set_input
-  """
-  filter the rows which have to be updated
-  """
+  """filter the rows which have to be updated"""
   where: playlist_bool_exp!
 }
 
-"""
-Junction table between videos and playlist
-"""
+"""Junction table between videos and playlist"""
 type playlist_videos {
   createdAt: timestamptz!
-  """
-  An object relationship
-  """
+  """An object relationship"""
   playlist: playlist!
   playlist_id: uuid!
   position: Int!
   updatedAt: timestamptz!
-  """
-  An object relationship
-  """
+  """An object relationship"""
   video: videos!
   video_id: uuid!
 }
@@ -8105,15 +6496,11 @@ input type for inserting array relation for remote table "playlist_videos"
 """
 input playlist_videos_arr_rel_insert_input {
   data: [playlist_videos_insert_input!]!
-  """
-  upsert condition
-  """
+  """upsert condition"""
   on_conflict: playlist_videos_on_conflict
 }
 
-"""
-aggregate avg on columns
-"""
+"""aggregate avg on columns"""
 type playlist_videos_avg_fields {
   position: Float
 }
@@ -8175,9 +6562,7 @@ input playlist_videos_insert_input {
   video_id: uuid
 }
 
-"""
-aggregate max on columns
-"""
+"""aggregate max on columns"""
 type playlist_videos_max_fields {
   createdAt: timestamptz
   playlist_id: uuid
@@ -8197,9 +6582,7 @@ input playlist_videos_max_order_by {
   video_id: order_by
 }
 
-"""
-aggregate min on columns
-"""
+"""aggregate min on columns"""
 type playlist_videos_min_fields {
   createdAt: timestamptz
   playlist_id: uuid
@@ -8223,13 +6606,9 @@ input playlist_videos_min_order_by {
 response of any mutation on the table "playlist_videos"
 """
 type playlist_videos_mutation_response {
-  """
-  number of rows affected by the mutation
-  """
+  """number of rows affected by the mutation"""
   affected_rows: Int!
-  """
-  data from the rows affected by the mutation
-  """
+  """data from the rows affected by the mutation"""
   returning: [playlist_videos!]!
 }
 
@@ -8242,9 +6621,7 @@ input playlist_videos_on_conflict {
   where: playlist_videos_bool_exp
 }
 
-"""
-Ordering options when selecting data from "playlist_videos".
-"""
+"""Ordering options when selecting data from "playlist_videos"."""
 input playlist_videos_order_by {
   createdAt: order_by
   playlist: playlist_order_by
@@ -8255,9 +6632,7 @@ input playlist_videos_order_by {
   video_id: order_by
 }
 
-"""
-primary key columns input for table: playlist_videos
-"""
+"""primary key columns input for table: playlist_videos"""
 input playlist_videos_pk_columns_input {
   playlist_id: uuid!
   video_id: uuid!
@@ -8267,25 +6642,15 @@ input playlist_videos_pk_columns_input {
 select columns of table "playlist_videos"
 """
 enum playlist_videos_select_column {
-  """
-  column name
-  """
+  """column name"""
   createdAt
-  """
-  column name
-  """
+  """column name"""
   playlist_id
-  """
-  column name
-  """
+  """column name"""
   position
-  """
-  column name
-  """
+  """column name"""
   updatedAt
-  """
-  column name
-  """
+  """column name"""
   video_id
 }
 
@@ -8300,9 +6665,7 @@ input playlist_videos_set_input {
   video_id: uuid
 }
 
-"""
-aggregate stddev on columns
-"""
+"""aggregate stddev on columns"""
 type playlist_videos_stddev_fields {
   position: Float
 }
@@ -8314,9 +6677,7 @@ input playlist_videos_stddev_order_by {
   position: order_by
 }
 
-"""
-aggregate stddev_pop on columns
-"""
+"""aggregate stddev_pop on columns"""
 type playlist_videos_stddev_pop_fields {
   position: Float
 }
@@ -8328,9 +6689,7 @@ input playlist_videos_stddev_pop_order_by {
   position: order_by
 }
 
-"""
-aggregate stddev_samp on columns
-"""
+"""aggregate stddev_samp on columns"""
 type playlist_videos_stddev_samp_fields {
   position: Float
 }
@@ -8346,19 +6705,13 @@ input playlist_videos_stddev_samp_order_by {
 Streaming cursor of the table "playlist_videos"
 """
 input playlist_videos_stream_cursor_input {
-  """
-  Stream column input with initial value
-  """
+  """Stream column input with initial value"""
   initial_value: playlist_videos_stream_cursor_value_input!
-  """
-  cursor ordering
-  """
+  """cursor ordering"""
   ordering: cursor_ordering
 }
 
-"""
-Initial value of the column from where the streaming should start
-"""
+"""Initial value of the column from where the streaming should start"""
 input playlist_videos_stream_cursor_value_input {
   createdAt: timestamptz
   playlist_id: uuid
@@ -8367,9 +6720,7 @@ input playlist_videos_stream_cursor_value_input {
   video_id: uuid
 }
 
-"""
-aggregate sum on columns
-"""
+"""aggregate sum on columns"""
 type playlist_videos_sum_fields {
   position: Int
 }
@@ -8385,46 +6736,28 @@ input playlist_videos_sum_order_by {
 update columns of table "playlist_videos"
 """
 enum playlist_videos_update_column {
-  """
-  column name
-  """
+  """column name"""
   createdAt
-  """
-  column name
-  """
+  """column name"""
   playlist_id
-  """
-  column name
-  """
+  """column name"""
   position
-  """
-  column name
-  """
+  """column name"""
   updatedAt
-  """
-  column name
-  """
+  """column name"""
   video_id
 }
 
 input playlist_videos_updates {
-  """
-  increments the numeric columns with given value of the filtered values
-  """
+  """increments the numeric columns with given value of the filtered values"""
   _inc: playlist_videos_inc_input
-  """
-  sets the columns of the filtered rows to the given values
-  """
+  """sets the columns of the filtered rows to the given values"""
   _set: playlist_videos_set_input
-  """
-  filter the rows which have to be updated
-  """
+  """filter the rows which have to be updated"""
   where: playlist_videos_bool_exp!
 }
 
-"""
-aggregate var_pop on columns
-"""
+"""aggregate var_pop on columns"""
 type playlist_videos_var_pop_fields {
   position: Float
 }
@@ -8436,9 +6769,7 @@ input playlist_videos_var_pop_order_by {
   position: order_by
 }
 
-"""
-aggregate var_samp on columns
-"""
+"""aggregate var_samp on columns"""
 type playlist_videos_var_samp_fields {
   position: Float
 }
@@ -8450,9 +6781,7 @@ input playlist_videos_var_samp_order_by {
   position: order_by
 }
 
-"""
-aggregate variance on columns
-"""
+"""aggregate variance on columns"""
 type playlist_videos_variance_fields {
   position: Float
 }
@@ -8464,16 +6793,12 @@ input playlist_videos_variance_order_by {
   position: order_by
 }
 
-"""
-Blog posts initial idea is fetch from hashnode for til
-"""
+"""Blog posts initial idea is fetch from hashnode for til"""
 type posts {
   author_id: String!
   brief: String!
   created_at: timestamptz!
-  """
-  Hashnode public id
-  """
+  """Hashnode public id"""
   hId: String!
   id: uuid!
   markdownContent: String!
@@ -8511,9 +6836,7 @@ type posts_aggregate_fields {
   variance: posts_variance_fields
 }
 
-"""
-aggregate avg on columns
-"""
+"""aggregate avg on columns"""
 type posts_avg_fields {
   readTimeInMinutes: Float
 }
@@ -8568,9 +6891,7 @@ input posts_insert_input {
   author_id: String
   brief: String
   created_at: timestamptz
-  """
-  Hashnode public id
-  """
+  """Hashnode public id"""
   hId: String
   id: uuid
   markdownContent: String
@@ -8583,16 +6904,12 @@ input posts_insert_input {
   visibility: String
 }
 
-"""
-aggregate max on columns
-"""
+"""aggregate max on columns"""
 type posts_max_fields {
   author_id: String
   brief: String
   created_at: timestamptz
-  """
-  Hashnode public id
-  """
+  """Hashnode public id"""
   hId: String
   id: uuid
   markdownContent: String
@@ -8604,16 +6921,12 @@ type posts_max_fields {
   visibility: String
 }
 
-"""
-aggregate min on columns
-"""
+"""aggregate min on columns"""
 type posts_min_fields {
   author_id: String
   brief: String
   created_at: timestamptz
-  """
-  Hashnode public id
-  """
+  """Hashnode public id"""
   hId: String
   id: uuid
   markdownContent: String
@@ -8629,13 +6942,9 @@ type posts_min_fields {
 response of any mutation on the table "posts"
 """
 type posts_mutation_response {
-  """
-  number of rows affected by the mutation
-  """
+  """number of rows affected by the mutation"""
   affected_rows: Int!
-  """
-  data from the rows affected by the mutation
-  """
+  """data from the rows affected by the mutation"""
   returning: [posts!]!
 }
 
@@ -8648,9 +6957,7 @@ input posts_on_conflict {
   where: posts_bool_exp
 }
 
-"""
-Ordering options when selecting data from "posts".
-"""
+"""Ordering options when selecting data from "posts"."""
 input posts_order_by {
   author_id: order_by
   brief: order_by
@@ -8667,9 +6974,7 @@ input posts_order_by {
   visibility: order_by
 }
 
-"""
-primary key columns input for table: posts
-"""
+"""primary key columns input for table: posts"""
 input posts_pk_columns_input {
   id: uuid!
 }
@@ -8678,57 +6983,31 @@ input posts_pk_columns_input {
 select columns of table "posts"
 """
 enum posts_select_column {
-  """
-  column name
-  """
+  """column name"""
   author_id
-  """
-  column name
-  """
+  """column name"""
   brief
-  """
-  column name
-  """
+  """column name"""
   created_at
-  """
-  column name
-  """
+  """column name"""
   hId
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   markdownContent
-  """
-  column name
-  """
+  """column name"""
   pinned
-  """
-  column name
-  """
+  """column name"""
   readTimeInMinutes
-  """
-  column name
-  """
+  """column name"""
   slug
-  """
-  column name
-  """
+  """column name"""
   status
-  """
-  column name
-  """
+  """column name"""
   title
-  """
-  column name
-  """
+  """column name"""
   updated_at
-  """
-  column name
-  """
+  """column name"""
   visibility
 }
 
@@ -8739,9 +7018,7 @@ input posts_set_input {
   author_id: String
   brief: String
   created_at: timestamptz
-  """
-  Hashnode public id
-  """
+  """Hashnode public id"""
   hId: String
   id: uuid
   markdownContent: String
@@ -8754,23 +7031,17 @@ input posts_set_input {
   visibility: String
 }
 
-"""
-aggregate stddev on columns
-"""
+"""aggregate stddev on columns"""
 type posts_stddev_fields {
   readTimeInMinutes: Float
 }
 
-"""
-aggregate stddev_pop on columns
-"""
+"""aggregate stddev_pop on columns"""
 type posts_stddev_pop_fields {
   readTimeInMinutes: Float
 }
 
-"""
-aggregate stddev_samp on columns
-"""
+"""aggregate stddev_samp on columns"""
 type posts_stddev_samp_fields {
   readTimeInMinutes: Float
 }
@@ -8779,26 +7050,18 @@ type posts_stddev_samp_fields {
 Streaming cursor of the table "posts"
 """
 input posts_stream_cursor_input {
-  """
-  Stream column input with initial value
-  """
+  """Stream column input with initial value"""
   initial_value: posts_stream_cursor_value_input!
-  """
-  cursor ordering
-  """
+  """cursor ordering"""
   ordering: cursor_ordering
 }
 
-"""
-Initial value of the column from where the streaming should start
-"""
+"""Initial value of the column from where the streaming should start"""
 input posts_stream_cursor_value_input {
   author_id: String
   brief: String
   created_at: timestamptz
-  """
-  Hashnode public id
-  """
+  """Hashnode public id"""
   hId: String
   id: uuid
   markdownContent: String
@@ -8811,9 +7074,7 @@ input posts_stream_cursor_value_input {
   visibility: String
 }
 
-"""
-aggregate sum on columns
-"""
+"""aggregate sum on columns"""
 type posts_sum_fields {
   readTimeInMinutes: Int
 }
@@ -8822,1279 +7083,739 @@ type posts_sum_fields {
 update columns of table "posts"
 """
 enum posts_update_column {
-  """
-  column name
-  """
+  """column name"""
   author_id
-  """
-  column name
-  """
+  """column name"""
   brief
-  """
-  column name
-  """
+  """column name"""
   created_at
-  """
-  column name
-  """
+  """column name"""
   hId
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   markdownContent
-  """
-  column name
-  """
+  """column name"""
   pinned
-  """
-  column name
-  """
+  """column name"""
   readTimeInMinutes
-  """
-  column name
-  """
+  """column name"""
   slug
-  """
-  column name
-  """
+  """column name"""
   status
-  """
-  column name
-  """
+  """column name"""
   title
-  """
-  column name
-  """
+  """column name"""
   updated_at
-  """
-  column name
-  """
+  """column name"""
   visibility
 }
 
 input posts_updates {
-  """
-  increments the numeric columns with given value of the filtered values
-  """
+  """increments the numeric columns with given value of the filtered values"""
   _inc: posts_inc_input
-  """
-  sets the columns of the filtered rows to the given values
-  """
+  """sets the columns of the filtered rows to the given values"""
   _set: posts_set_input
-  """
-  filter the rows which have to be updated
-  """
+  """filter the rows which have to be updated"""
   where: posts_bool_exp!
 }
 
-"""
-aggregate var_pop on columns
-"""
+"""aggregate var_pop on columns"""
 type posts_var_pop_fields {
   readTimeInMinutes: Float
 }
 
-"""
-aggregate var_samp on columns
-"""
+"""aggregate var_samp on columns"""
 type posts_var_samp_fields {
   readTimeInMinutes: Float
 }
 
-"""
-aggregate variance on columns
-"""
+"""aggregate variance on columns"""
 type posts_variance_fields {
   readTimeInMinutes: Float
 }
 
 type query_root {
-  """
-  An array relationship
-  """
+  """An array relationship"""
   audio_tags(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [audio_tags_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [audio_tags_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: audio_tags_bool_exp
   ): [audio_tags!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   audio_tags_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [audio_tags_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [audio_tags_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: audio_tags_bool_exp
   ): audio_tags_aggregate!
-  """
-  fetch data from the table: "audio_tags" using primary key columns
-  """
+  """fetch data from the table: "audio_tags" using primary key columns"""
   audio_tags_by_pk(audio_id: uuid!, tag_id: uuid!): audio_tags
-  """
-  An array relationship
-  """
+  """An array relationship"""
   audios(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [audios_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [audios_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: audios_bool_exp
   ): [audios!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   audios_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [audios_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [audios_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: audios_bool_exp
   ): audios_aggregate!
-  """
-  fetch data from the table: "audios" using primary key columns
-  """
+  """fetch data from the table: "audios" using primary key columns"""
   audios_by_pk(id: uuid!): audios
-  """
-  An array relationship
-  """
+  """An array relationship"""
   book_comments(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [book_comments_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [book_comments_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: book_comments_bool_exp
   ): [book_comments!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   book_comments_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [book_comments_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [book_comments_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: book_comments_bool_exp
   ): book_comments_aggregate!
-  """
-  fetch data from the table: "book_comments" using primary key columns
-  """
+  """fetch data from the table: "book_comments" using primary key columns"""
   book_comments_by_pk(id: uuid!): book_comments
-  """
-  An array relationship
-  """
+  """An array relationship"""
   books(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [books_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [books_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: books_bool_exp
   ): [books!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   books_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [books_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [books_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: books_bool_exp
   ): books_aggregate!
-  """
-  fetch data from the table: "books" using primary key columns
-  """
+  """fetch data from the table: "books" using primary key columns"""
   books_by_pk(id: uuid!): books
-  """
-  An array relationship
-  """
+  """An array relationship"""
   crawl_requests(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [crawl_requests_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [crawl_requests_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: crawl_requests_bool_exp
   ): [crawl_requests!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   crawl_requests_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [crawl_requests_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [crawl_requests_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: crawl_requests_bool_exp
   ): crawl_requests_aggregate!
-  """
-  fetch data from the table: "crawl_requests" using primary key columns
-  """
+  """fetch data from the table: "crawl_requests" using primary key columns"""
   crawl_requests_by_pk(id: uuid!): crawl_requests
-  """
-  An array relationship
-  """
+  """An array relationship"""
   device_requests(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [device_requests_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [device_requests_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: device_requests_bool_exp
   ): [device_requests!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   device_requests_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [device_requests_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [device_requests_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: device_requests_bool_exp
   ): device_requests_aggregate!
-  """
-  fetch data from the table: "device_requests" using primary key columns
-  """
+  """fetch data from the table: "device_requests" using primary key columns"""
   device_requests_by_pk(id: uuid!): device_requests
   """
   fetch data from the table: "feature_flag"
   """
   feature_flag(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [feature_flag_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [feature_flag_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: feature_flag_bool_exp
   ): [feature_flag!]!
   """
   fetch aggregated fields from the table: "feature_flag"
   """
   feature_flag_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [feature_flag_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [feature_flag_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: feature_flag_bool_exp
   ): feature_flag_aggregate!
-  """
-  fetch data from the table: "feature_flag" using primary key columns
-  """
+  """fetch data from the table: "feature_flag" using primary key columns"""
   feature_flag_by_pk(id: uuid!): feature_flag
-  """
-  An array relationship
-  """
+  """An array relationship"""
   finance_transactions(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [finance_transactions_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [finance_transactions_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: finance_transactions_bool_exp
   ): [finance_transactions!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   finance_transactions_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [finance_transactions_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [finance_transactions_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: finance_transactions_bool_exp
   ): finance_transactions_aggregate!
   """
   fetch data from the table: "finance_transactions" using primary key columns
   """
   finance_transactions_by_pk(id: uuid!): finance_transactions
-  """
-  An array relationship
-  """
+  """An array relationship"""
   journals(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [journals_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [journals_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: journals_bool_exp
   ): [journals!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   journals_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [journals_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [journals_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: journals_bool_exp
   ): journals_aggregate!
-  """
-  fetch data from the table: "journals" using primary key columns
-  """
+  """fetch data from the table: "journals" using primary key columns"""
   journals_by_pk(id: uuid!): journals
-  """
-  An array relationship
-  """
+  """An array relationship"""
   notifications(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [notifications_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [notifications_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: notifications_bool_exp
   ): [notifications!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   notifications_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [notifications_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [notifications_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: notifications_bool_exp
   ): notifications_aggregate!
-  """
-  fetch data from the table: "notifications" using primary key columns
-  """
+  """fetch data from the table: "notifications" using primary key columns"""
   notifications_by_pk(id: uuid!): notifications
   """
   fetch data from the table: "playlist"
   """
   playlist(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [playlist_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [playlist_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: playlist_bool_exp
   ): [playlist!]!
   """
   fetch aggregated fields from the table: "playlist"
   """
   playlist_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [playlist_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [playlist_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: playlist_bool_exp
   ): playlist_aggregate!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   playlist_audios(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [playlist_audios_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [playlist_audios_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: playlist_audios_bool_exp
   ): [playlist_audios!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   playlist_audios_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [playlist_audios_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [playlist_audios_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: playlist_audios_bool_exp
   ): playlist_audios_aggregate!
-  """
-  fetch data from the table: "playlist_audios" using primary key columns
-  """
+  """fetch data from the table: "playlist_audios" using primary key columns"""
   playlist_audios_by_pk(audio_id: uuid!, playlist_id: uuid!): playlist_audios
-  """
-  fetch data from the table: "playlist" using primary key columns
-  """
+  """fetch data from the table: "playlist" using primary key columns"""
   playlist_by_pk(id: uuid!): playlist
-  """
-  An array relationship
-  """
+  """An array relationship"""
   playlist_videos(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [playlist_videos_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [playlist_videos_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: playlist_videos_bool_exp
   ): [playlist_videos!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   playlist_videos_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [playlist_videos_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [playlist_videos_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: playlist_videos_bool_exp
   ): playlist_videos_aggregate!
-  """
-  fetch data from the table: "playlist_videos" using primary key columns
-  """
+  """fetch data from the table: "playlist_videos" using primary key columns"""
   playlist_videos_by_pk(playlist_id: uuid!, video_id: uuid!): playlist_videos
   """
   fetch data from the table: "posts"
   """
   posts(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [posts_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [posts_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: posts_bool_exp
   ): [posts!]!
   """
   fetch aggregated fields from the table: "posts"
   """
   posts_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [posts_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [posts_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: posts_bool_exp
   ): posts_aggregate!
-  """
-  fetch data from the table: "posts" using primary key columns
-  """
+  """fetch data from the table: "posts" using primary key columns"""
   posts_by_pk(id: uuid!): posts
-  """
-  An array relationship
-  """
+  """An array relationship"""
   reading_progresses(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [reading_progresses_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [reading_progresses_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: reading_progresses_bool_exp
   ): [reading_progresses!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   reading_progresses_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [reading_progresses_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [reading_progresses_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: reading_progresses_bool_exp
   ): reading_progresses_aggregate!
   """
   fetch data from the table: "reading_progresses" using primary key columns
   """
   reading_progresses_by_pk(id: uuid!): reading_progresses
-  """
-  An array relationship
-  """
+  """An array relationship"""
   shared_playlist_recipients(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [shared_playlist_recipients_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [shared_playlist_recipients_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: shared_playlist_recipients_bool_exp
   ): [shared_playlist_recipients!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   shared_playlist_recipients_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [shared_playlist_recipients_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [shared_playlist_recipients_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: shared_playlist_recipients_bool_exp
   ): shared_playlist_recipients_aggregate!
   """
   fetch data from the table: "shared_playlist_recipients" using primary key columns
   """
   shared_playlist_recipients_by_pk(id: uuid!): shared_playlist_recipients
-  """
-  An array relationship
-  """
+  """An array relationship"""
   shared_video_recipients(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [shared_video_recipients_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [shared_video_recipients_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: shared_video_recipients_bool_exp
   ): [shared_video_recipients!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   shared_video_recipients_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [shared_video_recipients_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [shared_video_recipients_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: shared_video_recipients_bool_exp
   ): shared_video_recipients_aggregate!
   """
   fetch data from the table: "shared_video_recipients" using primary key columns
   """
   shared_video_recipients_by_pk(id: uuid!): shared_video_recipients
-  """
-  An array relationship
-  """
+  """An array relationship"""
   subtitles(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [subtitles_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [subtitles_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: subtitles_bool_exp
   ): [subtitles!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   subtitles_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [subtitles_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [subtitles_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: subtitles_bool_exp
   ): subtitles_aggregate!
-  """
-  fetch data from the table: "subtitles" using primary key columns
-  """
+  """fetch data from the table: "subtitles" using primary key columns"""
   subtitles_by_pk(id: uuid!): subtitles
   """
   fetch data from the table: "tags"
   """
   tags(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [tags_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [tags_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: tags_bool_exp
   ): [tags!]!
   """
   fetch aggregated fields from the table: "tags"
   """
   tags_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [tags_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [tags_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: tags_bool_exp
   ): tags_aggregate!
-  """
-  fetch data from the table: "tags" using primary key columns
-  """
+  """fetch data from the table: "tags" using primary key columns"""
   tags_by_pk(id: uuid!): tags
   """
   fetch data from the table: "tasks"
   """
   tasks(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [tasks_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [tasks_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: tasks_bool_exp
   ): [tasks!]!
   """
   fetch aggregated fields from the table: "tasks"
   """
   tasks_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [tasks_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [tasks_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: tasks_bool_exp
   ): tasks_aggregate!
-  """
-  fetch data from the table: "tasks" using primary key columns
-  """
+  """fetch data from the table: "tasks" using primary key columns"""
   tasks_by_pk(id: uuid!): tasks
   """
   fetch data from the table: "test"
   """
   test(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [test_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [test_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: test_bool_exp
   ): [test!]!
   """
   fetch aggregated fields from the table: "test"
   """
   test_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [test_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [test_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: test_bool_exp
   ): test_aggregate!
-  """
-  fetch data from the table: "test" using primary key columns
-  """
+  """fetch data from the table: "test" using primary key columns"""
   test_by_pk(id: Int!): test
+  """
+  fetch data from the table: "user_settings"
+  """
+  user_settings(
+    """distinct select on columns"""
+    distinct_on: [user_settings_select_column!]
+    """limit the number of rows returned"""
+    limit: Int
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+    """sort the rows by one or more columns"""
+    order_by: [user_settings_order_by!]
+    """filter the rows returned"""
+    where: user_settings_bool_exp
+  ): [user_settings!]!
+  """
+  fetch aggregated fields from the table: "user_settings"
+  """
+  user_settings_aggregate(
+    """distinct select on columns"""
+    distinct_on: [user_settings_select_column!]
+    """limit the number of rows returned"""
+    limit: Int
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+    """sort the rows by one or more columns"""
+    order_by: [user_settings_order_by!]
+    """filter the rows returned"""
+    where: user_settings_bool_exp
+  ): user_settings_aggregate!
+  """fetch data from the table: "user_settings" using primary key columns"""
+  user_settings_by_pk(user_id: uuid!): user_settings
   """
   fetch data from the table: "user_video_history"
   """
   user_video_history(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [user_video_history_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [user_video_history_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: user_video_history_bool_exp
   ): [user_video_history!]!
   """
   fetch aggregated fields from the table: "user_video_history"
   """
   user_video_history_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [user_video_history_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [user_video_history_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: user_video_history_bool_exp
   ): user_video_history_aggregate!
   """
@@ -10105,243 +7826,135 @@ type query_root {
   fetch data from the table: "users"
   """
   users(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [users_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [users_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: users_bool_exp
   ): [users!]!
   """
   fetch aggregated fields from the table: "users"
   """
   users_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [users_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [users_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: users_bool_exp
   ): users_aggregate!
-  """
-  fetch data from the table: "users" using primary key columns
-  """
+  """fetch data from the table: "users" using primary key columns"""
   users_by_pk(id: uuid!): users
-  """
-  An array relationship
-  """
+  """An array relationship"""
   video_tags(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [video_tags_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [video_tags_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: video_tags_bool_exp
   ): [video_tags!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   video_tags_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [video_tags_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [video_tags_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: video_tags_bool_exp
   ): video_tags_aggregate!
-  """
-  fetch data from the table: "video_tags" using primary key columns
-  """
+  """fetch data from the table: "video_tags" using primary key columns"""
   video_tags_by_pk(tag_id: uuid!, video_id: uuid!): video_tags
-  """
-  An array relationship
-  """
+  """An array relationship"""
   video_views(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [video_views_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [video_views_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: video_views_bool_exp
   ): [video_views!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   video_views_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [video_views_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [video_views_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: video_views_bool_exp
   ): video_views_aggregate!
-  """
-  fetch data from the table: "video_views" using primary key columns
-  """
+  """fetch data from the table: "video_views" using primary key columns"""
   video_views_by_pk(id: uuid!): video_views
-  """
-  An array relationship
-  """
+  """An array relationship"""
   videos(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [videos_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [videos_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: videos_bool_exp
   ): [videos!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   videos_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [videos_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [videos_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: videos_bool_exp
   ): videos_aggregate!
-  """
-  fetch data from the table: "videos" using primary key columns
-  """
+  """fetch data from the table: "videos" using primary key columns"""
   videos_by_pk(id: uuid!): videos
 }
 
-"""
-Track how far end user read a book
-"""
+"""Track how far end user read a book"""
 type reading_progresses {
-  """
-  An object relationship
-  """
+  """An object relationship"""
   book: books!
   bookId: uuid!
   createdAt: timestamptz!
   currentPage: Int!
   id: uuid!
   lastReadAt: timestamptz!
-  """
-  Calculate percentage based on other column values
-  """
+  """Calculate percentage based on other column values"""
   percentage: numeric
   readingTimeMinutes: Int
   totalPages: Int!
   updatedAt: timestamptz!
-  """
-  An object relationship
-  """
+  """An object relationship"""
   user: users!
   userId: uuid!
 }
@@ -10404,20 +8017,14 @@ input type for inserting array relation for remote table "reading_progresses"
 """
 input reading_progresses_arr_rel_insert_input {
   data: [reading_progresses_insert_input!]!
-  """
-  upsert condition
-  """
+  """upsert condition"""
   on_conflict: reading_progresses_on_conflict
 }
 
-"""
-aggregate avg on columns
-"""
+"""aggregate avg on columns"""
 type reading_progresses_avg_fields {
   currentPage: Float
-  """
-  Calculate percentage based on other column values
-  """
+  """Calculate percentage based on other column values"""
   percentage: numeric
   readingTimeMinutes: Float
   totalPages: Float
@@ -10493,18 +8100,14 @@ input reading_progresses_insert_input {
   userId: uuid
 }
 
-"""
-aggregate max on columns
-"""
+"""aggregate max on columns"""
 type reading_progresses_max_fields {
   bookId: uuid
   createdAt: timestamptz
   currentPage: Int
   id: uuid
   lastReadAt: timestamptz
-  """
-  Calculate percentage based on other column values
-  """
+  """Calculate percentage based on other column values"""
   percentage: numeric
   readingTimeMinutes: Int
   totalPages: Int
@@ -10527,18 +8130,14 @@ input reading_progresses_max_order_by {
   userId: order_by
 }
 
-"""
-aggregate min on columns
-"""
+"""aggregate min on columns"""
 type reading_progresses_min_fields {
   bookId: uuid
   createdAt: timestamptz
   currentPage: Int
   id: uuid
   lastReadAt: timestamptz
-  """
-  Calculate percentage based on other column values
-  """
+  """Calculate percentage based on other column values"""
   percentage: numeric
   readingTimeMinutes: Int
   totalPages: Int
@@ -10565,13 +8164,9 @@ input reading_progresses_min_order_by {
 response of any mutation on the table "reading_progresses"
 """
 type reading_progresses_mutation_response {
-  """
-  number of rows affected by the mutation
-  """
+  """number of rows affected by the mutation"""
   affected_rows: Int!
-  """
-  data from the rows affected by the mutation
-  """
+  """data from the rows affected by the mutation"""
   returning: [reading_progresses!]!
 }
 
@@ -10584,9 +8179,7 @@ input reading_progresses_on_conflict {
   where: reading_progresses_bool_exp
 }
 
-"""
-Ordering options when selecting data from "reading_progresses".
-"""
+"""Ordering options when selecting data from "reading_progresses"."""
 input reading_progresses_order_by {
   book: books_order_by
   bookId: order_by
@@ -10602,9 +8195,7 @@ input reading_progresses_order_by {
   userId: order_by
 }
 
-"""
-primary key columns input for table: reading_progresses
-"""
+"""primary key columns input for table: reading_progresses"""
 input reading_progresses_pk_columns_input {
   id: uuid!
 }
@@ -10613,41 +8204,23 @@ input reading_progresses_pk_columns_input {
 select columns of table "reading_progresses"
 """
 enum reading_progresses_select_column {
-  """
-  column name
-  """
+  """column name"""
   bookId
-  """
-  column name
-  """
+  """column name"""
   createdAt
-  """
-  column name
-  """
+  """column name"""
   currentPage
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   lastReadAt
-  """
-  column name
-  """
+  """column name"""
   readingTimeMinutes
-  """
-  column name
-  """
+  """column name"""
   totalPages
-  """
-  column name
-  """
+  """column name"""
   updatedAt
-  """
-  column name
-  """
+  """column name"""
   userId
 }
 
@@ -10666,14 +8239,10 @@ input reading_progresses_set_input {
   userId: uuid
 }
 
-"""
-aggregate stddev on columns
-"""
+"""aggregate stddev on columns"""
 type reading_progresses_stddev_fields {
   currentPage: Float
-  """
-  Calculate percentage based on other column values
-  """
+  """Calculate percentage based on other column values"""
   percentage: numeric
   readingTimeMinutes: Float
   totalPages: Float
@@ -10688,14 +8257,10 @@ input reading_progresses_stddev_order_by {
   totalPages: order_by
 }
 
-"""
-aggregate stddev_pop on columns
-"""
+"""aggregate stddev_pop on columns"""
 type reading_progresses_stddev_pop_fields {
   currentPage: Float
-  """
-  Calculate percentage based on other column values
-  """
+  """Calculate percentage based on other column values"""
   percentage: numeric
   readingTimeMinutes: Float
   totalPages: Float
@@ -10710,14 +8275,10 @@ input reading_progresses_stddev_pop_order_by {
   totalPages: order_by
 }
 
-"""
-aggregate stddev_samp on columns
-"""
+"""aggregate stddev_samp on columns"""
 type reading_progresses_stddev_samp_fields {
   currentPage: Float
-  """
-  Calculate percentage based on other column values
-  """
+  """Calculate percentage based on other column values"""
   percentage: numeric
   readingTimeMinutes: Float
   totalPages: Float
@@ -10736,19 +8297,13 @@ input reading_progresses_stddev_samp_order_by {
 Streaming cursor of the table "reading_progresses"
 """
 input reading_progresses_stream_cursor_input {
-  """
-  Stream column input with initial value
-  """
+  """Stream column input with initial value"""
   initial_value: reading_progresses_stream_cursor_value_input!
-  """
-  cursor ordering
-  """
+  """cursor ordering"""
   ordering: cursor_ordering
 }
 
-"""
-Initial value of the column from where the streaming should start
-"""
+"""Initial value of the column from where the streaming should start"""
 input reading_progresses_stream_cursor_value_input {
   bookId: uuid
   createdAt: timestamptz
@@ -10761,14 +8316,10 @@ input reading_progresses_stream_cursor_value_input {
   userId: uuid
 }
 
-"""
-aggregate sum on columns
-"""
+"""aggregate sum on columns"""
 type reading_progresses_sum_fields {
   currentPage: Int
-  """
-  Calculate percentage based on other column values
-  """
+  """Calculate percentage based on other column values"""
   percentage: numeric
   readingTimeMinutes: Int
   totalPages: Int
@@ -10787,67 +8338,39 @@ input reading_progresses_sum_order_by {
 update columns of table "reading_progresses"
 """
 enum reading_progresses_update_column {
-  """
-  column name
-  """
+  """column name"""
   bookId
-  """
-  column name
-  """
+  """column name"""
   createdAt
-  """
-  column name
-  """
+  """column name"""
   currentPage
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   lastReadAt
-  """
-  column name
-  """
+  """column name"""
   readingTimeMinutes
-  """
-  column name
-  """
+  """column name"""
   totalPages
-  """
-  column name
-  """
+  """column name"""
   updatedAt
-  """
-  column name
-  """
+  """column name"""
   userId
 }
 
 input reading_progresses_updates {
-  """
-  increments the numeric columns with given value of the filtered values
-  """
+  """increments the numeric columns with given value of the filtered values"""
   _inc: reading_progresses_inc_input
-  """
-  sets the columns of the filtered rows to the given values
-  """
+  """sets the columns of the filtered rows to the given values"""
   _set: reading_progresses_set_input
-  """
-  filter the rows which have to be updated
-  """
+  """filter the rows which have to be updated"""
   where: reading_progresses_bool_exp!
 }
 
-"""
-aggregate var_pop on columns
-"""
+"""aggregate var_pop on columns"""
 type reading_progresses_var_pop_fields {
   currentPage: Float
-  """
-  Calculate percentage based on other column values
-  """
+  """Calculate percentage based on other column values"""
   percentage: numeric
   readingTimeMinutes: Float
   totalPages: Float
@@ -10862,14 +8385,10 @@ input reading_progresses_var_pop_order_by {
   totalPages: order_by
 }
 
-"""
-aggregate var_samp on columns
-"""
+"""aggregate var_samp on columns"""
 type reading_progresses_var_samp_fields {
   currentPage: Float
-  """
-  Calculate percentage based on other column values
-  """
+  """Calculate percentage based on other column values"""
   percentage: numeric
   readingTimeMinutes: Float
   totalPages: Float
@@ -10884,14 +8403,10 @@ input reading_progresses_var_samp_order_by {
   totalPages: order_by
 }
 
-"""
-aggregate variance on columns
-"""
+"""aggregate variance on columns"""
 type reading_progresses_variance_fields {
   currentPage: Float
-  """
-  Calculate percentage based on other column values
-  """
+  """Calculate percentage based on other column values"""
   percentage: numeric
   readingTimeMinutes: Float
   totalPages: Float
@@ -10912,16 +8427,12 @@ This table tell us what playlist is shared to whom. All videos in the playlist s
 type shared_playlist_recipients {
   created_at: timestamptz!
   id: uuid!
-  """
-  An object relationship
-  """
+  """An object relationship"""
   playlist: playlist!
   playlistId: uuid!
   recipientId: uuid!
   updated_at: timestamptz!
-  """
-  An object relationship
-  """
+  """An object relationship"""
   user: users!
 }
 
@@ -10948,10 +8459,7 @@ input shared_playlist_recipients_aggregate_bool_exp_count {
 aggregate fields of "shared_playlist_recipients"
 """
 type shared_playlist_recipients_aggregate_fields {
-  count(
-    columns: [shared_playlist_recipients_select_column!]
-    distinct: Boolean
-  ): Int!
+  count(columns: [shared_playlist_recipients_select_column!], distinct: Boolean): Int!
   max: shared_playlist_recipients_max_fields
   min: shared_playlist_recipients_min_fields
 }
@@ -10970,9 +8478,7 @@ input type for inserting array relation for remote table "shared_playlist_recipi
 """
 input shared_playlist_recipients_arr_rel_insert_input {
   data: [shared_playlist_recipients_insert_input!]!
-  """
-  upsert condition
-  """
+  """upsert condition"""
   on_conflict: shared_playlist_recipients_on_conflict
 }
 
@@ -11019,9 +8525,7 @@ input shared_playlist_recipients_insert_input {
   user: users_obj_rel_insert_input
 }
 
-"""
-aggregate max on columns
-"""
+"""aggregate max on columns"""
 type shared_playlist_recipients_max_fields {
   created_at: timestamptz
   id: uuid
@@ -11041,9 +8545,7 @@ input shared_playlist_recipients_max_order_by {
   updated_at: order_by
 }
 
-"""
-aggregate min on columns
-"""
+"""aggregate min on columns"""
 type shared_playlist_recipients_min_fields {
   created_at: timestamptz
   id: uuid
@@ -11067,13 +8569,9 @@ input shared_playlist_recipients_min_order_by {
 response of any mutation on the table "shared_playlist_recipients"
 """
 type shared_playlist_recipients_mutation_response {
-  """
-  number of rows affected by the mutation
-  """
+  """number of rows affected by the mutation"""
   affected_rows: Int!
-  """
-  data from the rows affected by the mutation
-  """
+  """data from the rows affected by the mutation"""
   returning: [shared_playlist_recipients!]!
 }
 
@@ -11099,9 +8597,7 @@ input shared_playlist_recipients_order_by {
   user: users_order_by
 }
 
-"""
-primary key columns input for table: shared_playlist_recipients
-"""
+"""primary key columns input for table: shared_playlist_recipients"""
 input shared_playlist_recipients_pk_columns_input {
   id: uuid!
 }
@@ -11110,25 +8606,15 @@ input shared_playlist_recipients_pk_columns_input {
 select columns of table "shared_playlist_recipients"
 """
 enum shared_playlist_recipients_select_column {
-  """
-  column name
-  """
+  """column name"""
   created_at
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   playlistId
-  """
-  column name
-  """
+  """column name"""
   recipientId
-  """
-  column name
-  """
+  """column name"""
   updated_at
 }
 
@@ -11147,19 +8633,13 @@ input shared_playlist_recipients_set_input {
 Streaming cursor of the table "shared_playlist_recipients"
 """
 input shared_playlist_recipients_stream_cursor_input {
-  """
-  Stream column input with initial value
-  """
+  """Stream column input with initial value"""
   initial_value: shared_playlist_recipients_stream_cursor_value_input!
-  """
-  cursor ordering
-  """
+  """cursor ordering"""
   ordering: cursor_ordering
 }
 
-"""
-Initial value of the column from where the streaming should start
-"""
+"""Initial value of the column from where the streaming should start"""
 input shared_playlist_recipients_stream_cursor_value_input {
   created_at: timestamptz
   id: uuid
@@ -11172,36 +8652,22 @@ input shared_playlist_recipients_stream_cursor_value_input {
 update columns of table "shared_playlist_recipients"
 """
 enum shared_playlist_recipients_update_column {
-  """
-  column name
-  """
+  """column name"""
   created_at
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   playlistId
-  """
-  column name
-  """
+  """column name"""
   recipientId
-  """
-  column name
-  """
+  """column name"""
   updated_at
 }
 
 input shared_playlist_recipients_updates {
-  """
-  sets the columns of the filtered rows to the given values
-  """
+  """sets the columns of the filtered rows to the given values"""
   _set: shared_playlist_recipients_set_input
-  """
-  filter the rows which have to be updated
-  """
+  """filter the rows which have to be updated"""
   where: shared_playlist_recipients_bool_exp!
 }
 
@@ -11211,18 +8677,12 @@ Each video can share for many users, one user can see many shared videos
 type shared_video_recipients {
   createdAt: timestamptz!
   id: uuid!
-  """
-  An object relationship
-  """
+  """An object relationship"""
   recipient: users
-  """
-  Just renamed from old receiver_id column
-  """
+  """Just renamed from old receiver_id column"""
   recipientId: uuid
   updatedAt: timestamptz!
-  """
-  An object relationship
-  """
+  """An object relationship"""
   video: videos!
   videoId: uuid!
   viewed: Boolean!
@@ -11267,10 +8727,7 @@ input shared_video_recipients_aggregate_bool_exp_count {
 aggregate fields of "shared_video_recipients"
 """
 type shared_video_recipients_aggregate_fields {
-  count(
-    columns: [shared_video_recipients_select_column!]
-    distinct: Boolean
-  ): Int!
+  count(columns: [shared_video_recipients_select_column!], distinct: Boolean): Int!
   max: shared_video_recipients_max_fields
   min: shared_video_recipients_min_fields
 }
@@ -11289,9 +8746,7 @@ input type for inserting array relation for remote table "shared_video_recipient
 """
 input shared_video_recipients_arr_rel_insert_input {
   data: [shared_video_recipients_insert_input!]!
-  """
-  upsert condition
-  """
+  """upsert condition"""
   on_conflict: shared_video_recipients_on_conflict
 }
 
@@ -11333,9 +8788,7 @@ input shared_video_recipients_insert_input {
   createdAt: timestamptz
   id: uuid
   recipient: users_obj_rel_insert_input
-  """
-  Just renamed from old receiver_id column
-  """
+  """Just renamed from old receiver_id column"""
   recipientId: uuid
   updatedAt: timestamptz
   video: videos_obj_rel_insert_input
@@ -11343,15 +8796,11 @@ input shared_video_recipients_insert_input {
   viewed: Boolean
 }
 
-"""
-aggregate max on columns
-"""
+"""aggregate max on columns"""
 type shared_video_recipients_max_fields {
   createdAt: timestamptz
   id: uuid
-  """
-  Just renamed from old receiver_id column
-  """
+  """Just renamed from old receiver_id column"""
   recipientId: uuid
   updatedAt: timestamptz
   videoId: uuid
@@ -11363,23 +8812,17 @@ order by max() on columns of table "shared_video_recipients"
 input shared_video_recipients_max_order_by {
   createdAt: order_by
   id: order_by
-  """
-  Just renamed from old receiver_id column
-  """
+  """Just renamed from old receiver_id column"""
   recipientId: order_by
   updatedAt: order_by
   videoId: order_by
 }
 
-"""
-aggregate min on columns
-"""
+"""aggregate min on columns"""
 type shared_video_recipients_min_fields {
   createdAt: timestamptz
   id: uuid
-  """
-  Just renamed from old receiver_id column
-  """
+  """Just renamed from old receiver_id column"""
   recipientId: uuid
   updatedAt: timestamptz
   videoId: uuid
@@ -11391,9 +8834,7 @@ order by min() on columns of table "shared_video_recipients"
 input shared_video_recipients_min_order_by {
   createdAt: order_by
   id: order_by
-  """
-  Just renamed from old receiver_id column
-  """
+  """Just renamed from old receiver_id column"""
   recipientId: order_by
   updatedAt: order_by
   videoId: order_by
@@ -11403,13 +8844,9 @@ input shared_video_recipients_min_order_by {
 response of any mutation on the table "shared_video_recipients"
 """
 type shared_video_recipients_mutation_response {
-  """
-  number of rows affected by the mutation
-  """
+  """number of rows affected by the mutation"""
   affected_rows: Int!
-  """
-  data from the rows affected by the mutation
-  """
+  """data from the rows affected by the mutation"""
   returning: [shared_video_recipients!]!
 }
 
@@ -11422,9 +8859,7 @@ input shared_video_recipients_on_conflict {
   where: shared_video_recipients_bool_exp
 }
 
-"""
-Ordering options when selecting data from "shared_video_recipients".
-"""
+"""Ordering options when selecting data from "shared_video_recipients"."""
 input shared_video_recipients_order_by {
   createdAt: order_by
   id: order_by
@@ -11436,9 +8871,7 @@ input shared_video_recipients_order_by {
   viewed: order_by
 }
 
-"""
-primary key columns input for table: shared_video_recipients
-"""
+"""primary key columns input for table: shared_video_recipients"""
 input shared_video_recipients_pk_columns_input {
   id: uuid!
 }
@@ -11447,29 +8880,17 @@ input shared_video_recipients_pk_columns_input {
 select columns of table "shared_video_recipients"
 """
 enum shared_video_recipients_select_column {
-  """
-  column name
-  """
+  """column name"""
   createdAt
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   recipientId
-  """
-  column name
-  """
+  """column name"""
   updatedAt
-  """
-  column name
-  """
+  """column name"""
   videoId
-  """
-  column name
-  """
+  """column name"""
   viewed
 }
 
@@ -11477,9 +8898,7 @@ enum shared_video_recipients_select_column {
 select "shared_video_recipients_aggregate_bool_exp_bool_and_arguments_columns" columns of table "shared_video_recipients"
 """
 enum shared_video_recipients_select_column_shared_video_recipients_aggregate_bool_exp_bool_and_arguments_columns {
-  """
-  column name
-  """
+  """column name"""
   viewed
 }
 
@@ -11487,9 +8906,7 @@ enum shared_video_recipients_select_column_shared_video_recipients_aggregate_boo
 select "shared_video_recipients_aggregate_bool_exp_bool_or_arguments_columns" columns of table "shared_video_recipients"
 """
 enum shared_video_recipients_select_column_shared_video_recipients_aggregate_bool_exp_bool_or_arguments_columns {
-  """
-  column name
-  """
+  """column name"""
   viewed
 }
 
@@ -11499,9 +8916,7 @@ input type for updating data in table "shared_video_recipients"
 input shared_video_recipients_set_input {
   createdAt: timestamptz
   id: uuid
-  """
-  Just renamed from old receiver_id column
-  """
+  """Just renamed from old receiver_id column"""
   recipientId: uuid
   updatedAt: timestamptz
   videoId: uuid
@@ -11512,25 +8927,17 @@ input shared_video_recipients_set_input {
 Streaming cursor of the table "shared_video_recipients"
 """
 input shared_video_recipients_stream_cursor_input {
-  """
-  Stream column input with initial value
-  """
+  """Stream column input with initial value"""
   initial_value: shared_video_recipients_stream_cursor_value_input!
-  """
-  cursor ordering
-  """
+  """cursor ordering"""
   ordering: cursor_ordering
 }
 
-"""
-Initial value of the column from where the streaming should start
-"""
+"""Initial value of the column from where the streaming should start"""
 input shared_video_recipients_stream_cursor_value_input {
   createdAt: timestamptz
   id: uuid
-  """
-  Just renamed from old receiver_id column
-  """
+  """Just renamed from old receiver_id column"""
   recipientId: uuid
   updatedAt: timestamptz
   videoId: uuid
@@ -11541,589 +8948,329 @@ input shared_video_recipients_stream_cursor_value_input {
 update columns of table "shared_video_recipients"
 """
 enum shared_video_recipients_update_column {
-  """
-  column name
-  """
+  """column name"""
   createdAt
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   recipientId
-  """
-  column name
-  """
+  """column name"""
   updatedAt
-  """
-  column name
-  """
+  """column name"""
   videoId
-  """
-  column name
-  """
+  """column name"""
   viewed
 }
 
 input shared_video_recipients_updates {
-  """
-  sets the columns of the filtered rows to the given values
-  """
+  """sets the columns of the filtered rows to the given values"""
   _set: shared_video_recipients_set_input
-  """
-  filter the rows which have to be updated
-  """
+  """filter the rows which have to be updated"""
   where: shared_video_recipients_bool_exp!
 }
 
 type subscription_root {
-  """
-  An array relationship
-  """
+  """An array relationship"""
   audio_tags(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [audio_tags_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [audio_tags_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: audio_tags_bool_exp
   ): [audio_tags!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   audio_tags_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [audio_tags_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [audio_tags_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: audio_tags_bool_exp
   ): audio_tags_aggregate!
-  """
-  fetch data from the table: "audio_tags" using primary key columns
-  """
+  """fetch data from the table: "audio_tags" using primary key columns"""
   audio_tags_by_pk(audio_id: uuid!, tag_id: uuid!): audio_tags
   """
   fetch data from the table in a streaming manner: "audio_tags"
   """
   audio_tags_stream(
-    """
-    maximum number of rows returned in a single batch
-    """
+    """maximum number of rows returned in a single batch"""
     batch_size: Int!
-    """
-    cursor to stream the results returned by the query
-    """
+    """cursor to stream the results returned by the query"""
     cursor: [audio_tags_stream_cursor_input]!
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: audio_tags_bool_exp
   ): [audio_tags!]!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   audios(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [audios_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [audios_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: audios_bool_exp
   ): [audios!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   audios_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [audios_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [audios_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: audios_bool_exp
   ): audios_aggregate!
-  """
-  fetch data from the table: "audios" using primary key columns
-  """
+  """fetch data from the table: "audios" using primary key columns"""
   audios_by_pk(id: uuid!): audios
   """
   fetch data from the table in a streaming manner: "audios"
   """
   audios_stream(
-    """
-    maximum number of rows returned in a single batch
-    """
+    """maximum number of rows returned in a single batch"""
     batch_size: Int!
-    """
-    cursor to stream the results returned by the query
-    """
+    """cursor to stream the results returned by the query"""
     cursor: [audios_stream_cursor_input]!
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: audios_bool_exp
   ): [audios!]!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   book_comments(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [book_comments_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [book_comments_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: book_comments_bool_exp
   ): [book_comments!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   book_comments_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [book_comments_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [book_comments_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: book_comments_bool_exp
   ): book_comments_aggregate!
-  """
-  fetch data from the table: "book_comments" using primary key columns
-  """
+  """fetch data from the table: "book_comments" using primary key columns"""
   book_comments_by_pk(id: uuid!): book_comments
   """
   fetch data from the table in a streaming manner: "book_comments"
   """
   book_comments_stream(
-    """
-    maximum number of rows returned in a single batch
-    """
+    """maximum number of rows returned in a single batch"""
     batch_size: Int!
-    """
-    cursor to stream the results returned by the query
-    """
+    """cursor to stream the results returned by the query"""
     cursor: [book_comments_stream_cursor_input]!
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: book_comments_bool_exp
   ): [book_comments!]!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   books(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [books_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [books_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: books_bool_exp
   ): [books!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   books_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [books_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [books_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: books_bool_exp
   ): books_aggregate!
-  """
-  fetch data from the table: "books" using primary key columns
-  """
+  """fetch data from the table: "books" using primary key columns"""
   books_by_pk(id: uuid!): books
   """
   fetch data from the table in a streaming manner: "books"
   """
   books_stream(
-    """
-    maximum number of rows returned in a single batch
-    """
+    """maximum number of rows returned in a single batch"""
     batch_size: Int!
-    """
-    cursor to stream the results returned by the query
-    """
+    """cursor to stream the results returned by the query"""
     cursor: [books_stream_cursor_input]!
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: books_bool_exp
   ): [books!]!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   crawl_requests(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [crawl_requests_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [crawl_requests_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: crawl_requests_bool_exp
   ): [crawl_requests!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   crawl_requests_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [crawl_requests_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [crawl_requests_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: crawl_requests_bool_exp
   ): crawl_requests_aggregate!
-  """
-  fetch data from the table: "crawl_requests" using primary key columns
-  """
+  """fetch data from the table: "crawl_requests" using primary key columns"""
   crawl_requests_by_pk(id: uuid!): crawl_requests
   """
   fetch data from the table in a streaming manner: "crawl_requests"
   """
   crawl_requests_stream(
-    """
-    maximum number of rows returned in a single batch
-    """
+    """maximum number of rows returned in a single batch"""
     batch_size: Int!
-    """
-    cursor to stream the results returned by the query
-    """
+    """cursor to stream the results returned by the query"""
     cursor: [crawl_requests_stream_cursor_input]!
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: crawl_requests_bool_exp
   ): [crawl_requests!]!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   device_requests(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [device_requests_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [device_requests_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: device_requests_bool_exp
   ): [device_requests!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   device_requests_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [device_requests_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [device_requests_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: device_requests_bool_exp
   ): device_requests_aggregate!
-  """
-  fetch data from the table: "device_requests" using primary key columns
-  """
+  """fetch data from the table: "device_requests" using primary key columns"""
   device_requests_by_pk(id: uuid!): device_requests
   """
   fetch data from the table in a streaming manner: "device_requests"
   """
   device_requests_stream(
-    """
-    maximum number of rows returned in a single batch
-    """
+    """maximum number of rows returned in a single batch"""
     batch_size: Int!
-    """
-    cursor to stream the results returned by the query
-    """
+    """cursor to stream the results returned by the query"""
     cursor: [device_requests_stream_cursor_input]!
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: device_requests_bool_exp
   ): [device_requests!]!
   """
   fetch data from the table: "feature_flag"
   """
   feature_flag(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [feature_flag_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [feature_flag_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: feature_flag_bool_exp
   ): [feature_flag!]!
   """
   fetch aggregated fields from the table: "feature_flag"
   """
   feature_flag_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [feature_flag_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [feature_flag_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: feature_flag_bool_exp
   ): feature_flag_aggregate!
-  """
-  fetch data from the table: "feature_flag" using primary key columns
-  """
+  """fetch data from the table: "feature_flag" using primary key columns"""
   feature_flag_by_pk(id: uuid!): feature_flag
   """
   fetch data from the table in a streaming manner: "feature_flag"
   """
   feature_flag_stream(
-    """
-    maximum number of rows returned in a single batch
-    """
+    """maximum number of rows returned in a single batch"""
     batch_size: Int!
-    """
-    cursor to stream the results returned by the query
-    """
+    """cursor to stream the results returned by the query"""
     cursor: [feature_flag_stream_cursor_input]!
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: feature_flag_bool_exp
   ): [feature_flag!]!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   finance_transactions(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [finance_transactions_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [finance_transactions_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: finance_transactions_bool_exp
   ): [finance_transactions!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   finance_transactions_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [finance_transactions_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [finance_transactions_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: finance_transactions_bool_exp
   ): finance_transactions_aggregate!
   """
@@ -12134,493 +9281,279 @@ type subscription_root {
   fetch data from the table in a streaming manner: "finance_transactions"
   """
   finance_transactions_stream(
-    """
-    maximum number of rows returned in a single batch
-    """
+    """maximum number of rows returned in a single batch"""
     batch_size: Int!
-    """
-    cursor to stream the results returned by the query
-    """
+    """cursor to stream the results returned by the query"""
     cursor: [finance_transactions_stream_cursor_input]!
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: finance_transactions_bool_exp
   ): [finance_transactions!]!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   journals(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [journals_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [journals_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: journals_bool_exp
   ): [journals!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   journals_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [journals_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [journals_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: journals_bool_exp
   ): journals_aggregate!
-  """
-  fetch data from the table: "journals" using primary key columns
-  """
+  """fetch data from the table: "journals" using primary key columns"""
   journals_by_pk(id: uuid!): journals
   """
   fetch data from the table in a streaming manner: "journals"
   """
   journals_stream(
-    """
-    maximum number of rows returned in a single batch
-    """
+    """maximum number of rows returned in a single batch"""
     batch_size: Int!
-    """
-    cursor to stream the results returned by the query
-    """
+    """cursor to stream the results returned by the query"""
     cursor: [journals_stream_cursor_input]!
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: journals_bool_exp
   ): [journals!]!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   notifications(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [notifications_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [notifications_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: notifications_bool_exp
   ): [notifications!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   notifications_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [notifications_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [notifications_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: notifications_bool_exp
   ): notifications_aggregate!
-  """
-  fetch data from the table: "notifications" using primary key columns
-  """
+  """fetch data from the table: "notifications" using primary key columns"""
   notifications_by_pk(id: uuid!): notifications
   """
   fetch data from the table in a streaming manner: "notifications"
   """
   notifications_stream(
-    """
-    maximum number of rows returned in a single batch
-    """
+    """maximum number of rows returned in a single batch"""
     batch_size: Int!
-    """
-    cursor to stream the results returned by the query
-    """
+    """cursor to stream the results returned by the query"""
     cursor: [notifications_stream_cursor_input]!
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: notifications_bool_exp
   ): [notifications!]!
   """
   fetch data from the table: "playlist"
   """
   playlist(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [playlist_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [playlist_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: playlist_bool_exp
   ): [playlist!]!
   """
   fetch aggregated fields from the table: "playlist"
   """
   playlist_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [playlist_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [playlist_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: playlist_bool_exp
   ): playlist_aggregate!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   playlist_audios(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [playlist_audios_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [playlist_audios_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: playlist_audios_bool_exp
   ): [playlist_audios!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   playlist_audios_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [playlist_audios_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [playlist_audios_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: playlist_audios_bool_exp
   ): playlist_audios_aggregate!
-  """
-  fetch data from the table: "playlist_audios" using primary key columns
-  """
+  """fetch data from the table: "playlist_audios" using primary key columns"""
   playlist_audios_by_pk(audio_id: uuid!, playlist_id: uuid!): playlist_audios
   """
   fetch data from the table in a streaming manner: "playlist_audios"
   """
   playlist_audios_stream(
-    """
-    maximum number of rows returned in a single batch
-    """
+    """maximum number of rows returned in a single batch"""
     batch_size: Int!
-    """
-    cursor to stream the results returned by the query
-    """
+    """cursor to stream the results returned by the query"""
     cursor: [playlist_audios_stream_cursor_input]!
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: playlist_audios_bool_exp
   ): [playlist_audios!]!
-  """
-  fetch data from the table: "playlist" using primary key columns
-  """
+  """fetch data from the table: "playlist" using primary key columns"""
   playlist_by_pk(id: uuid!): playlist
   """
   fetch data from the table in a streaming manner: "playlist"
   """
   playlist_stream(
-    """
-    maximum number of rows returned in a single batch
-    """
+    """maximum number of rows returned in a single batch"""
     batch_size: Int!
-    """
-    cursor to stream the results returned by the query
-    """
+    """cursor to stream the results returned by the query"""
     cursor: [playlist_stream_cursor_input]!
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: playlist_bool_exp
   ): [playlist!]!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   playlist_videos(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [playlist_videos_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [playlist_videos_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: playlist_videos_bool_exp
   ): [playlist_videos!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   playlist_videos_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [playlist_videos_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [playlist_videos_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: playlist_videos_bool_exp
   ): playlist_videos_aggregate!
-  """
-  fetch data from the table: "playlist_videos" using primary key columns
-  """
+  """fetch data from the table: "playlist_videos" using primary key columns"""
   playlist_videos_by_pk(playlist_id: uuid!, video_id: uuid!): playlist_videos
   """
   fetch data from the table in a streaming manner: "playlist_videos"
   """
   playlist_videos_stream(
-    """
-    maximum number of rows returned in a single batch
-    """
+    """maximum number of rows returned in a single batch"""
     batch_size: Int!
-    """
-    cursor to stream the results returned by the query
-    """
+    """cursor to stream the results returned by the query"""
     cursor: [playlist_videos_stream_cursor_input]!
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: playlist_videos_bool_exp
   ): [playlist_videos!]!
   """
   fetch data from the table: "posts"
   """
   posts(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [posts_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [posts_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: posts_bool_exp
   ): [posts!]!
   """
   fetch aggregated fields from the table: "posts"
   """
   posts_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [posts_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [posts_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: posts_bool_exp
   ): posts_aggregate!
-  """
-  fetch data from the table: "posts" using primary key columns
-  """
+  """fetch data from the table: "posts" using primary key columns"""
   posts_by_pk(id: uuid!): posts
   """
   fetch data from the table in a streaming manner: "posts"
   """
   posts_stream(
-    """
-    maximum number of rows returned in a single batch
-    """
+    """maximum number of rows returned in a single batch"""
     batch_size: Int!
-    """
-    cursor to stream the results returned by the query
-    """
+    """cursor to stream the results returned by the query"""
     cursor: [posts_stream_cursor_input]!
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: posts_bool_exp
   ): [posts!]!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   reading_progresses(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [reading_progresses_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [reading_progresses_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: reading_progresses_bool_exp
   ): [reading_progresses!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   reading_progresses_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [reading_progresses_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [reading_progresses_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: reading_progresses_bool_exp
   ): reading_progresses_aggregate!
   """
@@ -12631,67 +9564,37 @@ type subscription_root {
   fetch data from the table in a streaming manner: "reading_progresses"
   """
   reading_progresses_stream(
-    """
-    maximum number of rows returned in a single batch
-    """
+    """maximum number of rows returned in a single batch"""
     batch_size: Int!
-    """
-    cursor to stream the results returned by the query
-    """
+    """cursor to stream the results returned by the query"""
     cursor: [reading_progresses_stream_cursor_input]!
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: reading_progresses_bool_exp
   ): [reading_progresses!]!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   shared_playlist_recipients(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [shared_playlist_recipients_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [shared_playlist_recipients_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: shared_playlist_recipients_bool_exp
   ): [shared_playlist_recipients!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   shared_playlist_recipients_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [shared_playlist_recipients_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [shared_playlist_recipients_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: shared_playlist_recipients_bool_exp
   ): shared_playlist_recipients_aggregate!
   """
@@ -12702,67 +9605,37 @@ type subscription_root {
   fetch data from the table in a streaming manner: "shared_playlist_recipients"
   """
   shared_playlist_recipients_stream(
-    """
-    maximum number of rows returned in a single batch
-    """
+    """maximum number of rows returned in a single batch"""
     batch_size: Int!
-    """
-    cursor to stream the results returned by the query
-    """
+    """cursor to stream the results returned by the query"""
     cursor: [shared_playlist_recipients_stream_cursor_input]!
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: shared_playlist_recipients_bool_exp
   ): [shared_playlist_recipients!]!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   shared_video_recipients(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [shared_video_recipients_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [shared_video_recipients_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: shared_video_recipients_bool_exp
   ): [shared_video_recipients!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   shared_video_recipients_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [shared_video_recipients_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [shared_video_recipients_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: shared_video_recipients_bool_exp
   ): shared_video_recipients_aggregate!
   """
@@ -12773,351 +9646,252 @@ type subscription_root {
   fetch data from the table in a streaming manner: "shared_video_recipients"
   """
   shared_video_recipients_stream(
-    """
-    maximum number of rows returned in a single batch
-    """
+    """maximum number of rows returned in a single batch"""
     batch_size: Int!
-    """
-    cursor to stream the results returned by the query
-    """
+    """cursor to stream the results returned by the query"""
     cursor: [shared_video_recipients_stream_cursor_input]!
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: shared_video_recipients_bool_exp
   ): [shared_video_recipients!]!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   subtitles(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [subtitles_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [subtitles_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: subtitles_bool_exp
   ): [subtitles!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   subtitles_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [subtitles_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [subtitles_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: subtitles_bool_exp
   ): subtitles_aggregate!
-  """
-  fetch data from the table: "subtitles" using primary key columns
-  """
+  """fetch data from the table: "subtitles" using primary key columns"""
   subtitles_by_pk(id: uuid!): subtitles
   """
   fetch data from the table in a streaming manner: "subtitles"
   """
   subtitles_stream(
-    """
-    maximum number of rows returned in a single batch
-    """
+    """maximum number of rows returned in a single batch"""
     batch_size: Int!
-    """
-    cursor to stream the results returned by the query
-    """
+    """cursor to stream the results returned by the query"""
     cursor: [subtitles_stream_cursor_input]!
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: subtitles_bool_exp
   ): [subtitles!]!
   """
   fetch data from the table: "tags"
   """
   tags(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [tags_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [tags_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: tags_bool_exp
   ): [tags!]!
   """
   fetch aggregated fields from the table: "tags"
   """
   tags_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [tags_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [tags_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: tags_bool_exp
   ): tags_aggregate!
-  """
-  fetch data from the table: "tags" using primary key columns
-  """
+  """fetch data from the table: "tags" using primary key columns"""
   tags_by_pk(id: uuid!): tags
   """
   fetch data from the table in a streaming manner: "tags"
   """
   tags_stream(
-    """
-    maximum number of rows returned in a single batch
-    """
+    """maximum number of rows returned in a single batch"""
     batch_size: Int!
-    """
-    cursor to stream the results returned by the query
-    """
+    """cursor to stream the results returned by the query"""
     cursor: [tags_stream_cursor_input]!
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: tags_bool_exp
   ): [tags!]!
   """
   fetch data from the table: "tasks"
   """
   tasks(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [tasks_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [tasks_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: tasks_bool_exp
   ): [tasks!]!
   """
   fetch aggregated fields from the table: "tasks"
   """
   tasks_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [tasks_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [tasks_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: tasks_bool_exp
   ): tasks_aggregate!
-  """
-  fetch data from the table: "tasks" using primary key columns
-  """
+  """fetch data from the table: "tasks" using primary key columns"""
   tasks_by_pk(id: uuid!): tasks
   """
   fetch data from the table in a streaming manner: "tasks"
   """
   tasks_stream(
-    """
-    maximum number of rows returned in a single batch
-    """
+    """maximum number of rows returned in a single batch"""
     batch_size: Int!
-    """
-    cursor to stream the results returned by the query
-    """
+    """cursor to stream the results returned by the query"""
     cursor: [tasks_stream_cursor_input]!
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: tasks_bool_exp
   ): [tasks!]!
   """
   fetch data from the table: "test"
   """
   test(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [test_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [test_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: test_bool_exp
   ): [test!]!
   """
   fetch aggregated fields from the table: "test"
   """
   test_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [test_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [test_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: test_bool_exp
   ): test_aggregate!
-  """
-  fetch data from the table: "test" using primary key columns
-  """
+  """fetch data from the table: "test" using primary key columns"""
   test_by_pk(id: Int!): test
   """
   fetch data from the table in a streaming manner: "test"
   """
   test_stream(
-    """
-    maximum number of rows returned in a single batch
-    """
+    """maximum number of rows returned in a single batch"""
     batch_size: Int!
-    """
-    cursor to stream the results returned by the query
-    """
+    """cursor to stream the results returned by the query"""
     cursor: [test_stream_cursor_input]!
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: test_bool_exp
   ): [test!]!
+  """
+  fetch data from the table: "user_settings"
+  """
+  user_settings(
+    """distinct select on columns"""
+    distinct_on: [user_settings_select_column!]
+    """limit the number of rows returned"""
+    limit: Int
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+    """sort the rows by one or more columns"""
+    order_by: [user_settings_order_by!]
+    """filter the rows returned"""
+    where: user_settings_bool_exp
+  ): [user_settings!]!
+  """
+  fetch aggregated fields from the table: "user_settings"
+  """
+  user_settings_aggregate(
+    """distinct select on columns"""
+    distinct_on: [user_settings_select_column!]
+    """limit the number of rows returned"""
+    limit: Int
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+    """sort the rows by one or more columns"""
+    order_by: [user_settings_order_by!]
+    """filter the rows returned"""
+    where: user_settings_bool_exp
+  ): user_settings_aggregate!
+  """fetch data from the table: "user_settings" using primary key columns"""
+  user_settings_by_pk(user_id: uuid!): user_settings
+  """
+  fetch data from the table in a streaming manner: "user_settings"
+  """
+  user_settings_stream(
+    """maximum number of rows returned in a single batch"""
+    batch_size: Int!
+    """cursor to stream the results returned by the query"""
+    cursor: [user_settings_stream_cursor_input]!
+    """filter the rows returned"""
+    where: user_settings_bool_exp
+  ): [user_settings!]!
   """
   fetch data from the table: "user_video_history"
   """
   user_video_history(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [user_video_history_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [user_video_history_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: user_video_history_bool_exp
   ): [user_video_history!]!
   """
   fetch aggregated fields from the table: "user_video_history"
   """
   user_video_history_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [user_video_history_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [user_video_history_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: user_video_history_bool_exp
   ): user_video_history_aggregate!
   """
@@ -13128,308 +9902,176 @@ type subscription_root {
   fetch data from the table in a streaming manner: "user_video_history"
   """
   user_video_history_stream(
-    """
-    maximum number of rows returned in a single batch
-    """
+    """maximum number of rows returned in a single batch"""
     batch_size: Int!
-    """
-    cursor to stream the results returned by the query
-    """
+    """cursor to stream the results returned by the query"""
     cursor: [user_video_history_stream_cursor_input]!
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: user_video_history_bool_exp
   ): [user_video_history!]!
   """
   fetch data from the table: "users"
   """
   users(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [users_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [users_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: users_bool_exp
   ): [users!]!
   """
   fetch aggregated fields from the table: "users"
   """
   users_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [users_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [users_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: users_bool_exp
   ): users_aggregate!
-  """
-  fetch data from the table: "users" using primary key columns
-  """
+  """fetch data from the table: "users" using primary key columns"""
   users_by_pk(id: uuid!): users
   """
   fetch data from the table in a streaming manner: "users"
   """
   users_stream(
-    """
-    maximum number of rows returned in a single batch
-    """
+    """maximum number of rows returned in a single batch"""
     batch_size: Int!
-    """
-    cursor to stream the results returned by the query
-    """
+    """cursor to stream the results returned by the query"""
     cursor: [users_stream_cursor_input]!
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: users_bool_exp
   ): [users!]!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   video_tags(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [video_tags_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [video_tags_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: video_tags_bool_exp
   ): [video_tags!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   video_tags_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [video_tags_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [video_tags_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: video_tags_bool_exp
   ): video_tags_aggregate!
-  """
-  fetch data from the table: "video_tags" using primary key columns
-  """
+  """fetch data from the table: "video_tags" using primary key columns"""
   video_tags_by_pk(tag_id: uuid!, video_id: uuid!): video_tags
   """
   fetch data from the table in a streaming manner: "video_tags"
   """
   video_tags_stream(
-    """
-    maximum number of rows returned in a single batch
-    """
+    """maximum number of rows returned in a single batch"""
     batch_size: Int!
-    """
-    cursor to stream the results returned by the query
-    """
+    """cursor to stream the results returned by the query"""
     cursor: [video_tags_stream_cursor_input]!
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: video_tags_bool_exp
   ): [video_tags!]!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   video_views(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [video_views_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [video_views_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: video_views_bool_exp
   ): [video_views!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   video_views_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [video_views_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [video_views_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: video_views_bool_exp
   ): video_views_aggregate!
-  """
-  fetch data from the table: "video_views" using primary key columns
-  """
+  """fetch data from the table: "video_views" using primary key columns"""
   video_views_by_pk(id: uuid!): video_views
   """
   fetch data from the table in a streaming manner: "video_views"
   """
   video_views_stream(
-    """
-    maximum number of rows returned in a single batch
-    """
+    """maximum number of rows returned in a single batch"""
     batch_size: Int!
-    """
-    cursor to stream the results returned by the query
-    """
+    """cursor to stream the results returned by the query"""
     cursor: [video_views_stream_cursor_input]!
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: video_views_bool_exp
   ): [video_views!]!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   videos(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [videos_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [videos_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: videos_bool_exp
   ): [videos!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   videos_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [videos_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [videos_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: videos_bool_exp
   ): videos_aggregate!
-  """
-  fetch data from the table: "videos" using primary key columns
-  """
+  """fetch data from the table: "videos" using primary key columns"""
   videos_by_pk(id: uuid!): videos
   """
   fetch data from the table in a streaming manner: "videos"
   """
   videos_stream(
-    """
-    maximum number of rows returned in a single batch
-    """
+    """maximum number of rows returned in a single batch"""
     batch_size: Int!
-    """
-    cursor to stream the results returned by the query
-    """
+    """cursor to stream the results returned by the query"""
     cursor: [videos_stream_cursor_input]!
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: videos_bool_exp
   ): [videos!]!
 }
 
-"""
-Subtitles for video
-"""
+"""Subtitles for video"""
 type subtitles {
   created_at: timestamptz!
   id: uuid!
@@ -13437,21 +10079,13 @@ type subtitles {
   lang: String!
   updated_at: timestamptz!
   url: String!
-  """
-  User input, not validated yet
-  """
+  """User input, not validated yet"""
   urlInput: String
-  """
-  An object relationship
-  """
+  """An object relationship"""
   user: users
-  """
-  Owner, who create the subtitle
-  """
+  """Owner, who create the subtitle"""
   userId: uuid
-  """
-  An object relationship
-  """
+  """An object relationship"""
   video: videos!
   video_id: uuid!
 }
@@ -13514,9 +10148,7 @@ input type for inserting array relation for remote table "subtitles"
 """
 input subtitles_arr_rel_insert_input {
   data: [subtitles_insert_input!]!
-  """
-  upsert condition
-  """
+  """upsert condition"""
   on_conflict: subtitles_on_conflict
 }
 
@@ -13560,35 +10192,25 @@ input subtitles_insert_input {
   lang: String
   updated_at: timestamptz
   url: String
-  """
-  User input, not validated yet
-  """
+  """User input, not validated yet"""
   urlInput: String
   user: users_obj_rel_insert_input
-  """
-  Owner, who create the subtitle
-  """
+  """Owner, who create the subtitle"""
   userId: uuid
   video: videos_obj_rel_insert_input
   video_id: uuid
 }
 
-"""
-aggregate max on columns
-"""
+"""aggregate max on columns"""
 type subtitles_max_fields {
   created_at: timestamptz
   id: uuid
   lang: String
   updated_at: timestamptz
   url: String
-  """
-  User input, not validated yet
-  """
+  """User input, not validated yet"""
   urlInput: String
-  """
-  Owner, who create the subtitle
-  """
+  """Owner, who create the subtitle"""
   userId: uuid
   video_id: uuid
 }
@@ -13602,33 +10224,23 @@ input subtitles_max_order_by {
   lang: order_by
   updated_at: order_by
   url: order_by
-  """
-  User input, not validated yet
-  """
+  """User input, not validated yet"""
   urlInput: order_by
-  """
-  Owner, who create the subtitle
-  """
+  """Owner, who create the subtitle"""
   userId: order_by
   video_id: order_by
 }
 
-"""
-aggregate min on columns
-"""
+"""aggregate min on columns"""
 type subtitles_min_fields {
   created_at: timestamptz
   id: uuid
   lang: String
   updated_at: timestamptz
   url: String
-  """
-  User input, not validated yet
-  """
+  """User input, not validated yet"""
   urlInput: String
-  """
-  Owner, who create the subtitle
-  """
+  """Owner, who create the subtitle"""
   userId: uuid
   video_id: uuid
 }
@@ -13642,13 +10254,9 @@ input subtitles_min_order_by {
   lang: order_by
   updated_at: order_by
   url: order_by
-  """
-  User input, not validated yet
-  """
+  """User input, not validated yet"""
   urlInput: order_by
-  """
-  Owner, who create the subtitle
-  """
+  """Owner, who create the subtitle"""
   userId: order_by
   video_id: order_by
 }
@@ -13657,13 +10265,9 @@ input subtitles_min_order_by {
 response of any mutation on the table "subtitles"
 """
 type subtitles_mutation_response {
-  """
-  number of rows affected by the mutation
-  """
+  """number of rows affected by the mutation"""
   affected_rows: Int!
-  """
-  data from the rows affected by the mutation
-  """
+  """data from the rows affected by the mutation"""
   returning: [subtitles!]!
 }
 
@@ -13676,9 +10280,7 @@ input subtitles_on_conflict {
   where: subtitles_bool_exp
 }
 
-"""
-Ordering options when selecting data from "subtitles".
-"""
+"""Ordering options when selecting data from "subtitles"."""
 input subtitles_order_by {
   created_at: order_by
   id: order_by
@@ -13693,9 +10295,7 @@ input subtitles_order_by {
   video_id: order_by
 }
 
-"""
-primary key columns input for table: subtitles
-"""
+"""primary key columns input for table: subtitles"""
 input subtitles_pk_columns_input {
   id: uuid!
 }
@@ -13704,41 +10304,23 @@ input subtitles_pk_columns_input {
 select columns of table "subtitles"
 """
 enum subtitles_select_column {
-  """
-  column name
-  """
+  """column name"""
   created_at
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   isDefault
-  """
-  column name
-  """
+  """column name"""
   lang
-  """
-  column name
-  """
+  """column name"""
   updated_at
-  """
-  column name
-  """
+  """column name"""
   url
-  """
-  column name
-  """
+  """column name"""
   urlInput
-  """
-  column name
-  """
+  """column name"""
   userId
-  """
-  column name
-  """
+  """column name"""
   video_id
 }
 
@@ -13746,9 +10328,7 @@ enum subtitles_select_column {
 select "subtitles_aggregate_bool_exp_bool_and_arguments_columns" columns of table "subtitles"
 """
 enum subtitles_select_column_subtitles_aggregate_bool_exp_bool_and_arguments_columns {
-  """
-  column name
-  """
+  """column name"""
   isDefault
 }
 
@@ -13756,9 +10336,7 @@ enum subtitles_select_column_subtitles_aggregate_bool_exp_bool_and_arguments_col
 select "subtitles_aggregate_bool_exp_bool_or_arguments_columns" columns of table "subtitles"
 """
 enum subtitles_select_column_subtitles_aggregate_bool_exp_bool_or_arguments_columns {
-  """
-  column name
-  """
+  """column name"""
   isDefault
 }
 
@@ -13772,13 +10350,9 @@ input subtitles_set_input {
   lang: String
   updated_at: timestamptz
   url: String
-  """
-  User input, not validated yet
-  """
+  """User input, not validated yet"""
   urlInput: String
-  """
-  Owner, who create the subtitle
-  """
+  """Owner, who create the subtitle"""
   userId: uuid
   video_id: uuid
 }
@@ -13787,19 +10361,13 @@ input subtitles_set_input {
 Streaming cursor of the table "subtitles"
 """
 input subtitles_stream_cursor_input {
-  """
-  Stream column input with initial value
-  """
+  """Stream column input with initial value"""
   initial_value: subtitles_stream_cursor_value_input!
-  """
-  cursor ordering
-  """
+  """cursor ordering"""
   ordering: cursor_ordering
 }
 
-"""
-Initial value of the column from where the streaming should start
-"""
+"""Initial value of the column from where the streaming should start"""
 input subtitles_stream_cursor_value_input {
   created_at: timestamptz
   id: uuid
@@ -13807,13 +10375,9 @@ input subtitles_stream_cursor_value_input {
   lang: String
   updated_at: timestamptz
   url: String
-  """
-  User input, not validated yet
-  """
+  """User input, not validated yet"""
   urlInput: String
-  """
-  Owner, who create the subtitle
-  """
+  """Owner, who create the subtitle"""
   userId: uuid
   video_id: uuid
 }
@@ -13822,52 +10386,30 @@ input subtitles_stream_cursor_value_input {
 update columns of table "subtitles"
 """
 enum subtitles_update_column {
-  """
-  column name
-  """
+  """column name"""
   created_at
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   isDefault
-  """
-  column name
-  """
+  """column name"""
   lang
-  """
-  column name
-  """
+  """column name"""
   updated_at
-  """
-  column name
-  """
+  """column name"""
   url
-  """
-  column name
-  """
+  """column name"""
   urlInput
-  """
-  column name
-  """
+  """column name"""
   userId
-  """
-  column name
-  """
+  """column name"""
   video_id
 }
 
 input subtitles_updates {
-  """
-  sets the columns of the filtered rows to the given values
-  """
+  """sets the columns of the filtered rows to the given values"""
   _set: subtitles_set_input
-  """
-  filter the rows which have to be updated
-  """
+  """filter the rows which have to be updated"""
   where: subtitles_bool_exp!
 }
 
@@ -13875,54 +10417,30 @@ input subtitles_updates {
 Including all tags for all sites (watch, listen, etc). Tags can have name and slug, slug + site is unique
 """
 type tags {
-  """
-  An array relationship
-  """
+  """An array relationship"""
   audio_tags(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [audio_tags_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [audio_tags_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: audio_tags_bool_exp
   ): [audio_tags!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   audio_tags_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [audio_tags_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [audio_tags_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: audio_tags_bool_exp
   ): audio_tags_aggregate!
   created_at: timestamptz!
@@ -13933,54 +10451,30 @@ type tags {
   site: String!
   slug: String!
   updated_at: timestamptz!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   video_tags(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [video_tags_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [video_tags_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: video_tags_bool_exp
   ): [video_tags!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   video_tags_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [video_tags_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [video_tags_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: video_tags_bool_exp
   ): video_tags_aggregate!
 }
@@ -14010,9 +10504,7 @@ type tags_aggregate_fields {
   variance: tags_variance_fields
 }
 
-"""
-aggregate avg on columns
-"""
+"""aggregate avg on columns"""
 type tags_avg_fields {
   display_order: Float
 }
@@ -14075,9 +10567,7 @@ input tags_insert_input {
   video_tags: video_tags_arr_rel_insert_input
 }
 
-"""
-aggregate max on columns
-"""
+"""aggregate max on columns"""
 type tags_max_fields {
   created_at: timestamptz
   description: String
@@ -14089,9 +10579,7 @@ type tags_max_fields {
   updated_at: timestamptz
 }
 
-"""
-aggregate min on columns
-"""
+"""aggregate min on columns"""
 type tags_min_fields {
   created_at: timestamptz
   description: String
@@ -14107,13 +10595,9 @@ type tags_min_fields {
 response of any mutation on the table "tags"
 """
 type tags_mutation_response {
-  """
-  number of rows affected by the mutation
-  """
+  """number of rows affected by the mutation"""
   affected_rows: Int!
-  """
-  data from the rows affected by the mutation
-  """
+  """data from the rows affected by the mutation"""
   returning: [tags!]!
 }
 
@@ -14122,9 +10606,7 @@ input type for inserting object relation for remote table "tags"
 """
 input tags_obj_rel_insert_input {
   data: tags_insert_input!
-  """
-  upsert condition
-  """
+  """upsert condition"""
   on_conflict: tags_on_conflict
 }
 
@@ -14137,9 +10619,7 @@ input tags_on_conflict {
   where: tags_bool_exp
 }
 
-"""
-Ordering options when selecting data from "tags".
-"""
+"""Ordering options when selecting data from "tags"."""
 input tags_order_by {
   audio_tags_aggregate: audio_tags_aggregate_order_by
   created_at: order_by
@@ -14153,9 +10633,7 @@ input tags_order_by {
   video_tags_aggregate: video_tags_aggregate_order_by
 }
 
-"""
-primary key columns input for table: tags
-"""
+"""primary key columns input for table: tags"""
 input tags_pk_columns_input {
   id: uuid!
 }
@@ -14164,37 +10642,21 @@ input tags_pk_columns_input {
 select columns of table "tags"
 """
 enum tags_select_column {
-  """
-  column name
-  """
+  """column name"""
   created_at
-  """
-  column name
-  """
+  """column name"""
   description
-  """
-  column name
-  """
+  """column name"""
   display_order
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   name
-  """
-  column name
-  """
+  """column name"""
   site
-  """
-  column name
-  """
+  """column name"""
   slug
-  """
-  column name
-  """
+  """column name"""
   updated_at
 }
 
@@ -14212,23 +10674,17 @@ input tags_set_input {
   updated_at: timestamptz
 }
 
-"""
-aggregate stddev on columns
-"""
+"""aggregate stddev on columns"""
 type tags_stddev_fields {
   display_order: Float
 }
 
-"""
-aggregate stddev_pop on columns
-"""
+"""aggregate stddev_pop on columns"""
 type tags_stddev_pop_fields {
   display_order: Float
 }
 
-"""
-aggregate stddev_samp on columns
-"""
+"""aggregate stddev_samp on columns"""
 type tags_stddev_samp_fields {
   display_order: Float
 }
@@ -14237,19 +10693,13 @@ type tags_stddev_samp_fields {
 Streaming cursor of the table "tags"
 """
 input tags_stream_cursor_input {
-  """
-  Stream column input with initial value
-  """
+  """Stream column input with initial value"""
   initial_value: tags_stream_cursor_value_input!
-  """
-  cursor ordering
-  """
+  """cursor ordering"""
   ordering: cursor_ordering
 }
 
-"""
-Initial value of the column from where the streaming should start
-"""
+"""Initial value of the column from where the streaming should start"""
 input tags_stream_cursor_value_input {
   created_at: timestamptz
   description: String
@@ -14261,9 +10711,7 @@ input tags_stream_cursor_value_input {
   updated_at: timestamptz
 }
 
-"""
-aggregate sum on columns
-"""
+"""aggregate sum on columns"""
 type tags_sum_fields {
   display_order: Int
 }
@@ -14272,79 +10720,49 @@ type tags_sum_fields {
 update columns of table "tags"
 """
 enum tags_update_column {
-  """
-  column name
-  """
+  """column name"""
   created_at
-  """
-  column name
-  """
+  """column name"""
   description
-  """
-  column name
-  """
+  """column name"""
   display_order
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   name
-  """
-  column name
-  """
+  """column name"""
   site
-  """
-  column name
-  """
+  """column name"""
   slug
-  """
-  column name
-  """
+  """column name"""
   updated_at
 }
 
 input tags_updates {
-  """
-  increments the numeric columns with given value of the filtered values
-  """
+  """increments the numeric columns with given value of the filtered values"""
   _inc: tags_inc_input
-  """
-  sets the columns of the filtered rows to the given values
-  """
+  """sets the columns of the filtered rows to the given values"""
   _set: tags_set_input
-  """
-  filter the rows which have to be updated
-  """
+  """filter the rows which have to be updated"""
   where: tags_bool_exp!
 }
 
-"""
-aggregate var_pop on columns
-"""
+"""aggregate var_pop on columns"""
 type tags_var_pop_fields {
   display_order: Float
 }
 
-"""
-aggregate var_samp on columns
-"""
+"""aggregate var_samp on columns"""
 type tags_var_samp_fields {
   display_order: Float
 }
 
-"""
-aggregate variance on columns
-"""
+"""aggregate variance on columns"""
 type tags_variance_fields {
   display_order: Float
 }
 
-"""
-Reference for Cloud Tasks, the goal is idempotent for Cloud Tasks
-"""
+"""Reference for Cloud Tasks, the goal is idempotent for Cloud Tasks"""
 type tasks {
   completed: Boolean!
   created_at: timestamptz!
@@ -14352,9 +10770,7 @@ type tasks {
   entity_type: String!
   id: uuid!
   metadata(
-    """
-    JSON select path
-    """
+    """JSON select path"""
     path: String
   ): jsonb!
   status: String!
@@ -14380,9 +10796,7 @@ type tasks_aggregate_fields {
   min: tasks_min_fields
 }
 
-"""
-append existing jsonb value of filtered columns with new jsonb value
-"""
+"""append existing jsonb value of filtered columns with new jsonb value"""
 input tasks_append_input {
   metadata: jsonb
 }
@@ -14461,9 +10875,7 @@ input tasks_insert_input {
   updated_at: timestamptz
 }
 
-"""
-aggregate max on columns
-"""
+"""aggregate max on columns"""
 type tasks_max_fields {
   created_at: timestamptz
   entity_id: uuid
@@ -14475,9 +10887,7 @@ type tasks_max_fields {
   updated_at: timestamptz
 }
 
-"""
-aggregate min on columns
-"""
+"""aggregate min on columns"""
 type tasks_min_fields {
   created_at: timestamptz
   entity_id: uuid
@@ -14493,13 +10903,9 @@ type tasks_min_fields {
 response of any mutation on the table "tasks"
 """
 type tasks_mutation_response {
-  """
-  number of rows affected by the mutation
-  """
+  """number of rows affected by the mutation"""
   affected_rows: Int!
-  """
-  data from the rows affected by the mutation
-  """
+  """data from the rows affected by the mutation"""
   returning: [tasks!]!
 }
 
@@ -14512,9 +10918,7 @@ input tasks_on_conflict {
   where: tasks_bool_exp
 }
 
-"""
-Ordering options when selecting data from "tasks".
-"""
+"""Ordering options when selecting data from "tasks"."""
 input tasks_order_by {
   completed: order_by
   created_at: order_by
@@ -14528,16 +10932,12 @@ input tasks_order_by {
   updated_at: order_by
 }
 
-"""
-primary key columns input for table: tasks
-"""
+"""primary key columns input for table: tasks"""
 input tasks_pk_columns_input {
   id: uuid!
 }
 
-"""
-prepend existing jsonb value of filtered columns with new jsonb value
-"""
+"""prepend existing jsonb value of filtered columns with new jsonb value"""
 input tasks_prepend_input {
   metadata: jsonb
 }
@@ -14546,45 +10946,25 @@ input tasks_prepend_input {
 select columns of table "tasks"
 """
 enum tasks_select_column {
-  """
-  column name
-  """
+  """column name"""
   completed
-  """
-  column name
-  """
+  """column name"""
   created_at
-  """
-  column name
-  """
+  """column name"""
   entity_id
-  """
-  column name
-  """
+  """column name"""
   entity_type
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   metadata
-  """
-  column name
-  """
+  """column name"""
   status
-  """
-  column name
-  """
+  """column name"""
   task_id
-  """
-  column name
-  """
+  """column name"""
   type
-  """
-  column name
-  """
+  """column name"""
   updated_at
 }
 
@@ -14608,19 +10988,13 @@ input tasks_set_input {
 Streaming cursor of the table "tasks"
 """
 input tasks_stream_cursor_input {
-  """
-  Stream column input with initial value
-  """
+  """Stream column input with initial value"""
   initial_value: tasks_stream_cursor_value_input!
-  """
-  cursor ordering
-  """
+  """cursor ordering"""
   ordering: cursor_ordering
 }
 
-"""
-Initial value of the column from where the streaming should start
-"""
+"""Initial value of the column from where the streaming should start"""
 input tasks_stream_cursor_value_input {
   completed: Boolean
   created_at: timestamptz
@@ -14638,52 +11012,30 @@ input tasks_stream_cursor_value_input {
 update columns of table "tasks"
 """
 enum tasks_update_column {
-  """
-  column name
-  """
+  """column name"""
   completed
-  """
-  column name
-  """
+  """column name"""
   created_at
-  """
-  column name
-  """
+  """column name"""
   entity_id
-  """
-  column name
-  """
+  """column name"""
   entity_type
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   metadata
-  """
-  column name
-  """
+  """column name"""
   status
-  """
-  column name
-  """
+  """column name"""
   task_id
-  """
-  column name
-  """
+  """column name"""
   type
-  """
-  column name
-  """
+  """column name"""
   updated_at
 }
 
 input tasks_updates {
-  """
-  append existing jsonb value of filtered columns with new jsonb value
-  """
+  """append existing jsonb value of filtered columns with new jsonb value"""
   _append: tasks_append_input
   """
   delete the field or element with specified path (for JSON arrays, negative integers count from the end)
@@ -14697,17 +11049,11 @@ input tasks_updates {
   delete key/value pair or string element. key/value pairs are matched based on their key value
   """
   _delete_key: tasks_delete_key_input
-  """
-  prepend existing jsonb value of filtered columns with new jsonb value
-  """
+  """prepend existing jsonb value of filtered columns with new jsonb value"""
   _prepend: tasks_prepend_input
-  """
-  sets the columns of the filtered rows to the given values
-  """
+  """sets the columns of the filtered rows to the given values"""
   _set: tasks_set_input
-  """
-  filter the rows which have to be updated
-  """
+  """filter the rows which have to be updated"""
   where: tasks_bool_exp!
 }
 
@@ -14744,9 +11090,7 @@ type test_aggregate_fields {
   variance: test_variance_fields
 }
 
-"""
-aggregate avg on columns
-"""
+"""aggregate avg on columns"""
 type test_avg_fields {
   id: Float
 }
@@ -14787,17 +11131,13 @@ input test_insert_input {
   id: Int
 }
 
-"""
-aggregate max on columns
-"""
+"""aggregate max on columns"""
 type test_max_fields {
   description: String
   id: Int
 }
 
-"""
-aggregate min on columns
-"""
+"""aggregate min on columns"""
 type test_min_fields {
   description: String
   id: Int
@@ -14807,13 +11147,9 @@ type test_min_fields {
 response of any mutation on the table "test"
 """
 type test_mutation_response {
-  """
-  number of rows affected by the mutation
-  """
+  """number of rows affected by the mutation"""
   affected_rows: Int!
-  """
-  data from the rows affected by the mutation
-  """
+  """data from the rows affected by the mutation"""
   returning: [test!]!
 }
 
@@ -14826,17 +11162,13 @@ input test_on_conflict {
   where: test_bool_exp
 }
 
-"""
-Ordering options when selecting data from "test".
-"""
+"""Ordering options when selecting data from "test"."""
 input test_order_by {
   description: order_by
   id: order_by
 }
 
-"""
-primary key columns input for table: test
-"""
+"""primary key columns input for table: test"""
 input test_pk_columns_input {
   id: Int!
 }
@@ -14845,13 +11177,9 @@ input test_pk_columns_input {
 select columns of table "test"
 """
 enum test_select_column {
-  """
-  column name
-  """
+  """column name"""
   description
-  """
-  column name
-  """
+  """column name"""
   id
 }
 
@@ -14863,23 +11191,17 @@ input test_set_input {
   id: Int
 }
 
-"""
-aggregate stddev on columns
-"""
+"""aggregate stddev on columns"""
 type test_stddev_fields {
   id: Float
 }
 
-"""
-aggregate stddev_pop on columns
-"""
+"""aggregate stddev_pop on columns"""
 type test_stddev_pop_fields {
   id: Float
 }
 
-"""
-aggregate stddev_samp on columns
-"""
+"""aggregate stddev_samp on columns"""
 type test_stddev_samp_fields {
   id: Float
 }
@@ -14888,27 +11210,19 @@ type test_stddev_samp_fields {
 Streaming cursor of the table "test"
 """
 input test_stream_cursor_input {
-  """
-  Stream column input with initial value
-  """
+  """Stream column input with initial value"""
   initial_value: test_stream_cursor_value_input!
-  """
-  cursor ordering
-  """
+  """cursor ordering"""
   ordering: cursor_ordering
 }
 
-"""
-Initial value of the column from where the streaming should start
-"""
+"""Initial value of the column from where the streaming should start"""
 input test_stream_cursor_value_input {
   description: String
   id: Int
 }
 
-"""
-aggregate sum on columns
-"""
+"""aggregate sum on columns"""
 type test_sum_fields {
   id: Int
 }
@@ -14917,48 +11231,32 @@ type test_sum_fields {
 update columns of table "test"
 """
 enum test_update_column {
-  """
-  column name
-  """
+  """column name"""
   description
-  """
-  column name
-  """
+  """column name"""
   id
 }
 
 input test_updates {
-  """
-  increments the numeric columns with given value of the filtered values
-  """
+  """increments the numeric columns with given value of the filtered values"""
   _inc: test_inc_input
-  """
-  sets the columns of the filtered rows to the given values
-  """
+  """sets the columns of the filtered rows to the given values"""
   _set: test_set_input
-  """
-  filter the rows which have to be updated
-  """
+  """filter the rows which have to be updated"""
   where: test_bool_exp!
 }
 
-"""
-aggregate var_pop on columns
-"""
+"""aggregate var_pop on columns"""
 type test_var_pop_fields {
   id: Float
 }
 
-"""
-aggregate var_samp on columns
-"""
+"""aggregate var_samp on columns"""
 type test_var_samp_fields {
   id: Float
 }
 
-"""
-aggregate variance on columns
-"""
+"""aggregate variance on columns"""
 type test_variance_fields {
   id: Float
 }
@@ -14981,6 +11279,206 @@ input timestamptz_comparison_exp {
 }
 
 """
+columns and relationships of "user_settings"
+"""
+type user_settings {
+  data(
+    """JSON select path"""
+    path: String
+  ): jsonb!
+  """An object relationship"""
+  user: users!
+  user_id: uuid!
+}
+
+"""
+aggregated selection of "user_settings"
+"""
+type user_settings_aggregate {
+  aggregate: user_settings_aggregate_fields
+  nodes: [user_settings!]!
+}
+
+"""
+aggregate fields of "user_settings"
+"""
+type user_settings_aggregate_fields {
+  count(columns: [user_settings_select_column!], distinct: Boolean): Int!
+  max: user_settings_max_fields
+  min: user_settings_min_fields
+}
+
+"""append existing jsonb value of filtered columns with new jsonb value"""
+input user_settings_append_input {
+  data: jsonb
+}
+
+"""
+Boolean expression to filter rows from the table "user_settings". All fields are combined with a logical 'AND'.
+"""
+input user_settings_bool_exp {
+  _and: [user_settings_bool_exp!]
+  _not: user_settings_bool_exp
+  _or: [user_settings_bool_exp!]
+  data: jsonb_comparison_exp
+  user: users_bool_exp
+  user_id: uuid_comparison_exp
+}
+
+"""
+unique or primary key constraints on table "user_settings"
+"""
+enum user_settings_constraint {
+  """
+  unique or primary key constraint on columns "user_id"
+  """
+  user_settings_pkey
+}
+
+"""
+delete the field or element with specified path (for JSON arrays, negative integers count from the end)
+"""
+input user_settings_delete_at_path_input {
+  data: [String!]
+}
+
+"""
+delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array
+"""
+input user_settings_delete_elem_input {
+  data: Int
+}
+
+"""
+delete key/value pair or string element. key/value pairs are matched based on their key value
+"""
+input user_settings_delete_key_input {
+  data: String
+}
+
+"""
+input type for inserting data into table "user_settings"
+"""
+input user_settings_insert_input {
+  data: jsonb
+  user: users_obj_rel_insert_input
+  user_id: uuid
+}
+
+"""aggregate max on columns"""
+type user_settings_max_fields {
+  user_id: uuid
+}
+
+"""aggregate min on columns"""
+type user_settings_min_fields {
+  user_id: uuid
+}
+
+"""
+response of any mutation on the table "user_settings"
+"""
+type user_settings_mutation_response {
+  """number of rows affected by the mutation"""
+  affected_rows: Int!
+  """data from the rows affected by the mutation"""
+  returning: [user_settings!]!
+}
+
+"""
+on_conflict condition type for table "user_settings"
+"""
+input user_settings_on_conflict {
+  constraint: user_settings_constraint!
+  update_columns: [user_settings_update_column!]! = []
+  where: user_settings_bool_exp
+}
+
+"""Ordering options when selecting data from "user_settings"."""
+input user_settings_order_by {
+  data: order_by
+  user: users_order_by
+  user_id: order_by
+}
+
+"""primary key columns input for table: user_settings"""
+input user_settings_pk_columns_input {
+  user_id: uuid!
+}
+
+"""prepend existing jsonb value of filtered columns with new jsonb value"""
+input user_settings_prepend_input {
+  data: jsonb
+}
+
+"""
+select columns of table "user_settings"
+"""
+enum user_settings_select_column {
+  """column name"""
+  data
+  """column name"""
+  user_id
+}
+
+"""
+input type for updating data in table "user_settings"
+"""
+input user_settings_set_input {
+  data: jsonb
+  user_id: uuid
+}
+
+"""
+Streaming cursor of the table "user_settings"
+"""
+input user_settings_stream_cursor_input {
+  """Stream column input with initial value"""
+  initial_value: user_settings_stream_cursor_value_input!
+  """cursor ordering"""
+  ordering: cursor_ordering
+}
+
+"""Initial value of the column from where the streaming should start"""
+input user_settings_stream_cursor_value_input {
+  data: jsonb
+  user_id: uuid
+}
+
+"""
+update columns of table "user_settings"
+"""
+enum user_settings_update_column {
+  """column name"""
+  data
+  """column name"""
+  user_id
+}
+
+input user_settings_updates {
+  """append existing jsonb value of filtered columns with new jsonb value"""
+  _append: user_settings_append_input
+  """
+  delete the field or element with specified path (for JSON arrays, negative integers count from the end)
+  """
+  _delete_at_path: user_settings_delete_at_path_input
+  """
+  delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array
+  """
+  _delete_elem: user_settings_delete_elem_input
+  """
+  delete key/value pair or string element. key/value pairs are matched based on their key value
+  """
+  _delete_key: user_settings_delete_key_input
+  """prepend existing jsonb value of filtered columns with new jsonb value"""
+  _prepend: user_settings_prepend_input
+  """sets the columns of the filtered rows to the given values"""
+  _set: user_settings_set_input
+  """filter the rows which have to be updated"""
+  where: user_settings_bool_exp!
+}
+
+"""
 Pivot table between user and video, let we know how do end user interact with video
 """
 type user_video_history {
@@ -14989,14 +11487,10 @@ type user_video_history {
   last_watched_at: timestamptz!
   progress_seconds: Int!
   updated_at: timestamptz!
-  """
-  An object relationship
-  """
+  """An object relationship"""
   user: users!
   user_id: uuid!
-  """
-  An object relationship
-  """
+  """An object relationship"""
   video: videos!
   video_id: uuid!
 }
@@ -15059,15 +11553,11 @@ input type for inserting array relation for remote table "user_video_history"
 """
 input user_video_history_arr_rel_insert_input {
   data: [user_video_history_insert_input!]!
-  """
-  upsert condition
-  """
+  """upsert condition"""
   on_conflict: user_video_history_on_conflict
 }
 
-"""
-aggregate avg on columns
-"""
+"""aggregate avg on columns"""
 type user_video_history_avg_fields {
   progress_seconds: Float
 }
@@ -15133,9 +11623,7 @@ input user_video_history_insert_input {
   video_id: uuid
 }
 
-"""
-aggregate max on columns
-"""
+"""aggregate max on columns"""
 type user_video_history_max_fields {
   created_at: timestamptz
   id: uuid
@@ -15159,9 +11647,7 @@ input user_video_history_max_order_by {
   video_id: order_by
 }
 
-"""
-aggregate min on columns
-"""
+"""aggregate min on columns"""
 type user_video_history_min_fields {
   created_at: timestamptz
   id: uuid
@@ -15189,13 +11675,9 @@ input user_video_history_min_order_by {
 response of any mutation on the table "user_video_history"
 """
 type user_video_history_mutation_response {
-  """
-  number of rows affected by the mutation
-  """
+  """number of rows affected by the mutation"""
   affected_rows: Int!
-  """
-  data from the rows affected by the mutation
-  """
+  """data from the rows affected by the mutation"""
   returning: [user_video_history!]!
 }
 
@@ -15208,9 +11690,7 @@ input user_video_history_on_conflict {
   where: user_video_history_bool_exp
 }
 
-"""
-Ordering options when selecting data from "user_video_history".
-"""
+"""Ordering options when selecting data from "user_video_history"."""
 input user_video_history_order_by {
   created_at: order_by
   id: order_by
@@ -15223,9 +11703,7 @@ input user_video_history_order_by {
   video_id: order_by
 }
 
-"""
-primary key columns input for table: user_video_history
-"""
+"""primary key columns input for table: user_video_history"""
 input user_video_history_pk_columns_input {
   id: uuid!
 }
@@ -15234,33 +11712,19 @@ input user_video_history_pk_columns_input {
 select columns of table "user_video_history"
 """
 enum user_video_history_select_column {
-  """
-  column name
-  """
+  """column name"""
   created_at
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   last_watched_at
-  """
-  column name
-  """
+  """column name"""
   progress_seconds
-  """
-  column name
-  """
+  """column name"""
   updated_at
-  """
-  column name
-  """
+  """column name"""
   user_id
-  """
-  column name
-  """
+  """column name"""
   video_id
 }
 
@@ -15277,9 +11741,7 @@ input user_video_history_set_input {
   video_id: uuid
 }
 
-"""
-aggregate stddev on columns
-"""
+"""aggregate stddev on columns"""
 type user_video_history_stddev_fields {
   progress_seconds: Float
 }
@@ -15291,9 +11753,7 @@ input user_video_history_stddev_order_by {
   progress_seconds: order_by
 }
 
-"""
-aggregate stddev_pop on columns
-"""
+"""aggregate stddev_pop on columns"""
 type user_video_history_stddev_pop_fields {
   progress_seconds: Float
 }
@@ -15305,9 +11765,7 @@ input user_video_history_stddev_pop_order_by {
   progress_seconds: order_by
 }
 
-"""
-aggregate stddev_samp on columns
-"""
+"""aggregate stddev_samp on columns"""
 type user_video_history_stddev_samp_fields {
   progress_seconds: Float
 }
@@ -15323,19 +11781,13 @@ input user_video_history_stddev_samp_order_by {
 Streaming cursor of the table "user_video_history"
 """
 input user_video_history_stream_cursor_input {
-  """
-  Stream column input with initial value
-  """
+  """Stream column input with initial value"""
   initial_value: user_video_history_stream_cursor_value_input!
-  """
-  cursor ordering
-  """
+  """cursor ordering"""
   ordering: cursor_ordering
 }
 
-"""
-Initial value of the column from where the streaming should start
-"""
+"""Initial value of the column from where the streaming should start"""
 input user_video_history_stream_cursor_value_input {
   created_at: timestamptz
   id: uuid
@@ -15346,9 +11798,7 @@ input user_video_history_stream_cursor_value_input {
   video_id: uuid
 }
 
-"""
-aggregate sum on columns
-"""
+"""aggregate sum on columns"""
 type user_video_history_sum_fields {
   progress_seconds: Int
 }
@@ -15364,54 +11814,32 @@ input user_video_history_sum_order_by {
 update columns of table "user_video_history"
 """
 enum user_video_history_update_column {
-  """
-  column name
-  """
+  """column name"""
   created_at
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   last_watched_at
-  """
-  column name
-  """
+  """column name"""
   progress_seconds
-  """
-  column name
-  """
+  """column name"""
   updated_at
-  """
-  column name
-  """
+  """column name"""
   user_id
-  """
-  column name
-  """
+  """column name"""
   video_id
 }
 
 input user_video_history_updates {
-  """
-  increments the numeric columns with given value of the filtered values
-  """
+  """increments the numeric columns with given value of the filtered values"""
   _inc: user_video_history_inc_input
-  """
-  sets the columns of the filtered rows to the given values
-  """
+  """sets the columns of the filtered rows to the given values"""
   _set: user_video_history_set_input
-  """
-  filter the rows which have to be updated
-  """
+  """filter the rows which have to be updated"""
   where: user_video_history_bool_exp!
 }
 
-"""
-aggregate var_pop on columns
-"""
+"""aggregate var_pop on columns"""
 type user_video_history_var_pop_fields {
   progress_seconds: Float
 }
@@ -15423,9 +11851,7 @@ input user_video_history_var_pop_order_by {
   progress_seconds: order_by
 }
 
-"""
-aggregate var_samp on columns
-"""
+"""aggregate var_samp on columns"""
 type user_video_history_var_samp_fields {
   progress_seconds: Float
 }
@@ -15437,9 +11863,7 @@ input user_video_history_var_samp_order_by {
   progress_seconds: order_by
 }
 
-"""
-aggregate variance on columns
-"""
+"""aggregate variance on columns"""
 type user_video_history_variance_fields {
   progress_seconds: Float
 }
@@ -15455,810 +11879,426 @@ input user_video_history_variance_order_by {
 columns and relationships of "users"
 """
 type users {
-  """
-  An array relationship
-  """
+  """An array relationship"""
   audios(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [audios_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [audios_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: audios_bool_exp
   ): [audios!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   audios_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [audios_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [audios_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: audios_bool_exp
   ): audios_aggregate!
   auth0_id: String!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   book_comments(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [book_comments_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [book_comments_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: book_comments_bool_exp
   ): [book_comments!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   book_comments_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [book_comments_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [book_comments_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: book_comments_bool_exp
   ): book_comments_aggregate!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   books(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [books_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [books_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: books_bool_exp
   ): [books!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   books_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [books_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [books_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: books_bool_exp
   ): books_aggregate!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   crawl_requests(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [crawl_requests_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [crawl_requests_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: crawl_requests_bool_exp
   ): [crawl_requests!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   crawl_requests_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [crawl_requests_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [crawl_requests_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: crawl_requests_bool_exp
   ): crawl_requests_aggregate!
   created_at: timestamptz
-  """
-  An array relationship
-  """
+  """An array relationship"""
   device_requests(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [device_requests_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [device_requests_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: device_requests_bool_exp
   ): [device_requests!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   device_requests_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [device_requests_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [device_requests_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: device_requests_bool_exp
   ): device_requests_aggregate!
   email: String!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   finance_transactions(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [finance_transactions_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [finance_transactions_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: finance_transactions_bool_exp
   ): [finance_transactions!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   finance_transactions_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [finance_transactions_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [finance_transactions_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: finance_transactions_bool_exp
   ): finance_transactions_aggregate!
   id: uuid!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   journals(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [journals_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [journals_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: journals_bool_exp
   ): [journals!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   journals_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [journals_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [journals_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: journals_bool_exp
   ): journals_aggregate!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   notifications(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [notifications_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [notifications_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: notifications_bool_exp
   ): [notifications!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   notifications_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [notifications_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [notifications_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: notifications_bool_exp
   ): notifications_aggregate!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   playlists(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [playlist_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [playlist_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: playlist_bool_exp
   ): [playlist!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   playlists_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [playlist_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [playlist_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: playlist_bool_exp
   ): playlist_aggregate!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   reading_progresses(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [reading_progresses_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [reading_progresses_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: reading_progresses_bool_exp
   ): [reading_progresses!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   reading_progresses_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [reading_progresses_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [reading_progresses_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: reading_progresses_bool_exp
   ): reading_progresses_aggregate!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   shared_playlist_recipients(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [shared_playlist_recipients_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [shared_playlist_recipients_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: shared_playlist_recipients_bool_exp
   ): [shared_playlist_recipients!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   shared_playlist_recipients_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [shared_playlist_recipients_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [shared_playlist_recipients_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: shared_playlist_recipients_bool_exp
   ): shared_playlist_recipients_aggregate!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   shared_video_recipients(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [shared_video_recipients_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [shared_video_recipients_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: shared_video_recipients_bool_exp
   ): [shared_video_recipients!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   shared_video_recipients_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [shared_video_recipients_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [shared_video_recipients_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: shared_video_recipients_bool_exp
   ): shared_video_recipients_aggregate!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   subtitles(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [subtitles_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [subtitles_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: subtitles_bool_exp
   ): [subtitles!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   subtitles_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [subtitles_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [subtitles_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: subtitles_bool_exp
   ): subtitles_aggregate!
   updated_at: timestamptz
-  """
-  An array relationship
-  """
+  """An array relationship"""
   user_video_histories(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [user_video_history_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [user_video_history_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: user_video_history_bool_exp
   ): [user_video_history!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   user_video_histories_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [user_video_history_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [user_video_history_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: user_video_history_bool_exp
   ): user_video_history_aggregate!
   username: String
-  """
-  An array relationship
-  """
+  """An array relationship"""
   video_views(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [video_views_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [video_views_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: video_views_bool_exp
   ): [video_views!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   video_views_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [video_views_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [video_views_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: video_views_bool_exp
   ): video_views_aggregate!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   videos(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [videos_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [videos_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: videos_bool_exp
   ): [videos!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   videos_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [videos_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [videos_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: videos_bool_exp
   ): videos_aggregate!
 }
@@ -16377,9 +12417,7 @@ input users_insert_input {
   videos: videos_arr_rel_insert_input
 }
 
-"""
-aggregate max on columns
-"""
+"""aggregate max on columns"""
 type users_max_fields {
   auth0_id: String
   created_at: timestamptz
@@ -16389,9 +12427,7 @@ type users_max_fields {
   username: String
 }
 
-"""
-aggregate min on columns
-"""
+"""aggregate min on columns"""
 type users_min_fields {
   auth0_id: String
   created_at: timestamptz
@@ -16405,13 +12441,9 @@ type users_min_fields {
 response of any mutation on the table "users"
 """
 type users_mutation_response {
-  """
-  number of rows affected by the mutation
-  """
+  """number of rows affected by the mutation"""
   affected_rows: Int!
-  """
-  data from the rows affected by the mutation
-  """
+  """data from the rows affected by the mutation"""
   returning: [users!]!
 }
 
@@ -16420,9 +12452,7 @@ input type for inserting object relation for remote table "users"
 """
 input users_obj_rel_insert_input {
   data: users_insert_input!
-  """
-  upsert condition
-  """
+  """upsert condition"""
   on_conflict: users_on_conflict
 }
 
@@ -16435,9 +12465,7 @@ input users_on_conflict {
   where: users_bool_exp
 }
 
-"""
-Ordering options when selecting data from "users".
-"""
+"""Ordering options when selecting data from "users"."""
 input users_order_by {
   audios_aggregate: audios_aggregate_order_by
   auth0_id: order_by
@@ -16463,9 +12491,7 @@ input users_order_by {
   videos_aggregate: videos_aggregate_order_by
 }
 
-"""
-primary key columns input for table: users
-"""
+"""primary key columns input for table: users"""
 input users_pk_columns_input {
   id: uuid!
 }
@@ -16474,29 +12500,17 @@ input users_pk_columns_input {
 select columns of table "users"
 """
 enum users_select_column {
-  """
-  column name
-  """
+  """column name"""
   auth0_id
-  """
-  column name
-  """
+  """column name"""
   created_at
-  """
-  column name
-  """
+  """column name"""
   email
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   updated_at
-  """
-  column name
-  """
+  """column name"""
   username
 }
 
@@ -16516,19 +12530,13 @@ input users_set_input {
 Streaming cursor of the table "users"
 """
 input users_stream_cursor_input {
-  """
-  Stream column input with initial value
-  """
+  """Stream column input with initial value"""
   initial_value: users_stream_cursor_value_input!
-  """
-  cursor ordering
-  """
+  """cursor ordering"""
   ordering: cursor_ordering
 }
 
-"""
-Initial value of the column from where the streaming should start
-"""
+"""Initial value of the column from where the streaming should start"""
 input users_stream_cursor_value_input {
   auth0_id: String
   created_at: timestamptz
@@ -16542,40 +12550,24 @@ input users_stream_cursor_value_input {
 update columns of table "users"
 """
 enum users_update_column {
-  """
-  column name
-  """
+  """column name"""
   auth0_id
-  """
-  column name
-  """
+  """column name"""
   created_at
-  """
-  column name
-  """
+  """column name"""
   email
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   updated_at
-  """
-  column name
-  """
+  """column name"""
   username
 }
 
 input users_updates {
-  """
-  sets the columns of the filtered rows to the given values
-  """
+  """sets the columns of the filtered rows to the given values"""
   _set: users_set_input
-  """
-  filter the rows which have to be updated
-  """
+  """filter the rows which have to be updated"""
   where: users_bool_exp!
 }
 
@@ -16601,15 +12593,11 @@ Junction table between videos and tags which showing many to many relationship b
 """
 type video_tags {
   created_at: timestamptz!
-  """
-  An object relationship
-  """
+  """An object relationship"""
   tag: tags!
   tag_id: uuid!
   updated_at: timestamptz!
-  """
-  An object relationship
-  """
+  """An object relationship"""
   video: videos!
   video_id: uuid!
 }
@@ -16656,9 +12644,7 @@ input type for inserting array relation for remote table "video_tags"
 """
 input video_tags_arr_rel_insert_input {
   data: [video_tags_insert_input!]!
-  """
-  upsert condition
-  """
+  """upsert condition"""
   on_conflict: video_tags_on_conflict
 }
 
@@ -16699,9 +12685,7 @@ input video_tags_insert_input {
   video_id: uuid
 }
 
-"""
-aggregate max on columns
-"""
+"""aggregate max on columns"""
 type video_tags_max_fields {
   created_at: timestamptz
   tag_id: uuid
@@ -16719,9 +12703,7 @@ input video_tags_max_order_by {
   video_id: order_by
 }
 
-"""
-aggregate min on columns
-"""
+"""aggregate min on columns"""
 type video_tags_min_fields {
   created_at: timestamptz
   tag_id: uuid
@@ -16743,13 +12725,9 @@ input video_tags_min_order_by {
 response of any mutation on the table "video_tags"
 """
 type video_tags_mutation_response {
-  """
-  number of rows affected by the mutation
-  """
+  """number of rows affected by the mutation"""
   affected_rows: Int!
-  """
-  data from the rows affected by the mutation
-  """
+  """data from the rows affected by the mutation"""
   returning: [video_tags!]!
 }
 
@@ -16762,9 +12740,7 @@ input video_tags_on_conflict {
   where: video_tags_bool_exp
 }
 
-"""
-Ordering options when selecting data from "video_tags".
-"""
+"""Ordering options when selecting data from "video_tags"."""
 input video_tags_order_by {
   created_at: order_by
   tag: tags_order_by
@@ -16774,9 +12750,7 @@ input video_tags_order_by {
   video_id: order_by
 }
 
-"""
-primary key columns input for table: video_tags
-"""
+"""primary key columns input for table: video_tags"""
 input video_tags_pk_columns_input {
   tag_id: uuid!
   video_id: uuid!
@@ -16786,21 +12760,13 @@ input video_tags_pk_columns_input {
 select columns of table "video_tags"
 """
 enum video_tags_select_column {
-  """
-  column name
-  """
+  """column name"""
   created_at
-  """
-  column name
-  """
+  """column name"""
   tag_id
-  """
-  column name
-  """
+  """column name"""
   updated_at
-  """
-  column name
-  """
+  """column name"""
   video_id
 }
 
@@ -16818,19 +12784,13 @@ input video_tags_set_input {
 Streaming cursor of the table "video_tags"
 """
 input video_tags_stream_cursor_input {
-  """
-  Stream column input with initial value
-  """
+  """Stream column input with initial value"""
   initial_value: video_tags_stream_cursor_value_input!
-  """
-  cursor ordering
-  """
+  """cursor ordering"""
   ordering: cursor_ordering
 }
 
-"""
-Initial value of the column from where the streaming should start
-"""
+"""Initial value of the column from where the streaming should start"""
 input video_tags_stream_cursor_value_input {
   created_at: timestamptz
   tag_id: uuid
@@ -16842,32 +12802,20 @@ input video_tags_stream_cursor_value_input {
 update columns of table "video_tags"
 """
 enum video_tags_update_column {
-  """
-  column name
-  """
+  """column name"""
   created_at
-  """
-  column name
-  """
+  """column name"""
   tag_id
-  """
-  column name
-  """
+  """column name"""
   updated_at
-  """
-  column name
-  """
+  """column name"""
   video_id
 }
 
 input video_tags_updates {
-  """
-  sets the columns of the filtered rows to the given values
-  """
+  """sets the columns of the filtered rows to the given values"""
   _set: video_tags_set_input
-  """
-  filter the rows which have to be updated
-  """
+  """filter the rows which have to be updated"""
   where: video_tags_bool_exp!
 }
 
@@ -16876,14 +12824,10 @@ columns and relationships of "video_views"
 """
 type video_views {
   id: uuid!
-  """
-  An object relationship
-  """
+  """An object relationship"""
   user: users!
   user_id: uuid!
-  """
-  An object relationship
-  """
+  """An object relationship"""
   video: videos!
   video_id: uuid!
   viewed_at: timestamptz
@@ -16931,9 +12875,7 @@ input type for inserting array relation for remote table "video_views"
 """
 input video_views_arr_rel_insert_input {
   data: [video_views_insert_input!]!
-  """
-  upsert condition
-  """
+  """upsert condition"""
   on_conflict: video_views_on_conflict
 }
 
@@ -16974,9 +12916,7 @@ input video_views_insert_input {
   viewed_at: timestamptz
 }
 
-"""
-aggregate max on columns
-"""
+"""aggregate max on columns"""
 type video_views_max_fields {
   id: uuid
   user_id: uuid
@@ -16994,9 +12934,7 @@ input video_views_max_order_by {
   viewed_at: order_by
 }
 
-"""
-aggregate min on columns
-"""
+"""aggregate min on columns"""
 type video_views_min_fields {
   id: uuid
   user_id: uuid
@@ -17018,13 +12956,9 @@ input video_views_min_order_by {
 response of any mutation on the table "video_views"
 """
 type video_views_mutation_response {
-  """
-  number of rows affected by the mutation
-  """
+  """number of rows affected by the mutation"""
   affected_rows: Int!
-  """
-  data from the rows affected by the mutation
-  """
+  """data from the rows affected by the mutation"""
   returning: [video_views!]!
 }
 
@@ -17037,9 +12971,7 @@ input video_views_on_conflict {
   where: video_views_bool_exp
 }
 
-"""
-Ordering options when selecting data from "video_views".
-"""
+"""Ordering options when selecting data from "video_views"."""
 input video_views_order_by {
   id: order_by
   user: users_order_by
@@ -17049,9 +12981,7 @@ input video_views_order_by {
   viewed_at: order_by
 }
 
-"""
-primary key columns input for table: video_views
-"""
+"""primary key columns input for table: video_views"""
 input video_views_pk_columns_input {
   id: uuid!
 }
@@ -17060,21 +12990,13 @@ input video_views_pk_columns_input {
 select columns of table "video_views"
 """
 enum video_views_select_column {
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   user_id
-  """
-  column name
-  """
+  """column name"""
   video_id
-  """
-  column name
-  """
+  """column name"""
   viewed_at
 }
 
@@ -17092,19 +13014,13 @@ input video_views_set_input {
 Streaming cursor of the table "video_views"
 """
 input video_views_stream_cursor_input {
-  """
-  Stream column input with initial value
-  """
+  """Stream column input with initial value"""
   initial_value: video_views_stream_cursor_value_input!
-  """
-  cursor ordering
-  """
+  """cursor ordering"""
   ordering: cursor_ordering
 }
 
-"""
-Initial value of the column from where the streaming should start
-"""
+"""Initial value of the column from where the streaming should start"""
 input video_views_stream_cursor_value_input {
   id: uuid
   user_id: uuid
@@ -17116,32 +13032,20 @@ input video_views_stream_cursor_value_input {
 update columns of table "video_views"
 """
 enum video_views_update_column {
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   user_id
-  """
-  column name
-  """
+  """column name"""
   video_id
-  """
-  column name
-  """
+  """column name"""
   viewed_at
 }
 
 input video_views_updates {
-  """
-  sets the columns of the filtered rows to the given values
-  """
+  """sets the columns of the filtered rows to the given values"""
   _set: video_views_set_input
-  """
-  filter the rows which have to be updated
-  """
+  """filter the rows which have to be updated"""
   where: video_views_bool_exp!
 }
 
@@ -17161,59 +13065,33 @@ type videos {
   Processing hints (input: customRequestHeaders) and failure record (output: lastError) for the reliability flow
   """
   metadata(
-    """
-    JSON select path
-    """
+    """JSON select path"""
     path: String
   ): jsonb
-  """
-  An array relationship
-  """
+  """An array relationship"""
   playlist_videos(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [playlist_videos_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [playlist_videos_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: playlist_videos_bool_exp
   ): [playlist_videos!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   playlist_videos_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [playlist_videos_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [playlist_videos_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: playlist_videos_bool_exp
   ): playlist_videos_aggregate!
   public: Boolean!
@@ -17221,76 +13099,46 @@ type videos {
   Bump to request a reprocess; an update-event on this column re-enqueues processing
   """
   retry_count: Int!
-  """
-  short id like Youtube video id
-  """
+  """short id like Youtube video id"""
   sId: String
   """
   List of shared recipient emails after validated by the system, should use this field to show for end users. Only system can update this field. End user should NOT know the real shared user ids.
   """
   sharedRecipients(
-    """
-    JSON select path
-    """
+    """JSON select path"""
     path: String
   ): jsonb
   """
   List of recipient emails from user input, not validated yet. End user can update this.
   """
   sharedRecipientsInput(
-    """
-    JSON select path
-    """
+    """JSON select path"""
     path: String
   ): jsonb
-  """
-  An array relationship
-  """
+  """An array relationship"""
   shared_video_recipients(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [shared_video_recipients_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [shared_video_recipients_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: shared_video_recipients_bool_exp
   ): [shared_video_recipients!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   shared_video_recipients_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [shared_video_recipients_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [shared_video_recipients_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: shared_video_recipients_bool_exp
   ): shared_video_recipients_aggregate!
   """
@@ -17300,213 +13148,115 @@ type videos {
   slug: String!
   source: String
   status: String
-  """
-  An array relationship
-  """
+  """An array relationship"""
   subtitles(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [subtitles_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [subtitles_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: subtitles_bool_exp
   ): [subtitles!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   subtitles_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [subtitles_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [subtitles_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: subtitles_bool_exp
   ): subtitles_aggregate!
   thumbnailUrl: String
   title: String!
   updatedAt: timestamptz
-  """
-  An object relationship
-  """
+  """An object relationship"""
   user: users!
   user_id: uuid!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   user_video_histories(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [user_video_history_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [user_video_history_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: user_video_history_bool_exp
   ): [user_video_history!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   user_video_histories_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [user_video_history_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [user_video_history_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: user_video_history_bool_exp
   ): user_video_history_aggregate!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   video_tags(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [video_tags_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [video_tags_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: video_tags_bool_exp
   ): [video_tags!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   video_tags_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [video_tags_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [video_tags_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: video_tags_bool_exp
   ): video_tags_aggregate!
   video_url: String!
-  """
-  An array relationship
-  """
+  """An array relationship"""
   video_views(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [video_views_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [video_views_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: video_views_bool_exp
   ): [video_views!]!
-  """
-  An aggregate relationship
-  """
+  """An aggregate relationship"""
   video_views_aggregate(
-    """
-    distinct select on columns
-    """
+    """distinct select on columns"""
     distinct_on: [video_views_select_column!]
-    """
-    limit the number of rows returned
-    """
+    """limit the number of rows returned"""
     limit: Int
-    """
-    skip the first n rows. Use only with order_by
-    """
+    """skip the first n rows. Use only with order_by"""
     offset: Int
-    """
-    sort the rows by one or more columns
-    """
+    """sort the rows by one or more columns"""
     order_by: [video_views_order_by!]
-    """
-    filter the rows returned
-    """
+    """filter the rows returned"""
     where: video_views_bool_exp
   ): video_views_aggregate!
   view_count: Int
@@ -17581,9 +13331,7 @@ input videos_aggregate_order_by {
   variance: videos_variance_order_by
 }
 
-"""
-append existing jsonb value of filtered columns with new jsonb value
-"""
+"""append existing jsonb value of filtered columns with new jsonb value"""
 input videos_append_input {
   """
   Processing hints (input: customRequestHeaders) and failure record (output: lastError) for the reliability flow
@@ -17604,15 +13352,11 @@ input type for inserting array relation for remote table "videos"
 """
 input videos_arr_rel_insert_input {
   data: [videos_insert_input!]!
-  """
-  upsert condition
-  """
+  """upsert condition"""
   on_conflict: videos_on_conflict
 }
 
-"""
-aggregate avg on columns
-"""
+"""aggregate avg on columns"""
 type videos_avg_fields {
   duration: Float
   """
@@ -17783,9 +13527,7 @@ input videos_insert_input {
   Bump to request a reprocess; an update-event on this column re-enqueues processing
   """
   retry_count: Int
-  """
-  short id like Youtube video id
-  """
+  """short id like Youtube video id"""
   sId: String
   """
   List of shared recipient emails after validated by the system, should use this field to show for end users. Only system can update this field. End user should NOT know the real shared user ids.
@@ -17816,9 +13558,7 @@ input videos_insert_input {
   view_count: Int
 }
 
-"""
-aggregate max on columns
-"""
+"""aggregate max on columns"""
 type videos_max_fields {
   createdAt: timestamptz
   description: String
@@ -17828,9 +13568,7 @@ type videos_max_fields {
   Bump to request a reprocess; an update-event on this column re-enqueues processing
   """
   retry_count: Int
-  """
-  short id like Youtube video id
-  """
+  """short id like Youtube video id"""
   sId: String
   slug: String
   source: String
@@ -17855,9 +13593,7 @@ input videos_max_order_by {
   Bump to request a reprocess; an update-event on this column re-enqueues processing
   """
   retry_count: order_by
-  """
-  short id like Youtube video id
-  """
+  """short id like Youtube video id"""
   sId: order_by
   slug: order_by
   source: order_by
@@ -17870,9 +13606,7 @@ input videos_max_order_by {
   view_count: order_by
 }
 
-"""
-aggregate min on columns
-"""
+"""aggregate min on columns"""
 type videos_min_fields {
   createdAt: timestamptz
   description: String
@@ -17882,9 +13616,7 @@ type videos_min_fields {
   Bump to request a reprocess; an update-event on this column re-enqueues processing
   """
   retry_count: Int
-  """
-  short id like Youtube video id
-  """
+  """short id like Youtube video id"""
   sId: String
   slug: String
   source: String
@@ -17909,9 +13641,7 @@ input videos_min_order_by {
   Bump to request a reprocess; an update-event on this column re-enqueues processing
   """
   retry_count: order_by
-  """
-  short id like Youtube video id
-  """
+  """short id like Youtube video id"""
   sId: order_by
   slug: order_by
   source: order_by
@@ -17928,13 +13658,9 @@ input videos_min_order_by {
 response of any mutation on the table "videos"
 """
 type videos_mutation_response {
-  """
-  number of rows affected by the mutation
-  """
+  """number of rows affected by the mutation"""
   affected_rows: Int!
-  """
-  data from the rows affected by the mutation
-  """
+  """data from the rows affected by the mutation"""
   returning: [videos!]!
 }
 
@@ -17943,9 +13669,7 @@ input type for inserting object relation for remote table "videos"
 """
 input videos_obj_rel_insert_input {
   data: videos_insert_input!
-  """
-  upsert condition
-  """
+  """upsert condition"""
   on_conflict: videos_on_conflict
 }
 
@@ -17958,9 +13682,7 @@ input videos_on_conflict {
   where: videos_bool_exp
 }
 
-"""
-Ordering options when selecting data from "videos".
-"""
+"""Ordering options when selecting data from "videos"."""
 input videos_order_by {
   createdAt: order_by
   description: order_by
@@ -17992,16 +13714,12 @@ input videos_order_by {
   view_count: order_by
 }
 
-"""
-primary key columns input for table: videos
-"""
+"""primary key columns input for table: videos"""
 input videos_pk_columns_input {
   id: uuid!
 }
 
-"""
-prepend existing jsonb value of filtered columns with new jsonb value
-"""
+"""prepend existing jsonb value of filtered columns with new jsonb value"""
 input videos_prepend_input {
   """
   Processing hints (input: customRequestHeaders) and failure record (output: lastError) for the reliability flow
@@ -18021,89 +13739,47 @@ input videos_prepend_input {
 select columns of table "videos"
 """
 enum videos_select_column {
-  """
-  column name
-  """
+  """column name"""
   createdAt
-  """
-  column name
-  """
+  """column name"""
   description
-  """
-  column name
-  """
+  """column name"""
   duration
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   keepOriginalSource
-  """
-  column name
-  """
+  """column name"""
   metadata
-  """
-  column name
-  """
+  """column name"""
   public
-  """
-  column name
-  """
+  """column name"""
   retry_count
-  """
-  column name
-  """
+  """column name"""
   sId
-  """
-  column name
-  """
+  """column name"""
   sharedRecipients
-  """
-  column name
-  """
+  """column name"""
   sharedRecipientsInput
-  """
-  column name
-  """
+  """column name"""
   skip_process
-  """
-  column name
-  """
+  """column name"""
   slug
-  """
-  column name
-  """
+  """column name"""
   source
-  """
-  column name
-  """
+  """column name"""
   status
-  """
-  column name
-  """
+  """column name"""
   thumbnailUrl
-  """
-  column name
-  """
+  """column name"""
   title
-  """
-  column name
-  """
+  """column name"""
   updatedAt
-  """
-  column name
-  """
+  """column name"""
   user_id
-  """
-  column name
-  """
+  """column name"""
   video_url
-  """
-  column name
-  """
+  """column name"""
   view_count
 }
 
@@ -18111,17 +13787,11 @@ enum videos_select_column {
 select "videos_aggregate_bool_exp_bool_and_arguments_columns" columns of table "videos"
 """
 enum videos_select_column_videos_aggregate_bool_exp_bool_and_arguments_columns {
-  """
-  column name
-  """
+  """column name"""
   keepOriginalSource
-  """
-  column name
-  """
+  """column name"""
   public
-  """
-  column name
-  """
+  """column name"""
   skip_process
 }
 
@@ -18129,17 +13799,11 @@ enum videos_select_column_videos_aggregate_bool_exp_bool_and_arguments_columns {
 select "videos_aggregate_bool_exp_bool_or_arguments_columns" columns of table "videos"
 """
 enum videos_select_column_videos_aggregate_bool_exp_bool_or_arguments_columns {
-  """
-  column name
-  """
+  """column name"""
   keepOriginalSource
-  """
-  column name
-  """
+  """column name"""
   public
-  """
-  column name
-  """
+  """column name"""
   skip_process
 }
 
@@ -18164,9 +13828,7 @@ input videos_set_input {
   Bump to request a reprocess; an update-event on this column re-enqueues processing
   """
   retry_count: Int
-  """
-  short id like Youtube video id
-  """
+  """short id like Youtube video id"""
   sId: String
   """
   List of shared recipient emails after validated by the system, should use this field to show for end users. Only system can update this field. End user should NOT know the real shared user ids.
@@ -18191,9 +13853,7 @@ input videos_set_input {
   view_count: Int
 }
 
-"""
-aggregate stddev on columns
-"""
+"""aggregate stddev on columns"""
 type videos_stddev_fields {
   duration: Float
   """
@@ -18215,9 +13875,7 @@ input videos_stddev_order_by {
   view_count: order_by
 }
 
-"""
-aggregate stddev_pop on columns
-"""
+"""aggregate stddev_pop on columns"""
 type videos_stddev_pop_fields {
   duration: Float
   """
@@ -18239,9 +13897,7 @@ input videos_stddev_pop_order_by {
   view_count: order_by
 }
 
-"""
-aggregate stddev_samp on columns
-"""
+"""aggregate stddev_samp on columns"""
 type videos_stddev_samp_fields {
   duration: Float
   """
@@ -18267,19 +13923,13 @@ input videos_stddev_samp_order_by {
 Streaming cursor of the table "videos"
 """
 input videos_stream_cursor_input {
-  """
-  Stream column input with initial value
-  """
+  """Stream column input with initial value"""
   initial_value: videos_stream_cursor_value_input!
-  """
-  cursor ordering
-  """
+  """cursor ordering"""
   ordering: cursor_ordering
 }
 
-"""
-Initial value of the column from where the streaming should start
-"""
+"""Initial value of the column from where the streaming should start"""
 input videos_stream_cursor_value_input {
   createdAt: timestamptz
   description: String
@@ -18298,9 +13948,7 @@ input videos_stream_cursor_value_input {
   Bump to request a reprocess; an update-event on this column re-enqueues processing
   """
   retry_count: Int
-  """
-  short id like Youtube video id
-  """
+  """short id like Youtube video id"""
   sId: String
   """
   List of shared recipient emails after validated by the system, should use this field to show for end users. Only system can update this field. End user should NOT know the real shared user ids.
@@ -18325,9 +13973,7 @@ input videos_stream_cursor_value_input {
   view_count: Int
 }
 
-"""
-aggregate sum on columns
-"""
+"""aggregate sum on columns"""
 type videos_sum_fields {
   duration: Int
   """
@@ -18353,96 +13999,52 @@ input videos_sum_order_by {
 update columns of table "videos"
 """
 enum videos_update_column {
-  """
-  column name
-  """
+  """column name"""
   createdAt
-  """
-  column name
-  """
+  """column name"""
   description
-  """
-  column name
-  """
+  """column name"""
   duration
-  """
-  column name
-  """
+  """column name"""
   id
-  """
-  column name
-  """
+  """column name"""
   keepOriginalSource
-  """
-  column name
-  """
+  """column name"""
   metadata
-  """
-  column name
-  """
+  """column name"""
   public
-  """
-  column name
-  """
+  """column name"""
   retry_count
-  """
-  column name
-  """
+  """column name"""
   sId
-  """
-  column name
-  """
+  """column name"""
   sharedRecipients
-  """
-  column name
-  """
+  """column name"""
   sharedRecipientsInput
-  """
-  column name
-  """
+  """column name"""
   skip_process
-  """
-  column name
-  """
+  """column name"""
   slug
-  """
-  column name
-  """
+  """column name"""
   source
-  """
-  column name
-  """
+  """column name"""
   status
-  """
-  column name
-  """
+  """column name"""
   thumbnailUrl
-  """
-  column name
-  """
+  """column name"""
   title
-  """
-  column name
-  """
+  """column name"""
   updatedAt
-  """
-  column name
-  """
+  """column name"""
   user_id
-  """
-  column name
-  """
+  """column name"""
   video_url
-  """
-  column name
-  """
+  """column name"""
   view_count
 }
 
 input videos_updates {
-  """
-  append existing jsonb value of filtered columns with new jsonb value
-  """
+  """append existing jsonb value of filtered columns with new jsonb value"""
   _append: videos_append_input
   """
   delete the field or element with specified path (for JSON arrays, negative integers count from the end)
@@ -18456,27 +14058,17 @@ input videos_updates {
   delete key/value pair or string element. key/value pairs are matched based on their key value
   """
   _delete_key: videos_delete_key_input
-  """
-  increments the numeric columns with given value of the filtered values
-  """
+  """increments the numeric columns with given value of the filtered values"""
   _inc: videos_inc_input
-  """
-  prepend existing jsonb value of filtered columns with new jsonb value
-  """
+  """prepend existing jsonb value of filtered columns with new jsonb value"""
   _prepend: videos_prepend_input
-  """
-  sets the columns of the filtered rows to the given values
-  """
+  """sets the columns of the filtered rows to the given values"""
   _set: videos_set_input
-  """
-  filter the rows which have to be updated
-  """
+  """filter the rows which have to be updated"""
   where: videos_bool_exp!
 }
 
-"""
-aggregate var_pop on columns
-"""
+"""aggregate var_pop on columns"""
 type videos_var_pop_fields {
   duration: Float
   """
@@ -18498,9 +14090,7 @@ input videos_var_pop_order_by {
   view_count: order_by
 }
 
-"""
-aggregate var_samp on columns
-"""
+"""aggregate var_samp on columns"""
 type videos_var_samp_fields {
   duration: Float
   """
@@ -18522,9 +14112,7 @@ input videos_var_samp_order_by {
   view_count: order_by
 }
 
-"""
-aggregate variance on columns
-"""
+"""aggregate variance on columns"""
 type videos_variance_fields {
   duration: Float
   """


### PR DESCRIPTION
## Summary
Follow-up from SWO-326. The committed `schema.graphql` had multi-line docstrings from an older Hasura/codegen; current local Hasura (v2.48.0) emits single-line, so **every** `pnpm codegen` reformatted ~9.7k lines (SWO-328/329 had to skip committing it). Regenerated once against **local** Hasura.

**The diff is large but purely mechanical** — multi-line → single-line docstrings, plus the `user_settings` SDL that was deferred. **No semantic/API change**: `graphql.ts` and `gql.ts` are unchanged, only `schema.graphql`.

## Test plan
- [x] Only `schema.graphql` changed (2744 ins / 7156 del); `user_settings` types present.
- [x] A subsequent `pnpm codegen` against local Hasura produces no further `schema.graphql` diff.

Review = confirm it's just the reformat + `user_settings`.

SWO-339