### PR TITLE
fix(main): finance React #130 — import echarts-for-react ESM build (SWO-356)

### DIFF
--- a/packages/ui/src/main/home-page/spending-breakdown/donut-chart.test.tsx
+++ b/packages/ui/src/main/home-page/spending-breakdown/donut-chart.test.tsx
@@ -29,7 +29,7 @@ vi.mock('echarts/renderers', () => ({
 }));
 
 // Mock the echarts-for-react core component
-vi.mock('echarts-for-react/lib/core', () => ({
+vi.mock('echarts-for-react/esm/core', () => ({
   default: ({ onEvents, option }: any) => {
     return (
       <div

--- a/packages/ui/src/main/home-page/spending-breakdown/donut-chart.tsx
+++ b/packages/ui/src/main/home-page/spending-breakdown/donut-chart.tsx
@@ -5,7 +5,11 @@ import { PieChart } from 'echarts/charts';
 import { LegendComponent, TooltipComponent } from 'echarts/components';
 import * as echarts from 'echarts/core';
 import { CanvasRenderer } from 'echarts/renderers';
-import ReactEChartsCore from 'echarts-for-react/lib/core';
+// Import the ESM build (real `export default`), not lib/core (CJS with
+// `__esModule` + `exports.default`). Under the vite 8/rolldown build the CJS
+// default import resolves to the module object instead of the component,
+// which crashes the finance page with React error #130 (SWO-356).
+import ReactEChartsCore from 'echarts-for-react/esm/core';
 
 echarts.use([PieChart, TooltipComponent, LegendComponent, CanvasRenderer]);
 


### PR DESCRIPTION
## SWO-356 — Finance page crashes on prod (React #130)

**Prod hotfix.** The finance page white-screens on prod (ErrorBoundary fallback) with `Minified React error #130 …args[]=object` ("element type is invalid: got object"), introduced by **#372** (vite 6→8 rolldown + `@vitejs/plugin-react` 4→6, SWO-352), which auto-deployed.

### Root cause
`donut-chart.tsx` imported the chart from the **CommonJS** build:
```ts
import ReactEChartsCore from 'echarts-for-react/lib/core';
```
`echarts-for-react/lib/core` is CJS (`__esModule` + `exports.default`). Under the new vite 8 / rolldown build, the default import resolves to the **module object** (`{ __esModule, default }`) rather than `.default`, so React receives an object as an element type → #130. Finance is the only route that renders a chart, so it's the only one that crashed. **Not the chunking** — reproduced identically with `advancedChunks` removed.

### Fix
Import the package's **ESM** build (real `export default`), which sidesteps the CJS interop:
```ts
import ReactEChartsCore from 'echarts-for-react/esm/core';
```
Plus the matching vitest mock path in `donut-chart.test.tsx`.

### Test
Reproduced against the **prod build** with a seeded Auth0 session + mocked `GetFinanceRecords`: React #130 on the donut mount before; after the fix the finance dashboard + donut render cleanly with no #130. `donut-chart.test.tsx` (7 tests) green.

### Follow-up (not in this PR)
Worth an audit for other CJS-default `.../lib/*` imports that the vite 8 interop could bite the same way. Filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)