### PR TITLE
[WIP] fix(fe): clear all source-level tsc errors (SWO-348)

### DIFF
--- a/apps/listen/src/main.tsx
+++ b/apps/listen/src/main.tsx
@@ -14,7 +14,6 @@ import { routeTree } from './routeTree.gen';
 
 validateEnvVars();
 
-// @ts-expect-error
 const router = createRouter({
   routeTree,
   defaultViewTransition: true,

--- a/apps/listen/src/routes/__root.tsx
+++ b/apps/listen/src/routes/__root.tsx
@@ -1,6 +1,5 @@
 import { createRootRouteWithContext, Outlet } from '@tanstack/react-router';
 import type { Auth } from 'core';
-import React from 'react';
 
 export interface RouterContext {
   auth: Auth.AuthContextValue;

--- a/apps/main/src/routes/library.index.lazy.tsx
+++ b/apps/main/src/routes/library.index.lazy.tsx
@@ -95,7 +95,7 @@ const LibraryPage: React.FC = () => {
   //   console.log('Search:', query);
   // };
 
-  const handleBookClick = (book: BookWithProgress) => {
+  const handleBookClick = (book: { id: string }) => {
     // Navigate to book reader
     navigate({
       to: '/library/books/$bookId',
@@ -103,7 +103,7 @@ const LibraryPage: React.FC = () => {
     });
   };
 
-  const handleContinueReading = (book: CurrentBook) => {
+  const handleContinueReading = (book: { id: string }) => {
     // Navigate to continue reading
     navigate({
       to: '/library/books/$bookId',
@@ -142,7 +142,7 @@ const LibraryPage: React.FC = () => {
     isCompleted: book.isCompleted,
     isNew: book.isNew,
     coverGradient: getCoverGradient(book.id), // Generate consistent gradient based on ID
-    thumbnailUrl: book.thumbnailUrl,
+    thumbnailUrl: book.thumbnailUrl ?? undefined,
   }));
 
   // Show error state

--- a/apps/til/src/components/markdown/index.tsx
+++ b/apps/til/src/components/markdown/index.tsx
@@ -21,7 +21,7 @@ const MarkdownContent = React.memo((props: MarkdownContentProps) => {
       .replace(/\\n/g, '\n')
       .replace(
         /!\[(.*?)\]\((.*?)( align=(.*?))?\)/g,
-        (_match, alt, url, alignFull, alignValue) => {
+        (_match, alt, url, _alignFull, alignValue) => {
           return alignValue
             ? `![${alt}](${url}#align=${alignValue})`
             : `![${alt}](${url})`;
@@ -35,10 +35,12 @@ const MarkdownContent = React.memo((props: MarkdownContentProps) => {
         blockquote({ children }) {
           return <MarkdownBlockquote>{children}</MarkdownBlockquote>;
         },
-        code({ node, inline, className, children, ...props }) {
+        code({ node, className, children, ...props }) {
+          // react-markdown v9 no longer passes `inline`; a `language-*` class
+          // means a fenced code block, otherwise it's inline code.
           const match = /language-(\w+)/.exec(className || '');
 
-          if (!inline && match) {
+          if (match) {
             const [, language] = match;
             const code = String(children).replace(/\n$/, '');
 

--- a/apps/til/src/routes/index.lazy.tsx
+++ b/apps/til/src/routes/index.lazy.tsx
@@ -1,6 +1,5 @@
 import { createLazyFileRoute, Link } from '@tanstack/react-router';
 import { useLoadPosts } from 'core/til/query-hooks/posts';
-import React from 'react';
 import { HomeContainer } from 'ui/til/home-container';
 import { Layout } from '../components/layout';
 

--- a/apps/watch/src/main.tsx
+++ b/apps/watch/src/main.tsx
@@ -4,7 +4,7 @@ import {
   RouterProvider,
 } from '@tanstack/react-router';
 import { Auth, ErrorBoundary, Query } from 'core';
-import React, { StrictMode } from 'react';
+import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { ErrorFallback } from 'ui/universal/error-boundary';
 import { UniversalMinimalismThemeProvider } from 'ui/universal/minimalism';
@@ -26,7 +26,6 @@ validateEnvVars();
 // cache; the default (browser history) is unchanged when off.
 const standalone = readStandaloneCache();
 
-// @ts-expect-error
 const router = createRouter({
   routeTree,
   history: standalone

--- a/apps/watch/src/routes/__root.tsx
+++ b/apps/watch/src/routes/__root.tsx
@@ -1,6 +1,5 @@
 import { createRootRouteWithContext, Outlet } from '@tanstack/react-router';
 import type { Auth } from 'core';
-import React from 'react';
 
 export interface RouterContext {
   auth: Auth.AuthContextValue;

--- a/apps/watch/src/routes/history.lazy.tsx
+++ b/apps/watch/src/routes/history.lazy.tsx
@@ -1,7 +1,7 @@
 import { createLazyFileRoute, Link } from '@tanstack/react-router';
 import { useAuthContext } from 'core/providers/auth';
 import { useLoadHistory } from 'core/watch/query-hooks/history';
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { AuthRoute } from 'ui/universal/authRoute';
 import { HistoryContainer } from 'ui/watch/history-page/container';
 import { Layout } from '../components/layout';

--- a/apps/watch/src/routes/index.lazy.tsx
+++ b/apps/watch/src/routes/index.lazy.tsx
@@ -1,7 +1,6 @@
 import { createLazyFileRoute, Link } from '@tanstack/react-router';
 import { useAuthContext } from 'core/providers/auth';
 import { useLoadVideos } from 'core/watch/query-hooks/videos';
-import React from 'react';
 import { AuthRoute } from 'ui/universal/authRoute';
 import { HomeContainer } from 'ui/watch/home-page/container';
 import { Layout } from '../components/layout';

--- a/apps/watch/src/routes/playlist.$slug.$playlistId.$videoId.lazy.tsx
+++ b/apps/watch/src/routes/playlist.$slug.$playlistId.$videoId.lazy.tsx
@@ -7,7 +7,7 @@ import {
   useSharePlaylist,
 } from 'core/watch/mutation-hooks/share-videos';
 import { useLoadPlaylistDetail } from 'core/watch/query-hooks/playlist-detail';
-import React, { lazy, useState } from 'react';
+import { lazy, useState } from 'react';
 import { AuthRoute } from 'ui/universal/authRoute';
 import { VideoDetailContainer } from 'ui/watch/video-detail-page/containers';
 import { Layout } from '../components/layout';

--- a/apps/watch/src/routes/video.$slug.$id.lazy.tsx
+++ b/apps/watch/src/routes/video.$slug.$id.lazy.tsx
@@ -7,7 +7,7 @@ import {
   useShareVideo,
 } from 'core/watch/mutation-hooks/share-videos';
 import { useLoadVideoDetail } from 'core/watch/query-hooks/video-detail';
-import React, { lazy, useState } from 'react';
+import { lazy, useState } from 'react';
 import { AuthRoute } from 'ui/universal/authRoute';
 import { VideoDetailContainer } from 'ui/watch/video-detail-page/containers';
 import { Layout } from '../components/layout';

--- a/packages/core/src/universal/extension/communication/index.ts
+++ b/packages/core/src/universal/extension/communication/index.ts
@@ -1,3 +1,19 @@
+// Minimal typing for the Chrome extension messaging API used below. The app
+// runs in browsers where `chrome` may be undefined (no extension), so it's
+// optional and guarded before use.
+declare const chrome:
+  | {
+      runtime?: {
+        sendMessage: (
+          extensionId: string,
+          message: unknown,
+          responseCallback?: () => void,
+        ) => void;
+        lastError?: { message?: string };
+      };
+    }
+  | undefined;
+
 interface NotifyExtensionParams<T> {
   id: string;
   type: string;
@@ -15,7 +31,7 @@ const notifyExtension = <T>({ id, type, data }: NotifyExtensionParams<T>) => {
   if (typeof chrome !== 'undefined' && chrome.runtime) {
     chrome.runtime.sendMessage(id, { type, data }, () => {
       // Ignore errors - extension might not be installed
-      if (chrome.runtime.lastError) {
+      if (chrome.runtime?.lastError) {
         console.log('Extension not available');
       }
     });

--- a/packages/ui/src/listen/minimalism/music-widget/Controls.tsx
+++ b/packages/ui/src/listen/minimalism/music-widget/Controls.tsx
@@ -9,11 +9,6 @@ import SkipNextRounded from '@mui/icons-material/SkipNextRounded';
 import SkipPreviousRounded from '@mui/icons-material/SkipPreviousRounded';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
-
-//@ts-expect-error
-// import { SAudioPlayerLoopMode } from "core";
-
-// ts sucks
 enum SAudioPlayerLoopMode {
   None = 'none',
   All = 'all',

--- a/packages/ui/src/main/home-page/landing-card/styled.tsx
+++ b/packages/ui/src/main/home-page/landing-card/styled.tsx
@@ -27,14 +27,14 @@ const IconContainer = styled(Box, {
   height: 60,
   borderRadius: '50%',
   backgroundColor: `${customColor || theme.palette.primary.main}15`,
-})) as typeof Box;
+}));
 
 const IconTypography = styled(Typography, {
   shouldForwardProp: (prop) => prop !== 'customColor',
 })<{ customColor?: string }>(({ customColor, theme }) => ({
   fontSize: '2rem',
   color: customColor || theme.palette.primary.main,
-})) as typeof Typography;
+}));
 
 const TitleTypography = styled(Typography)(() => ({
   fontWeight: 600,

--- a/packages/ui/src/watch/videos/video-player/index.tsx
+++ b/packages/ui/src/watch/videos/video-player/index.tsx
@@ -265,7 +265,7 @@ const VideoPlayer = (props: VideoPlayerProps) => {
           e.preventDefault();
           e.stopPropagation();
           player.seekTo(0, 'seconds');
-          handleSeek();
+          handleSeek(0);
           break;
 
         case 'End': // Jump to end
@@ -273,7 +273,7 @@ const VideoPlayer = (props: VideoPlayerProps) => {
           e.stopPropagation();
           if (duration) {
             player.seekTo(duration - 1, 'seconds');
-            handleSeek();
+            handleSeek(duration - 1);
           }
           break;
 
@@ -318,7 +318,7 @@ const VideoPlayer = (props: VideoPlayerProps) => {
             const percentage = Number.parseInt(e.key, 10) / 10;
             const newTime = duration * percentage;
             player.seekTo(newTime, 'seconds');
-            handleSeek();
+            handleSeek(newTime);
           }
           break;
 


### PR DESCRIPTION
## Summary
Makes **source** (non-test) typecheck-clean across `core`/`ui`/`main`/`watch`/`listen`/`til` — the prereq for the `tsc` CI gate (SWO-349). All six now report **0** source errors.

**Two are real behavior fixes:**
- **video-player** (`ui/watch`): `handleSeek()` was called with no argument on the Home / End / speed-change keys, though it takes the seek target everywhere else — so after those keys the seek UI didn't sync. Now passes the target (`handleSeek(0)` / `(duration - 1)` / `(newTime)`).
- **markdown** (`til`): react-markdown v9 removed the code `inline` prop; gate on the `language-*` className instead (block vs inline code) — same behavior, no more phantom prop.

**Type-only:**
- `landing-card` styled: the `as typeof Box/Typography` casts dropped the `customColor` prop type → removed the casts.
- `core` extension/communication: added a minimal typed `chrome` global + optional-chained `lastError`.
- `library.index`: typed the click handlers as `{ id: string }` (they only use `id`; the old `BookWithProgress`/`CurrentBook` types were never defined) + coerced nullable `thumbnailUrl`.
- Removed unused `React` imports (watch ×6, listen, til) and dead `@ts-expect-error` directives (watch/listen main.tsx, ui Controls).

## Test plan
- [x] `tsc --noEmit` = **0** source errors for core, ui, main, watch, listen, til.
- [x] `turbo build` (all apps) passes; `turbo test` (core + ui) passes — video-player + landing-card tests green (no behavior regression).

Note: ~250 test-file tsc errors remain out of scope (SWO-351); the gate (SWO-349) excludes test files initially.

SWO-348