### PR TITLE
[WIP] feat(main): per-day journal route /journal/$date (fix back button) (SWO-344)

### DIFF
--- a/apps/main/src/routeTree.gen.ts
+++ b/apps/main/src/routeTree.gen.ts
@@ -20,6 +20,7 @@ const JournalLazyImport = createFileRoute('/journal')();
 const FinanceLazyImport = createFileRoute('/finance')();
 const IndexLazyImport = createFileRoute('/')();
 const LibraryIndexLazyImport = createFileRoute('/library/')();
+const JournalDateLazyImport = createFileRoute('/journal/$date')();
 const LibraryBooksBookIdLazyImport = createFileRoute(
   '/library/books/$bookId',
 )();
@@ -50,6 +51,14 @@ const LibraryIndexLazyRoute = LibraryIndexLazyImport.update({
   getParentRoute: () => rootRoute,
 } as any).lazy(() =>
   import('./routes/library.index.lazy').then((d) => d.Route),
+);
+
+const JournalDateLazyRoute = JournalDateLazyImport.update({
+  id: '/$date',
+  path: '/$date',
+  getParentRoute: () => JournalLazyRoute,
+} as any).lazy(() =>
+  import('./routes/journal.$date.lazy').then((d) => d.Route),
 );
 
 const LibraryBooksBookIdLazyRoute = LibraryBooksBookIdLazyImport.update({
@@ -85,6 +94,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof JournalLazyImport;
       parentRoute: typeof rootRoute;
     };
+    '/journal/$date': {
+      id: '/journal/$date';
+      path: '/$date';
+      fullPath: '/journal/$date';
+      preLoaderRoute: typeof JournalDateLazyImport;
+      parentRoute: typeof JournalLazyImport;
+    };
     '/library/': {
       id: '/library/';
       path: '/library';
@@ -104,10 +120,23 @@ declare module '@tanstack/react-router' {
 
 // Create and export the route tree
 
+interface JournalLazyRouteChildren {
+  JournalDateLazyRoute: typeof JournalDateLazyRoute;
+}
+
+const JournalLazyRouteChildren: JournalLazyRouteChildren = {
+  JournalDateLazyRoute: JournalDateLazyRoute,
+};
+
+const JournalLazyRouteWithChildren = JournalLazyRoute._addFileChildren(
+  JournalLazyRouteChildren,
+);
+
 export interface FileRoutesByFullPath {
   '/': typeof IndexLazyRoute;
   '/finance': typeof FinanceLazyRoute;
-  '/journal': typeof JournalLazyRoute;
+  '/journal': typeof JournalLazyRouteWithChildren;
+  '/journal/$date': typeof JournalDateLazyRoute;
   '/library': typeof LibraryIndexLazyRoute;
   '/library/books/$bookId': typeof LibraryBooksBookIdLazyRoute;
 }
@@ -115,7 +144,8 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexLazyRoute;
   '/finance': typeof FinanceLazyRoute;
-  '/journal': typeof JournalLazyRoute;
+  '/journal': typeof JournalLazyRouteWithChildren;
+  '/journal/$date': typeof JournalDateLazyRoute;
   '/library': typeof LibraryIndexLazyRoute;
   '/library/books/$bookId': typeof LibraryBooksBookIdLazyRoute;
 }
@@ -124,7 +154,8 @@ export interface FileRoutesById {
   __root__: typeof rootRoute;
   '/': typeof IndexLazyRoute;
   '/finance': typeof FinanceLazyRoute;
-  '/journal': typeof JournalLazyRoute;
+  '/journal': typeof JournalLazyRouteWithChildren;
+  '/journal/$date': typeof JournalDateLazyRoute;
   '/library/': typeof LibraryIndexLazyRoute;
   '/library/books/$bookId': typeof LibraryBooksBookIdLazyRoute;
 }
@@ -135,15 +166,23 @@ export interface FileRouteTypes {
     | '/'
     | '/finance'
     | '/journal'
+    | '/journal/$date'
     | '/library'
     | '/library/books/$bookId';
   fileRoutesByTo: FileRoutesByTo;
-  to: '/' | '/finance' | '/journal' | '/library' | '/library/books/$bookId';
+  to:
+    | '/'
+    | '/finance'
+    | '/journal'
+    | '/journal/$date'
+    | '/library'
+    | '/library/books/$bookId';
   id:
     | '__root__'
     | '/'
     | '/finance'
     | '/journal'
+    | '/journal/$date'
     | '/library/'
     | '/library/books/$bookId';
   fileRoutesById: FileRoutesById;
@@ -152,7 +191,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexLazyRoute: typeof IndexLazyRoute;
   FinanceLazyRoute: typeof FinanceLazyRoute;
-  JournalLazyRoute: typeof JournalLazyRoute;
+  JournalLazyRoute: typeof JournalLazyRouteWithChildren;
   LibraryIndexLazyRoute: typeof LibraryIndexLazyRoute;
   LibraryBooksBookIdLazyRoute: typeof LibraryBooksBookIdLazyRoute;
 }
@@ -160,7 +199,7 @@ export interface RootRouteChildren {
 const rootRouteChildren: RootRouteChildren = {
   IndexLazyRoute: IndexLazyRoute,
   FinanceLazyRoute: FinanceLazyRoute,
-  JournalLazyRoute: JournalLazyRoute,
+  JournalLazyRoute: JournalLazyRouteWithChildren,
   LibraryIndexLazyRoute: LibraryIndexLazyRoute,
   LibraryBooksBookIdLazyRoute: LibraryBooksBookIdLazyRoute,
 };
@@ -189,7 +228,14 @@ export const routeTree = rootRoute
       "filePath": "finance.lazy.tsx"
     },
     "/journal": {
-      "filePath": "journal.lazy.tsx"
+      "filePath": "journal.lazy.tsx",
+      "children": [
+        "/journal/$date"
+      ]
+    },
+    "/journal/$date": {
+      "filePath": "journal.$date.lazy.tsx",
+      "parent": "/journal"
     },
     "/library/": {
       "filePath": "library.index.lazy.tsx"

--- a/apps/main/src/routes/journal.$date.lazy.tsx
+++ b/apps/main/src/routes/journal.$date.lazy.tsx
@@ -1,0 +1,125 @@
+import { createLazyFileRoute } from '@tanstack/react-router';
+import {
+  useCreateJournal,
+  useDeleteJournal,
+  useUpdateJournal,
+} from 'core/journal/mutation-hooks';
+import { useLoadJournalByDate } from 'core/journal/query-hooks';
+import { useAuthContext } from 'core/providers/auth';
+import { useQueryContext } from 'core/providers/query';
+import { lazy, Suspense, useState } from 'react';
+import { JournalDetail } from 'ui/journal/journal-detail';
+import { AuthRoute } from 'ui/universal/authRoute';
+import { Container } from 'ui/universal/containers/generic';
+import { Layout } from '../components/layout';
+
+const EditDialog = lazy(() =>
+  import('ui/journal/edit-dialog').then((m) => ({ default: m.EditDialog })),
+);
+const Notification = lazy(() =>
+  import('ui/universal/notification').then((m) => ({
+    default: m.Notification,
+  })),
+);
+
+// One day's journal entry, as its own route (`/journal/2026-03-18`). Because
+// this is a real route rather than an in-page state switch, the browser back
+// button returns to the month list and the day is bookmarkable / refresh-safe
+// (SWO-341).
+const JournalDayPage = () => {
+  const { date } = Route.useParams();
+  const navigate = Route.useNavigate();
+  const { getAccessToken } = useAuthContext();
+  const { invalidateQuery } = useQueryContext();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [notification, setNotification] = useState<{
+    message: string;
+    severity: 'success' | 'error';
+  } | null>(null);
+
+  const { data: journal, isLoading } = useLoadJournalByDate({
+    getAccessToken,
+    date,
+  });
+
+  // EditDialog requires both mutations; only update is used here (editing an
+  // existing day), but the prop is required so we pass both.
+  const createJournal = useCreateJournal({ onSuccess: () => {} });
+  const updateJournal = useUpdateJournal({
+    onSuccess: () => {
+      setDialogOpen(false);
+      invalidateQuery(['journal-by-date', date]);
+      setNotification({
+        message: 'Journal entry updated successfully',
+        severity: 'success',
+      });
+    },
+  });
+  const deleteJournal = useDeleteJournal({
+    onSuccess: () => {
+      navigate({ to: '/journal' });
+    },
+  });
+
+  const goBack = () => navigate({ to: '/journal' });
+
+  const handleDelete = async () => {
+    if (
+      journal?.id &&
+      window.confirm('Are you sure you want to delete this journal entry?')
+    ) {
+      await deleteJournal({ id: journal.id });
+    }
+  };
+
+  const handleSave = async (input: any) => {
+    if (journal?.id) {
+      await updateJournal({ id: journal.id, set: input });
+    }
+  };
+
+  return (
+    <Layout>
+      <Container maxWidth="sm" sx={{ pb: 8, position: 'relative' }}>
+        <JournalDetail
+          journal={journal}
+          isLoading={isLoading}
+          onBackClick={goBack}
+          onEditClick={() => setDialogOpen(true)}
+          onDeleteClick={handleDelete}
+        />
+
+        <Suspense fallback={null}>
+          <EditDialog
+            journalDetail={journal}
+            isLoadingDetail={isLoading}
+            open={dialogOpen}
+            onClose={() => setDialogOpen(false)}
+            createJournal={createJournal}
+            updateJournal={updateJournal}
+            onSave={handleSave}
+          />
+        </Suspense>
+
+        <Suspense fallback={null}>
+          {notification && (
+            <Notification
+              notification={notification}
+              onClose={() => setNotification(null)}
+            />
+          )}
+        </Suspense>
+      </Container>
+    </Layout>
+  );
+};
+
+export const Route = createLazyFileRoute('/journal/$date')({
+  component: () => {
+    return (
+      <AuthRoute>
+        <JournalDayPage />
+      </AuthRoute>
+    );
+  },
+});

--- a/apps/main/src/routes/journal.lazy.tsx
+++ b/apps/main/src/routes/journal.lazy.tsx
@@ -1,14 +1,7 @@
 import { createLazyFileRoute } from '@tanstack/react-router';
 import type { Journal } from 'core/journal';
-import {
-  useCreateJournal,
-  useDeleteJournal,
-  useUpdateJournal,
-} from 'core/journal/mutation-hooks';
-import {
-  useLoadJournalById,
-  useLoadJournalsByMonth,
-} from 'core/journal/query-hooks';
+import { useCreateJournal } from 'core/journal/mutation-hooks';
+import { useLoadJournalsByMonth } from 'core/journal/query-hooks';
 import { useAuthContext } from 'core/providers/auth';
 import { getCurrentMonthYear } from 'core/universal/common';
 import { lazy, Suspense, useState } from 'react';
@@ -18,11 +11,6 @@ import { AuthRoute } from 'ui/universal/authRoute';
 import { Container } from 'ui/universal/containers/generic';
 import { Layout } from '../components/layout';
 
-const JournalDetail = lazy(() =>
-  import('ui/journal/journal-detail').then((m) => ({
-    default: m.JournalDetail,
-  })),
-);
 const EditDialog = lazy(() =>
   import('ui/journal/edit-dialog').then((m) => ({ default: m.EditDialog })),
 );
@@ -32,22 +20,23 @@ const Notification = lazy(() =>
   })),
 );
 
+// The month list. Clicking a day navigates to its own route (`/journal/$date`)
+// instead of switching an in-page `view` — that's what makes the browser back
+// button work (SWO-341). This route only lists + creates; viewing/editing a day
+// lives on the day route.
 const JournalPage = () => {
   const { getAccessToken } = useAuthContext();
-  const [view, setView] = useState<'list' | 'detail' | 'edit'>('list');
-  const [selectedJournal, setSelectedJournal] = useState<Journal | null>(null);
+  const navigate = Route.useNavigate();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [notification, setNotification] = useState<{
     message: string;
     severity: 'success' | 'error';
   } | null>(null);
 
-  // Date navigation state
   const defaultDate = getCurrentMonthYear();
   const [month, setMonth] = useState(defaultDate.month);
   const [year, setYear] = useState(defaultDate.year);
 
-  // Data loading hooks
   const { data: journalData, isLoading: isLoadingJournals } =
     useLoadJournalsByMonth({
       getAccessToken,
@@ -55,51 +44,26 @@ const JournalPage = () => {
       year,
     });
 
-  const { data: journalDetail, isLoading: isLoadingDetail } =
-    useLoadJournalById({
-      getAccessToken,
-      id: selectedJournal?.id,
-    });
-
-  // Mutation hooks
   const createJournal = useCreateJournal({
     onSuccess: () => {
       setDialogOpen(false);
-      setView('list');
       setNotification({
         message: 'Journal entry created successfully',
         severity: 'success',
       });
     },
-  });
-
-  const updateJournal = useUpdateJournal({
-    onSuccess: () => {
-      setDialogOpen(false);
-      setView('detail');
+    onError: () => {
+      // One entry per day is DB-enforced — a same-day create is rejected.
       setNotification({
-        message: 'Journal entry updated successfully',
-        severity: 'success',
+        message:
+          'Could not create the entry — there may already be one for that day.',
+        severity: 'error',
       });
     },
   });
 
-  const deleteJournal = useDeleteJournal({
-    onSuccess: () => {
-      setDialogOpen(false);
-      setView('list');
-      setSelectedJournal(null);
-      setNotification({
-        message: 'Journal entry deleted successfully',
-        severity: 'success',
-      });
-    },
-  });
-
-  // Handler functions
   const handleJournalClick = (journal: Journal) => {
-    setSelectedJournal(journal);
-    setView('detail');
+    navigate({ to: '/journal/$date', params: { date: journal.date } });
   };
 
   const handleMonthChange = (newMonth: number, newYear: number) => {
@@ -107,112 +71,47 @@ const JournalPage = () => {
     setYear(newYear);
   };
 
-  const handleCreateNew = () => {
-    setSelectedJournal(null);
-    setDialogOpen(true);
-  };
-
-  const handleEdit = () => {
-    setDialogOpen(true);
-  };
-
-  const handleDelete = async () => {
-    if (selectedJournal?.id) {
-      if (
-        window.confirm('Are you sure you want to delete this journal entry?')
-      ) {
-        await deleteJournal({ id: selectedJournal.id });
-      }
-    }
-  };
-
   const handleSave = async (input: any) => {
-    if (selectedJournal?.id) {
-      await updateJournal({ id: selectedJournal.id, set: input });
-    } else {
-      await createJournal({
-        object: input,
-      });
-    }
-  };
-
-  const handleCloseDialog = () => {
-    setDialogOpen(false);
-  };
-
-  const handleBackToList = () => {
-    setView('list');
-    setSelectedJournal(null);
-  };
-
-  const handleCloseNotification = () => {
-    setNotification(null);
-  };
-
-  // Render functions
-  const renderContent = () => {
-    switch (view) {
-      case 'detail':
-        return (
-          <Suspense fallback={null}>
-            <JournalDetail
-              journal={journalDetail}
-              isLoading={isLoadingDetail}
-              onBackClick={handleBackToList}
-              onEditClick={handleEdit}
-              onDeleteClick={handleDelete}
-            />
-          </Suspense>
-        );
-      default:
-        return (
-          <JournalList
-            journals={journalData?.journals || []}
-            stats={
-              journalData?.stats || {
-                categories: [],
-                oldest: { month: 0, year: 0 },
-              }
-            }
-            isLoading={isLoadingJournals}
-            month={month}
-            year={year}
-            onJournalClick={handleJournalClick}
-            onMonthChange={handleMonthChange}
-          />
-        );
-    }
+    await createJournal({ object: input });
   };
 
   return (
     <Layout>
       <Container maxWidth="sm" sx={{ pb: 8, position: 'relative' }}>
-        {renderContent()}
-
-        {/* FAB for creating new journal entry */}
-        {view === 'list' && <FabButton onClick={handleCreateNew} />}
-
-        {/* Edit Dialog */}
-        <Suspense fallback={null}>
-          {
-            <EditDialog
-              journalDetail={journalDetail!}
-              isLoadingDetail={isLoadingDetail}
-              open={dialogOpen}
-              onClose={handleCloseDialog}
-              createJournal={createJournal}
-              updateJournal={updateJournal}
-              onSave={handleSave}
-            />
+        <JournalList
+          journals={journalData?.journals || []}
+          stats={
+            journalData?.stats || {
+              categories: [],
+              oldest: { month: 0, year: 0 },
+            }
           }
+          isLoading={isLoadingJournals}
+          month={month}
+          year={year}
+          onJournalClick={handleJournalClick}
+          onMonthChange={handleMonthChange}
+        />
+
+        <FabButton onClick={() => setDialogOpen(true)} />
+
+        <Suspense fallback={null}>
+          <EditDialog
+            journalDetail={null}
+            isLoadingDetail={false}
+            open={dialogOpen}
+            onClose={() => setDialogOpen(false)}
+            createJournal={createJournal}
+            updateJournal={undefined}
+            onSave={handleSave}
+          />
         </Suspense>
 
-        {/* Notifications */}
         <Suspense fallback={null}>
           {notification && (
             <Notification
               notification={notification}
-              onClose={handleCloseNotification}
+              onClose={() => setNotification(null)}
             />
           )}
         </Suspense>


### PR DESCRIPTION
## Summary

The back-button fix (parent SWO-341). The journal was a single `/journal` route where list→detail was a React `view` state, so the URL never changed and browser-back exited the journal. Now each day is a **real route**:

- **New `journal.$date.lazy.tsx`** (`/journal/$date`) — loads the day via `useLoadJournalByDate` (SWO-343), renders `JournalDetail`, owns edit-dialog + delete for that day; back navigates to `/journal`.
- **`journal.lazy.tsx`** — drops the in-page `view`/`selectedJournal` state and the detail branch; clicking a day **navigates** to `/journal/$date`. List-only now (month nav + stats + FAB + create dialog). Surfaces the one-per-day create collision (DB constraint from SWO-342) via a notification.

Because list→detail is a route push, **browser back returns to the list**, and each day is **bookmarkable + refresh-safe**.

## Test plan
- [x] `turbo build --filter=main` passes; `routeTree.gen.ts` regenerated with `/journal/$date`; routes typecheck clean.
- [ ] **Manual (recommended):** open a day from the list → URL becomes `/journal/<date>` → browser back returns to the list; refresh on a day loads that day; edit/delete work from the day page.

Depends on SWO-343 (merged). Constraint SWO-342 merged + prod deduped, so one-per-day holds.

SWO-344