### PR TITLE
[WIP] test(main): journal flow e2e smoke test (SWO-350)

### DIFF
--- a/.github/workflows/e2e-main-pr.yml
+++ b/.github/workflows/e2e-main-pr.yml
@@ -1,0 +1,63 @@
+name: Main E2E on PR
+
+# Runs the main-app journal smoke test against a locally-built, locally-served
+# bundle (fake Auth0 session + mocked Hasura — see apps/main/e2e/support). It is
+# independent of the Firebase preview deploy on purpose, so it runs on every PR
+# that touches the main app or its shared packages.
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/main/**'
+      - 'packages/core/**'
+      - 'packages/ui/**'
+      - '.github/workflows/e2e-main-pr.yml'
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.18.0'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4.0.0
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install
+
+      # main's build:e2e resolves `core`/`ui` from their dist, so build those first.
+      - name: Build shared packages
+        run: pnpm turbo run build --filter=core --filter=ui
+
+      - name: Install Playwright browser
+        run: pnpm --filter main exec playwright install --with-deps chromium
+
+      # The e2e script's webServer runs build:e2e (fixed test env) + preview.
+      - name: Run Playwright tests
+        run: pnpm --filter main run e2e
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: apps/main/playwright-report/
+          retention-days: 30

--- a/.github/workflows/e2e-main-pr.yml
+++ b/.github/workflows/e2e-main-pr.yml
@@ -13,12 +13,17 @@ on:
       - 'packages/ui/**'
       - '.github/workflows/e2e-main-pr.yml'
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -33,7 +38,7 @@ jobs:
         run: |
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         name: Setup pnpm cache
         with:
           path: ${{ env.STORE_PATH }}

--- a/apps/main/.gitignore
+++ b/apps/main/.gitignore
@@ -1,0 +1,5 @@
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/apps/main/e2e/journal/journal-flow.spec.ts
+++ b/apps/main/e2e/journal/journal-flow.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from '@playwright/test';
+import {
+  findEntryActions,
+  findJournalEntry,
+  findJournalsHeading,
+  findRecentEntriesHeading,
+} from '../locators/journal';
+import { MOCK_ENTRY, mockJournalApi, seedAuth } from '../support/fixtures';
+import { formatEntryDate } from '../support/format';
+
+// The accessible name of the seeded entry's button, and its own route.
+const ENTRY_LABEL = formatEntryDate(MOCK_ENTRY.date);
+const DAY_URL = new RegExp(`/journal/${MOCK_ENTRY.date}$`);
+const LIST_URL = /\/journal\/?$/;
+
+// Smoke test for the journal flow — the net that catches what types can't: a
+// page that throws on first load (SWO-345) or the day route rendering the list
+// instead of the day (SWO-346). Auth is a seeded fake Auth0 session and the
+// Hasura API is mocked, so nothing here touches a real backend.
+test.describe('journal flow', () => {
+  test.beforeEach(async ({ context, page }) => {
+    await seedAuth(context);
+    await mockJournalApi(page);
+  });
+
+  test('lists the month, opens a day, and back returns to the list', async ({
+    page,
+  }) => {
+    await page.goto('/journal');
+
+    // The month list renders — not a white screen, not the login dialog.
+    await expect(findJournalsHeading(page)).toBeVisible();
+    await expect(findRecentEntriesHeading(page)).toBeVisible();
+    await expect(
+      page.getByText(MOCK_ENTRY.content, { exact: true }),
+    ).toBeVisible();
+
+    // Clicking a day goes to its own route AND renders the day page. The
+    // "entry actions" button is day-only and only rendered once the entry has
+    // loaded (the not-found branch omits it), and the "Recent Entries" heading
+    // is list-only — so this pair fails if the day route renders the list
+    // (SWO-346) or the entry never loads.
+    await findJournalEntry(page, ENTRY_LABEL).click();
+    await expect(page).toHaveURL(DAY_URL);
+    await expect(findEntryActions(page)).toBeVisible();
+    await expect(findRecentEntriesHeading(page)).toBeHidden();
+
+    // The browser back button returns to the list (it's a real route, not an
+    // in-page view switch — SWO-341).
+    await page.goBack();
+    await expect(page).toHaveURL(LIST_URL);
+    await expect(findRecentEntriesHeading(page)).toBeVisible();
+  });
+
+  test('loads a day directly on refresh', async ({ page }) => {
+    await page.goto(`/journal/${MOCK_ENTRY.date}`);
+    await expect(findEntryActions(page)).toBeVisible();
+
+    await page.reload();
+    await expect(page).toHaveURL(DAY_URL);
+    await expect(findEntryActions(page)).toBeVisible();
+    await expect(findRecentEntriesHeading(page)).toBeHidden();
+  });
+});

--- a/apps/main/e2e/locators/journal.ts
+++ b/apps/main/e2e/locators/journal.ts
@@ -1,0 +1,25 @@
+import type { Page } from '@playwright/test';
+
+// Semantic finders for the journal pages. Chosen by role, never DOM structure:
+// the month-list headings are headings, a journal entry is a button (its
+// accessible name is the formatted date), and the day page's overflow menu is
+// the "entry actions" button — which exists ONLY on the day page, so its
+// presence distinguishes the day route from the list (the SWO-346 regression).
+const findJournalsHeading = (page: Page) =>
+  page.getByRole('heading', { name: 'Journals', exact: true });
+
+const findRecentEntriesHeading = (page: Page) =>
+  page.getByRole('heading', { name: 'Recent Entries', exact: true });
+
+const findJournalEntry = (page: Page, name: string) =>
+  page.getByRole('button', { name, exact: true });
+
+const findEntryActions = (page: Page) =>
+  page.getByRole('button', { name: 'entry actions', exact: true });
+
+export {
+  findEntryActions,
+  findJournalEntry,
+  findJournalsHeading,
+  findRecentEntriesHeading,
+};

--- a/apps/main/e2e/support/fixtures.ts
+++ b/apps/main/e2e/support/fixtures.ts
@@ -1,0 +1,187 @@
+import type { BrowserContext, Page } from '@playwright/test';
+
+// The journal pages are auth-gated (Auth0) and read from Hasura. This harness
+// makes both deterministic and network-free so the flow can be exercised in CI
+// without a real backend:
+//   - seedAuth() writes a fake but well-formed @@auth0spajs@@ localStorage cache
+//     so the app boots signed-in (getAccessTokenSilently + getUser resolve from
+//     cache, no Auth0 network).
+//   - mockJournalApi() intercepts the Hasura GraphQL endpoint and answers the
+//     two journal queries with a fixed entry.
+//
+// The build under test is produced by `build:e2e` with fixed VITE_* values, so
+// these constants MUST match that build's config (audience === hasura url,
+// clientId, and the default Auth0 scope).
+const CLIENT_ID = 'e2e-client-id';
+const HASURA_URL = 'https://hasura.e2e.local/v1/graphql';
+const AUDIENCE = HASURA_URL;
+const SCOPE = 'openid profile email';
+const USER_ID = '00000000-0000-0000-0000-000000000001';
+
+// A fixed entry, date-independent so the test never depends on "today". The
+// list mock always returns it; clicking it navigates to /journal/<date>, and
+// the by-date mock echoes whatever date is requested.
+const MOCK_ENTRY = {
+  id: '11111111-1111-1111-1111-111111111111',
+  user_id: USER_ID,
+  date: '2026-07-04',
+  content: 'E2E smoke: the journal flow renders end to end.',
+  mood: 'happy',
+  tags: ['e2e', 'smoke'],
+  createdAt: '2026-07-04T08:00:00+00:00',
+  updatedAt: '2026-07-04T08:00:00+00:00',
+};
+
+// Seeds a fake Auth0 session into the context's localStorage before any app
+// script runs. The shapes mirror @auth0/auth0-spa-js@2's localStorage cache:
+// a wrapped token entry keyed `@@auth0spajs@@::<clientId>::<audience>::<scope>`
+// and an id-token entry keyed `@@auth0spajs@@::<clientId>::@@user@@`.
+const seedAuth = async (context: BrowserContext) => {
+  await context.addInitScript(
+    ({ clientId, audience, scope, userId }) => {
+      const b64url = (obj: unknown) =>
+        btoa(JSON.stringify(obj))
+          .replace(/\+/g, '-')
+          .replace(/\//g, '_')
+          .replace(/=+$/, '');
+      const nowSec = Math.floor(Date.now() / 1000);
+      const exp = nowSec + 86400;
+      const header = { alg: 'RS256', typ: 'JWT' };
+      const makeJwt = (payload: Record<string, unknown>) =>
+        `${b64url(header)}.${b64url(payload)}.sig`;
+
+      // The app parses the Hasura claims out of this access token (getClaims),
+      // so it must carry the `https://hasura.io/jwt/claims` namespace.
+      const accessToken = makeJwt({
+        iss: 'https://auth.e2e.local/',
+        aud: audience,
+        sub: 'auth0|e2e',
+        iat: nowSec,
+        exp,
+        'https://hasura.io/jwt/claims': {
+          'x-hasura-default-role': 'user',
+          'x-hasura-allowed-roles': ['user'],
+          'x-hasura-user-id': userId,
+        },
+      });
+
+      const idPayload = {
+        iss: 'https://auth.e2e.local/',
+        aud: clientId,
+        sub: 'auth0|e2e',
+        iat: nowSec,
+        exp,
+        name: 'E2E User',
+        email: 'e2e@e2e.local',
+        picture: 'https://e2e.local/avatar.png',
+      };
+      const idToken = makeJwt(idPayload);
+
+      // Mirror auth0-spa-js decodeToken: `claims` is the full payload plus the
+      // raw token; `user` is the payload minus the reserved OIDC claims.
+      const reserved = new Set([
+        'iss',
+        'aud',
+        'exp',
+        'nbf',
+        'iat',
+        'jti',
+        'azp',
+        'nonce',
+        'auth_time',
+        'at_hash',
+        'c_hash',
+        'acr',
+        'amr',
+        'sub_jwk',
+        'cnf',
+      ]);
+      const claims: Record<string, unknown> = { __raw: idToken };
+      const user: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(idPayload)) {
+        claims[key] = value;
+        if (!reserved.has(key)) {
+          user[key] = value;
+        }
+      }
+      const [encHeader, encPayload, encSignature] = idToken.split('.');
+      const decodedToken = {
+        encoded: {
+          header: encHeader,
+          payload: encPayload,
+          signature: encSignature,
+        },
+        header,
+        claims,
+        user,
+      };
+
+      const PREFIX = '@@auth0spajs@@';
+      const tokenKey = `${PREFIX}::${clientId}::${audience}::${scope}`;
+      const idKey = `${PREFIX}::${clientId}::@@user@@`;
+
+      localStorage.setItem(
+        tokenKey,
+        JSON.stringify({
+          body: {
+            client_id: clientId,
+            access_token: accessToken,
+            id_token: idToken,
+            scope,
+            expires_in: 86400,
+            token_type: 'Bearer',
+            audience,
+            decodedToken,
+          },
+          expiresAt: exp,
+        }),
+      );
+      localStorage.setItem(
+        idKey,
+        JSON.stringify({ id_token: idToken, decodedToken }),
+      );
+    },
+    { clientId: CLIENT_ID, audience: AUDIENCE, scope: SCOPE, userId: USER_ID },
+  );
+};
+
+// Intercepts the Hasura GraphQL endpoint and answers the journal queries. Also
+// aborts the external auth/error hosts so a cache miss or a stray Rollbar send
+// can never make the test flaky.
+const mockJournalApi = async (page: Page) => {
+  await page.route(/auth\.e2e\.local|rollbar\.com/, (route) => route.abort());
+
+  await page.route(HASURA_URL, (route) => {
+    const body = route.request().postData() ?? '';
+
+    if (body.includes('GetJournalsByMonth')) {
+      return route.fulfill({
+        json: {
+          data: {
+            journals: [MOCK_ENTRY],
+            happy_aggregate: { aggregate: { count: 1 } },
+            neutral_aggregate: { aggregate: { count: 0 } },
+            sad_aggregate: { aggregate: { count: 0 } },
+            oldest_aggregate: [{ date: MOCK_ENTRY.date }],
+          },
+        },
+      });
+    }
+
+    if (body.includes('GetJournalByDate')) {
+      let date = MOCK_ENTRY.date;
+      try {
+        date = JSON.parse(body).variables?.date ?? date;
+      } catch {
+        // keep the default date
+      }
+      return route.fulfill({
+        json: { data: { journals: [{ ...MOCK_ENTRY, date }] } },
+      });
+    }
+
+    return route.fulfill({ json: { data: {} } });
+  });
+};
+
+export { mockJournalApi, MOCK_ENTRY, seedAuth };

--- a/apps/main/e2e/support/format.ts
+++ b/apps/main/e2e/support/format.ts
@@ -1,0 +1,14 @@
+// Mirrors core's formatDate (weekday/month/day, en-US) for computing the
+// expected accessible name of a journal entry. `timeZone: 'UTC'` is pinned so
+// this Node-side value matches the browser render — the Playwright context runs
+// with timezoneId 'UTC', and the app's formatDate parses 'YYYY-MM-DD' as UTC
+// midnight. Both therefore produce the same string regardless of the CI TZ.
+const formatEntryDate = (isoDate: string) =>
+  new Date(`${isoDate}T00:00:00Z`).toLocaleDateString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+
+export { formatEntryDate };

--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -9,6 +9,9 @@
     "deploy": "vercel deploy dist --team=turborepo --confirm",
     "pre-dev": "cp ../../.env.development.local .env",
     "dev": "pnpm run pre-dev && vite",
+    "build:e2e": "VITE_HASURA_DOMAIN=https://hasura.e2e.local VITE_AUTH0_DOMAIN=auth.e2e.local VITE_AUTH0_CLIENT_ID=e2e-client-id VITE_MAIN_SITE_URL=e2e.local VITE_ROLLBAR_TOKEN=e2e-token VITE_ROLLBAR_ENV=test vite build",
+    "preview:e2e": "vite preview --port 4000 --strictPort",
+    "e2e": "playwright test",
     "lint": "biome lint --quit-on-problem .",
     "format": "biome format --write ."
   },
@@ -22,6 +25,7 @@
   },
   "devDependencies": {
     "@codecov/vite-plugin": "^1.9.1",
+    "@playwright/test": "^1.52.0",
     "@tanstack/router-plugin": "^1.78.2",
     "@types/node": "^18.11.9",
     "@types/react": "^18.3.12",

--- a/apps/main/playwright.config.ts
+++ b/apps/main/playwright.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const isCI = !!process.env.CI;
+const port = 4000;
+const baseURL = `http://localhost:${port}`;
+
+// Runs against a locally-built, locally-served bundle (see the `build:e2e` /
+// `preview:e2e` scripts) — no Firebase deploy and no real backend. The build
+// bakes in fixed VITE_* values that the auth/API mocks in e2e/support match.
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: isCI,
+  retries: isCI ? 2 : 0,
+  workers: isCI ? 1 : undefined,
+  reporter: isCI ? [['dot'], ['html', { open: 'never' }]] : [['list']],
+  use: {
+    baseURL,
+    // Pinned so date rendering (formatDate) is deterministic across machines.
+    timezoneId: 'UTC',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'pnpm run build:e2e && pnpm run preview:e2e',
+    url: baseURL,
+    reuseExistingServer: !isCI,
+    timeout: 180_000,
+  },
+});

--- a/packages/ui/src/journal/journal-list/index.test.tsx
+++ b/packages/ui/src/journal/journal-list/index.test.tsx
@@ -141,10 +141,12 @@ describe('JournalList', () => {
   it('handles journal card click', () => {
     render(<JournalList {...defaultProps} />);
 
-    const journalCard = screen
-      .getByText(mockJournals[0].content)
-      .closest('.MuiCard-root');
-    fireEvent.click(journalCard!);
+    // The card is a CardActionArea (a button) whose accessible name is the
+    // formatted date — click it the way a user/AT would reach it.
+    const journalCard = screen.getByRole('button', {
+      name: `formatted-date-${mockJournals[0].date}`,
+    });
+    fireEvent.click(journalCard);
 
     expect(defaultProps.onJournalClick).toHaveBeenCalledWith(mockJournals[0]);
   });

--- a/packages/ui/src/journal/journal-list/index.tsx
+++ b/packages/ui/src/journal/journal-list/index.tsx
@@ -9,6 +9,7 @@ import SentimentSatisfiedAltIcon from '@mui/icons-material/SentimentSatisfiedAlt
 import SentimentVeryDissatisfiedIcon from '@mui/icons-material/SentimentVeryDissatisfied';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
+import CardActionArea from '@mui/material/CardActionArea';
 import CardContent from '@mui/material/CardContent';
 import Chip from '@mui/material/Chip';
 import IconButton from '@mui/material/IconButton';
@@ -139,59 +140,61 @@ export const JournalList: React.FC<JournalListProps> = ({
   };
 
   const renderJournalCard = (journal: Journal) => (
-    <Card
-      key={journal.id}
-      sx={{
-        mb: 2,
-        cursor: 'pointer',
-      }}
-      onClick={() => onJournalClick(journal)}
-    >
-      <CardContent>
-        <Box
-          sx={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'flex-start',
-          }}
-        >
-          <Box>
-            <Typography variant="body1" fontWeight="medium">
-              {formatDate(journal.date)}
-            </Typography>
-            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 0.5 }}>
-              {journal.tags.map((tag: string) => (
-                <Chip
-                  key={tag}
-                  label={tag}
-                  size="small"
-                  sx={{
-                    height: 20,
-                    fontSize: '0.7rem',
-                    bgcolor: 'action.hover',
-                  }}
-                />
-              ))}
+    <Card key={journal.id} sx={{ mb: 2 }}>
+      {/* CardActionArea (not an onClick div) so the entry is keyboard- and
+          screen-reader-operable; the formatted date is its accessible name. */}
+      <CardActionArea
+        aria-label={formatDate(journal.date)}
+        onClick={() => onJournalClick(journal)}
+      >
+        <CardContent>
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'flex-start',
+            }}
+          >
+            <Box>
+              <Typography variant="body1" fontWeight="medium">
+                {formatDate(journal.date)}
+              </Typography>
+              <Box
+                sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 0.5 }}
+              >
+                {journal.tags.map((tag: string) => (
+                  <Chip
+                    key={tag}
+                    label={tag}
+                    size="small"
+                    sx={{
+                      height: 20,
+                      fontSize: '0.7rem',
+                      bgcolor: 'action.hover',
+                    }}
+                  />
+                ))}
+              </Box>
             </Box>
+            <MoodIcon mood={journal.mood as MoodType} size={20} />
           </Box>
-          <MoodIcon mood={journal.mood as MoodType} size={20} />
-        </Box>
 
-        <Typography
-          variant="body2"
-          color="text.secondary"
-          sx={{
-            mt: 1,
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            display: '-webkit-box',
-            WebkitLineClamp: 3,
-            WebkitBoxOrient: 'vertical',
-          }}
-        >
-          {journal.content}
-        </Typography>
-      </CardContent>
+          <Typography
+            variant="body2"
+            color="text.secondary"
+            sx={{
+              mt: 1,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              display: '-webkit-box',
+              WebkitLineClamp: 3,
+              WebkitBoxOrient: 'vertical',
+            }}
+          >
+            {journal.content}
+          </Typography>
+        </CardContent>
+      </CardActionArea>
     </Card>
   );
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,6 +300,9 @@ importers:
       '@codecov/vite-plugin':
         specifier: ^1.9.1
         version: 1.9.1(vite@6.4.3(@types/node@18.19.80)(jiti@2.4.2)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))
+      '@playwright/test':
+        specifier: ^1.52.0
+        version: 1.61.1
       '@tanstack/router-plugin':
         specifier: ^1.78.2
         version: 1.114.25(@tanstack/react-router@1.114.25(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.4.3(@types/node@18.19.80)(jiti@2.4.2)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0)


### PR DESCRIPTION
## SWO-350 — Journal flow E2E smoke test

Part of **SWO-347** (harden the frontend against prod escapes). The web apps have no unit-test runner, so the two SWO-344 prod escapes shipped unnoticed: a page that **threw on first load** (SWO-345) and a route that **rendered the list instead of the day** (SWO-346). This adds the smoke test that catches exactly that class of bug — and it's `apps/main`'s first E2E, establishing the mocked-e2e harness.

### The flow it covers
`/journal` (month list renders) → click a day → `/journal/<date>` **renders the day, not the list** → browser back returns to the list → refresh on the day loads it directly. Every assertion is a semantic locator (`e2e/locators/journal.ts`); the day-only "entry actions" button vs. the list-only "Recent Entries" heading is the pair that fails on the SWO-346 regression.

### Harness — backend-independent by design
No Firebase deploy, no real backend, no real data — so it runs deterministically on **every** main/core/ui PR:
- **`seedAuth()`** writes a well-formed `@@auth0spajs@@` localStorage cache (shapes mirror `@auth0/auth0-spa-js@2`) so the app boots signed-in — `getAccessTokenSilently` + `getUser` resolve from cache with **zero Auth0 network**.
- **`mockJournalApi()`** `page.route()`-mocks the two journal Hasura queries (dynamic: `GetJournalByDate` echoes the requested date).
- **`build:e2e`** builds main with fixed `VITE_*` test values the mocks match; Playwright's `webServer` serves the preview on `:4000`.

### CI
New workflow **`e2e-main-pr.yml`** (build core/ui → install chromium → `pnpm --filter main e2e`). It's a **new CI check** — flagging since it changes CI structure. Chose a standalone local-server job over bolting onto the Firebase preview workflow so it's not gated behind the flaky preview deploy (429 quota).

### Also — small a11y fix (required for a semantic handle)
The journal list card was a `<div onClick>` — not keyboard- or screen-reader-operable. Changed it to a MUI `CardActionArea` (real `<button>`, ripple, focus), with the formatted date as its accessible name. Fixes a genuine a11y gap and gives the test a role-based locator.

### Test
`pnpm --filter main e2e` → 2 passed locally (chromium). Verified it goes **red** when the day route renders the list (the SWO-346 shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Journal entries are now fully keyboard- and screen-reader accessible, with clearer labels for each entry.
  * Added end-to-end coverage for the journal flow to improve reliability of the main app experience.

* **Bug Fixes**
  * Improved the journal entry click target so cards respond more consistently across input methods.
  * Made journal testing and rendering behavior more stable across time zones and refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->