### PR TITLE
fix(ci): deploy Live Main on packages/ui + core changes (SWO-357)

### DIFF
--- a/.github/workflows/live-main-fe.yml
+++ b/.github/workflows/live-main-fe.yml
@@ -3,11 +3,18 @@
 
 name: Deploy Live Main Frontend
 'on':
+  # Also deploy when the shared packages the app bundles change — otherwise a
+  # fix in packages/ui or packages/core (like the finance React #130 hotfix)
+  # merges but never ships to prod. Mirrors the live listen/watch/game configs.
+  workflow_dispatch: {}
   push:
     branches:
       - main
     paths:
       - 'apps/main/**'
+      - 'packages/core/**'
+      - 'packages/ui/**'
+      - '.github/workflows/live-main-fe.yml'
 jobs:
   dev_deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## SWO-357 — Live Main didn't deploy the finance hotfix

**Why prod finance is still broken after #376 merged.** `live-main-fe.yml` triggered only on `paths: apps/main/**`. The finance React #130 fix (SWO-356) lives in `packages/ui/.../donut-chart.tsx`, so on merge **Live Main never ran** — Live Listen/Watch/Game did (they already watch `packages/ui`). The fix is on main but undeployed.

## Change
- Add `packages/core/**`, `packages/ui/**`, and `.github/workflows/live-main-fe.yml` to the push `paths` (mirrors live listen/watch/game).
- Add `workflow_dispatch` for manual redeploys.

Editing this workflow matches its own new path filter, so **merging this PR triggers the Live Main deploy** that ships the finance fix to prod. `workflow_dispatch` is the backstop if needed.

## Note
`preview-main-fe.yml` already watches core+ui (the PR preview ran for #376), so only the live deploy had the gap. `live-til-fe.yml` looks like it has the same omission — filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded deployment triggers so the live frontend can be updated when shared core or UI packages change.
  * Added a manual deployment option for more flexible releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->