### PR TITLE
test(listen): update stale logo assertion in home e2e

### DIFF
--- a/apps/listen/e2e/home/common.spec.ts
+++ b/apps/listen/e2e/home/common.spec.ts
@@ -10,7 +10,7 @@ test.describe('home visual', () => {
   });
 
   test('has logo', async ({ page }) => {
-    await expect(page.getByRole('link', { name: 'Flow Logo' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'SWorld logo' })).toBeVisible();
   });
 
   test('has site choices', async ({ page }) => {


### PR DESCRIPTION
## Summary

No user-facing changes. The listen home e2e still looked for the logo by its old name ("Flow Logo") from before the logo was replaced with the theme-aware SVG ("SWorld logo") in SWO-340, so the test fails against any fresh build. Updates the assertion to the current name. SWO-353.

## Test plan

- [ ] Listen e2e `has logo` test passes against a freshly built ui package (verified locally: 24/24 on dev server and preview build)
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the home page visual assertion to check for the current accessible logo label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->