### PR TITLE
[WIP] fix(journal): index route so /journal/$date renders (prod) (SWO-346)

### DIFF
--- a/apps/main/src/routeTree.gen.ts
+++ b/apps/main/src/routeTree.gen.ts
@@ -16,22 +16,16 @@ import { Route as rootRoute } from './routes/__root';
 
 // Create Virtual Routes
 
-const JournalLazyImport = createFileRoute('/journal')();
 const FinanceLazyImport = createFileRoute('/finance')();
 const IndexLazyImport = createFileRoute('/')();
 const LibraryIndexLazyImport = createFileRoute('/library/')();
+const JournalIndexLazyImport = createFileRoute('/journal/')();
 const JournalDateLazyImport = createFileRoute('/journal/$date')();
 const LibraryBooksBookIdLazyImport = createFileRoute(
   '/library/books/$bookId',
 )();
 
 // Create/Update Routes
-
-const JournalLazyRoute = JournalLazyImport.update({
-  id: '/journal',
-  path: '/journal',
-  getParentRoute: () => rootRoute,
-} as any).lazy(() => import('./routes/journal.lazy').then((d) => d.Route));
 
 const FinanceLazyRoute = FinanceLazyImport.update({
   id: '/finance',
@@ -53,10 +47,18 @@ const LibraryIndexLazyRoute = LibraryIndexLazyImport.update({
   import('./routes/library.index.lazy').then((d) => d.Route),
 );
 
+const JournalIndexLazyRoute = JournalIndexLazyImport.update({
+  id: '/journal/',
+  path: '/journal/',
+  getParentRoute: () => rootRoute,
+} as any).lazy(() =>
+  import('./routes/journal.index.lazy').then((d) => d.Route),
+);
+
 const JournalDateLazyRoute = JournalDateLazyImport.update({
-  id: '/$date',
-  path: '/$date',
-  getParentRoute: () => JournalLazyRoute,
+  id: '/journal/$date',
+  path: '/journal/$date',
+  getParentRoute: () => rootRoute,
 } as any).lazy(() =>
   import('./routes/journal.$date.lazy').then((d) => d.Route),
 );
@@ -87,19 +89,19 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof FinanceLazyImport;
       parentRoute: typeof rootRoute;
     };
-    '/journal': {
-      id: '/journal';
-      path: '/journal';
-      fullPath: '/journal';
-      preLoaderRoute: typeof JournalLazyImport;
-      parentRoute: typeof rootRoute;
-    };
     '/journal/$date': {
       id: '/journal/$date';
-      path: '/$date';
+      path: '/journal/$date';
       fullPath: '/journal/$date';
       preLoaderRoute: typeof JournalDateLazyImport;
-      parentRoute: typeof JournalLazyImport;
+      parentRoute: typeof rootRoute;
+    };
+    '/journal/': {
+      id: '/journal/';
+      path: '/journal';
+      fullPath: '/journal';
+      preLoaderRoute: typeof JournalIndexLazyImport;
+      parentRoute: typeof rootRoute;
     };
     '/library/': {
       id: '/library/';
@@ -120,23 +122,11 @@ declare module '@tanstack/react-router' {
 
 // Create and export the route tree
 
-interface JournalLazyRouteChildren {
-  JournalDateLazyRoute: typeof JournalDateLazyRoute;
-}
-
-const JournalLazyRouteChildren: JournalLazyRouteChildren = {
-  JournalDateLazyRoute: JournalDateLazyRoute,
-};
-
-const JournalLazyRouteWithChildren = JournalLazyRoute._addFileChildren(
-  JournalLazyRouteChildren,
-);
-
 export interface FileRoutesByFullPath {
   '/': typeof IndexLazyRoute;
   '/finance': typeof FinanceLazyRoute;
-  '/journal': typeof JournalLazyRouteWithChildren;
   '/journal/$date': typeof JournalDateLazyRoute;
+  '/journal': typeof JournalIndexLazyRoute;
   '/library': typeof LibraryIndexLazyRoute;
   '/library/books/$bookId': typeof LibraryBooksBookIdLazyRoute;
 }
@@ -144,8 +134,8 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexLazyRoute;
   '/finance': typeof FinanceLazyRoute;
-  '/journal': typeof JournalLazyRouteWithChildren;
   '/journal/$date': typeof JournalDateLazyRoute;
+  '/journal': typeof JournalIndexLazyRoute;
   '/library': typeof LibraryIndexLazyRoute;
   '/library/books/$bookId': typeof LibraryBooksBookIdLazyRoute;
 }
@@ -154,8 +144,8 @@ export interface FileRoutesById {
   __root__: typeof rootRoute;
   '/': typeof IndexLazyRoute;
   '/finance': typeof FinanceLazyRoute;
-  '/journal': typeof JournalLazyRouteWithChildren;
   '/journal/$date': typeof JournalDateLazyRoute;
+  '/journal/': typeof JournalIndexLazyRoute;
   '/library/': typeof LibraryIndexLazyRoute;
   '/library/books/$bookId': typeof LibraryBooksBookIdLazyRoute;
 }
@@ -165,24 +155,24 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/finance'
-    | '/journal'
     | '/journal/$date'
+    | '/journal'
     | '/library'
     | '/library/books/$bookId';
   fileRoutesByTo: FileRoutesByTo;
   to:
     | '/'
     | '/finance'
-    | '/journal'
     | '/journal/$date'
+    | '/journal'
     | '/library'
     | '/library/books/$bookId';
   id:
     | '__root__'
     | '/'
     | '/finance'
-    | '/journal'
     | '/journal/$date'
+    | '/journal/'
     | '/library/'
     | '/library/books/$bookId';
   fileRoutesById: FileRoutesById;
@@ -191,7 +181,8 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexLazyRoute: typeof IndexLazyRoute;
   FinanceLazyRoute: typeof FinanceLazyRoute;
-  JournalLazyRoute: typeof JournalLazyRouteWithChildren;
+  JournalDateLazyRoute: typeof JournalDateLazyRoute;
+  JournalIndexLazyRoute: typeof JournalIndexLazyRoute;
   LibraryIndexLazyRoute: typeof LibraryIndexLazyRoute;
   LibraryBooksBookIdLazyRoute: typeof LibraryBooksBookIdLazyRoute;
 }
@@ -199,7 +190,8 @@ export interface RootRouteChildren {
 const rootRouteChildren: RootRouteChildren = {
   IndexLazyRoute: IndexLazyRoute,
   FinanceLazyRoute: FinanceLazyRoute,
-  JournalLazyRoute: JournalLazyRouteWithChildren,
+  JournalDateLazyRoute: JournalDateLazyRoute,
+  JournalIndexLazyRoute: JournalIndexLazyRoute,
   LibraryIndexLazyRoute: LibraryIndexLazyRoute,
   LibraryBooksBookIdLazyRoute: LibraryBooksBookIdLazyRoute,
 };
@@ -216,7 +208,8 @@ export const routeTree = rootRoute
       "children": [
         "/",
         "/finance",
-        "/journal",
+        "/journal/$date",
+        "/journal/",
         "/library/",
         "/library/books/$bookId"
       ]
@@ -227,15 +220,11 @@ export const routeTree = rootRoute
     "/finance": {
       "filePath": "finance.lazy.tsx"
     },
-    "/journal": {
-      "filePath": "journal.lazy.tsx",
-      "children": [
-        "/journal/$date"
-      ]
-    },
     "/journal/$date": {
-      "filePath": "journal.$date.lazy.tsx",
-      "parent": "/journal"
+      "filePath": "journal.$date.lazy.tsx"
+    },
+    "/journal/": {
+      "filePath": "journal.index.lazy.tsx"
     },
     "/library/": {
       "filePath": "library.index.lazy.tsx"

--- a/apps/main/src/routes/journal.index.lazy.tsx
+++ b/apps/main/src/routes/journal.index.lazy.tsx
@@ -119,7 +119,7 @@ const JournalPage = () => {
   );
 };
 
-export const Route = createLazyFileRoute('/journal')({
+export const Route = createLazyFileRoute('/journal/')({
   component: () => {
     return (
       <AuthRoute>


### PR DESCRIPTION
## Summary
**Prod hotfix.** After SWO-344, navigating to `/journal/<date>` changed the URL but kept showing the month **list**. Cause: the list was `journal.lazy.tsx` = route `/journal`, which TanStack made the **parent** of `/journal/$date` — and the list renders with no `<Outlet/>`, so the child (day) never rendered.

Fix (the pattern `library` already uses): the list is now an **index** route — `journal.index.lazy.tsx` → `/journal/` — so `/journal/$date` is a **sibling** under a virtual `/journal` parent with a default `<Outlet/>`. In the regenerated tree, `/journal/` and `/journal/$date` are now siblings (like `/library/` + `/library/books/$bookId`).

## Test plan
- [x] `turbo build --filter=main` regenerates the tree; `/journal/$date` and `/journal/` are siblings (no `"parent": "/journal"`).
- [x] main typechecks clean (incl. the day route's `to: '/journal'`).
- [ ] **Manual on prod after deploy:** open a day → day page renders; back → list; refresh on a day loads that day.

SWO-346