### PR TITLE
[WIP] ci(fe): add source typecheck gate (SWO-349)

### DIFF
--- a/.github/workflows/typecheck-pr.yml
+++ b/.github/workflows/typecheck-pr.yml
@@ -1,0 +1,44 @@
+name: Typecheck on PR
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - 'apps/docs/**'
+      - '**/*.md'
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.18.0'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4.0.0
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install
+
+      # Typechecks source across the frontend packages (tests/stories/spec files
+      # are excluded via each package's tsconfig.typecheck.json until SWO-351).
+      - name: Typecheck
+        run: pnpm run typecheck

--- a/apps/listen/package.json
+++ b/apps/listen/package.json
@@ -12,7 +12,8 @@
     "e2e": "pnpm exec playwright test",
     "e2e-codegen": "pnpm exec playwright codegen",
     "lint": "biome lint --quit-on-problem .",
-    "format": "biome format --write ."
+    "format": "biome format --write .",
+    "typecheck": "tsc --noEmit -p tsconfig.typecheck.json"
   },
   "dependencies": {
     "@tanstack/react-router": "^1.78.2",

--- a/apps/listen/tsconfig.typecheck.json
+++ b/apps/listen/tsconfig.typecheck.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "exclude": [
+    "node_modules",
+    "e2e",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.stories.ts",
+    "**/*.stories.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx"
+  ],
+  "compilerOptions": {
+    "skipLibCheck": true
+  }
+}

--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -10,7 +10,8 @@
     "pre-dev": "cp ../../.env.development.local .env",
     "dev": "pnpm run pre-dev && vite",
     "lint": "biome lint --quit-on-problem .",
-    "format": "biome format --write ."
+    "format": "biome format --write .",
+    "typecheck": "tsc --noEmit -p tsconfig.typecheck.json"
   },
   "dependencies": {
     "@tanstack/react-router": "^1.78.2",

--- a/apps/main/tsconfig.typecheck.json
+++ b/apps/main/tsconfig.typecheck.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "exclude": [
+    "node_modules",
+    "e2e",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.stories.ts",
+    "**/*.stories.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx"
+  ],
+  "compilerOptions": {
+    "skipLibCheck": true
+  }
+}

--- a/apps/til/package.json
+++ b/apps/til/package.json
@@ -10,7 +10,8 @@
     "format": "biome format --write .",
     "dev": "pnpm run pre-dev && vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit -p tsconfig.typecheck.json"
   },
   "dependencies": {
     "@tanstack/react-router": "^1.78.2",

--- a/apps/til/tsconfig.typecheck.json
+++ b/apps/til/tsconfig.typecheck.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "exclude": [
+    "node_modules",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.stories.ts",
+    "**/*.stories.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx"
+  ],
+  "compilerOptions": {
+    "skipLibCheck": true
+  }
+}

--- a/apps/watch/package.json
+++ b/apps/watch/package.json
@@ -10,7 +10,8 @@
     "format": "biome format --write .",
     "dev": "pnpm run pre-dev && vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit -p tsconfig.typecheck.json"
   },
   "dependencies": {
     "@tanstack/react-router": "^1.78.2",

--- a/apps/watch/tsconfig.typecheck.json
+++ b/apps/watch/tsconfig.typecheck.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "exclude": [
+    "node_modules",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.stories.ts",
+    "**/*.stories.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx"
+  ],
+  "compilerOptions": {
+    "skipLibCheck": true
+  }
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "format": "biome format --write",
     "prepare": "husky",
     "lint": "biome check .",
-    "test": "turbo run test"
+    "test": "turbo run test",
+    "typecheck": "turbo run typecheck --filter=!docs"
   },
   "devDependencies": {
     "@biomejs/biome": "2.2.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,8 @@
     "dev": "tsup src/index.ts --format esm,cjs --watch --dts --external react",
     "lint": "biome lint --quit-on-problem .",
     "format": "biome format --write .",
-    "test": "vitest --coverage"
+    "test": "vitest --coverage",
+    "typecheck": "tsc --noEmit -p tsconfig.typecheck.json"
   },
   "devDependencies": {
     "@0no-co/graphqlsp": "^1.12.16",

--- a/packages/core/tsconfig.typecheck.json
+++ b/packages/core/tsconfig.typecheck.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["."],
+  "exclude": [
+    "dist",
+    "build",
+    "node_modules",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.stories.ts",
+    "**/*.stories.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx"
+  ],
+  "compilerOptions": {
+    "skipLibCheck": true
+  }
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -39,7 +39,8 @@
     "format": "biome format --write .",
     "test": "vitest --coverage",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "typecheck": "tsc --noEmit -p tsconfig.typecheck.json"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",

--- a/packages/ui/src/main/home-page/landing-card/styled.tsx
+++ b/packages/ui/src/main/home-page/landing-card/styled.tsx
@@ -1,5 +1,12 @@
-import { Box, Card, Typography } from '@mui/material';
+import {
+  Box,
+  type BoxProps,
+  Card,
+  Typography,
+  type TypographyProps,
+} from '@mui/material';
 import { styled } from '@mui/material/styles';
+import type { ComponentType } from 'react';
 
 const StyledCard = styled(Card)(({ theme }) => ({
   height: '100%',
@@ -27,14 +34,14 @@ const IconContainer = styled(Box, {
   height: 60,
   borderRadius: '50%',
   backgroundColor: `${customColor || theme.palette.primary.main}15`,
-}));
+})) as ComponentType<BoxProps & { customColor?: string }>;
 
 const IconTypography = styled(Typography, {
   shouldForwardProp: (prop) => prop !== 'customColor',
 })<{ customColor?: string }>(({ customColor, theme }) => ({
   fontSize: '2rem',
   color: customColor || theme.palette.primary.main,
-}));
+})) as ComponentType<TypographyProps & { customColor?: string }>;
 
 const TitleTypography = styled(Typography)(() => ({
   fontWeight: 600,

--- a/packages/ui/tsconfig.typecheck.json
+++ b/packages/ui/tsconfig.typecheck.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["."],
+  "exclude": [
+    "dist",
+    "build",
+    "node_modules",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.stories.ts",
+    "**/*.stories.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx"
+  ],
+  "compilerOptions": {
+    "skipLibCheck": true
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -36,6 +36,10 @@
     },
     "db:push": {
       "cache": false
+    },
+    "typecheck": {
+      "inputs": ["src/**/*.{ts,tsx}", "tsconfig*.json"],
+      "dependsOn": []
     }
   }
 }


### PR DESCRIPTION
## SWO-349 — Add a \`tsc --noEmit\` typecheck gate to CI

Part of **SWO-347** (harden the frontend against prod escapes). SWO-345 was a type error (`isPending` on a hook that didn't expose it) that only blew up at runtime in prod because nothing type-checks source in CI — `pnpm test` runs Vitest, which transpiles without type-checking. This adds that missing gate.

### What
- **Per package/app `tsconfig.typecheck.json`** (core, ui, main, watch, listen, til) — extends the base config, adds `skipLibCheck: true`, and **excludes test/stories/spec/e2e files**. Source-only for now; the ~250 test-file type errors are deferred to **SWO-351**.
- **`typecheck` script** in each package: `tsc --noEmit -p tsconfig.typecheck.json`.
- **Turbo `typecheck` task** + root `typecheck` script (`turbo run typecheck --filter=!docs` — docs is Docusaurus with a pre-existing broken typecheck and is already out of the frontend CI).
- **New workflow `.github/workflows/typecheck-pr.yml`** — mirrors `unit-test-pr.yml`, runs `pnpm run typecheck` on PRs (ignores `apps/docs/**` and `**/*.md`).

### Also fixes a hidden error the gate surfaced
SWO-348 removed the `landing-card/styled.tsx` casts (to fix the `customColor` overload) but that reintroduced a **TS2742 "not portable"** error. My SWO-348 verification used a grep that filtered lines containing `node_modules` — and the TS2742 message text contains `node_modules`, so it was silently dropped and shipped. Fixed properly with a cast that names the type portably (`BoxProps`/`TypographyProps`, direct deps) **and** carries `customColor`. Runtime-inert.

### Note on CI structure
This adds a **new CI check** (`Typecheck on PR`). It's not marked required — flagging it since it changes CI structure. Verified green on current main (`pnpm typecheck` → 6/6 successful).

### Deferred
- `noExplicitAny` (74 source anys) → follow-up ticket.
- Test-file type errors (~250) → SWO-351.

### Test
`pnpm typecheck` at repo root → all 6 packages pass. A PR introducing a source type error now fails this check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)