### PR TITLE
build(ci): upgrade pnpm to 10.34.3 with supply-chain hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ When work spans the backend or schema, the change lands in those repos, not here
 - **Testing:** Vitest, Playwright, Jest, Storybook
 - **Build:** Turborepo, pnpm, tsup
 - **Gaming:** Phaser.js, Matter.js physics
-- **Package Manager:** pnpm (>=9.4.0) · **Node:** >=22.14.0
+- **Package Manager:** pnpm (>=10.34.3) · **Node:** >=22.14.0
 
 ## Where knowledge lives
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": false,
   "engines": {
     "node": ">=24",
-    "pnpm": ">=9.4.0"
+    "pnpm": ">=10.34.3"
   },
   "scripts": {
     "build": "turbo run build",
@@ -31,7 +31,7 @@
     "turbo": "2.9.14",
     "typescript": "^5.6.2"
   },
-  "packageManager": "pnpm@9.4.0",
+  "packageManager": "pnpm@10.34.3",
   "pnpm": {
     "overrides": {
       "form-data@>=4.0.0 <4.0.4": "4.0.4",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,10 @@
 packages:
   - "apps/*"
   - "packages/*"
+
+# Supply-chain hardening (SWO-355)
+# Refuse to resolve versions published <7 days ago; frozen installs (CI) are unaffected.
+minimumReleaseAge: 10080
+# Dependency lifecycle scripts are blocked (pnpm 10 default); nothing in the
+# workspace needs one — build/test verified green with all scripts ignored.
+onlyBuiltDependencies: []


### PR DESCRIPTION
## Summary

No user-facing changes. Upgrades the package manager from pnpm 9.4.0 to 10.34.3 and hardens dependency installs: new releases younger than 7 days won't resolve (`minimumReleaseAge: 10080`), and dependency install scripts stay blocked (explicit empty allowlist — the whole workspace builds and tests green without any). One-edit rollout: the local pnpm launcher and CI (`pnpm/action-setup@v4`) both follow the `packageManager` pin automatically. SWO-355.

Verified locally under 10.34.3: fresh install 22s, 9/9 builds, 938 tests pass, lockfile byte-identical (no version movement), and the cooldown refuses a 2-day-old release when adding a dependency. CI installs are already frozen by pnpm's CI default, so the cooldown never affects builds.

## Test plan

- [ ] Fresh `pnpm install` works and reports pnpm v10.34.3
- [ ] `pnpm build` and `pnpm test` pass (verified locally)
- [ ] CI green