### PR TITLE
fix(main): journal day header full-width without 100vw horizontal scroll (SWO-371)

### DIFF
--- a/apps/main/src/routes/journal.$date.lazy.tsx
+++ b/apps/main/src/routes/journal.$date.lazy.tsx
@@ -9,7 +9,6 @@ import { useQueryContext } from 'core/providers/query';
 import { lazy, Suspense, useState } from 'react';
 import { JournalDetail } from 'ui/journal/journal-detail';
 import { AuthRoute } from 'ui/universal/authRoute';
-import { Container } from 'ui/universal/containers/generic';
 import { Layout } from '../components/layout';
 
 const EditDialog = lazy(() =>
@@ -76,35 +75,35 @@ const JournalDayPage = () => {
 
   return (
     <Layout>
-      <Container maxWidth="sm" sx={{ pb: 8, position: 'relative' }}>
-        <JournalDetail
-          journal={journal}
-          isLoading={isLoading}
-          onBackClick={goBack}
-          onEditClick={() => setDialogOpen(true)}
-          onDeleteClick={handleDelete}
+      {/* No wrapping Container: JournalDetail owns its layout (full-width sticky
+          header + `sm`-constrained content). The dialogs portal to the body. */}
+      <JournalDetail
+        journal={journal}
+        isLoading={isLoading}
+        onBackClick={goBack}
+        onEditClick={() => setDialogOpen(true)}
+        onDeleteClick={handleDelete}
+      />
+
+      <Suspense fallback={null}>
+        <EditDialog
+          journalDetail={journal}
+          isLoadingDetail={isLoading}
+          open={dialogOpen}
+          onClose={() => setDialogOpen(false)}
+          isSaving={updateMutation.isPending}
+          onSave={handleSave}
         />
+      </Suspense>
 
-        <Suspense fallback={null}>
-          <EditDialog
-            journalDetail={journal}
-            isLoadingDetail={isLoading}
-            open={dialogOpen}
-            onClose={() => setDialogOpen(false)}
-            isSaving={updateMutation.isPending}
-            onSave={handleSave}
+      <Suspense fallback={null}>
+        {notification && (
+          <Notification
+            notification={notification}
+            onClose={() => setNotification(null)}
           />
-        </Suspense>
-
-        <Suspense fallback={null}>
-          {notification && (
-            <Notification
-              notification={notification}
-              onClose={() => setNotification(null)}
-            />
-          )}
-        </Suspense>
-      </Container>
+        )}
+      </Suspense>
     </Layout>
   );
 };

--- a/packages/ui/src/journal/journal-detail/index.tsx
+++ b/packages/ui/src/journal/journal-detail/index.tsx
@@ -8,6 +8,7 @@ import MoreVertIcon from '@mui/icons-material/MoreVert';
 import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
+import Container from '@mui/material/Container';
 import Divider from '@mui/material/Divider';
 import IconButton from '@mui/material/IconButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
@@ -32,6 +33,11 @@ interface JournalDetailProps {
   onEditClick: () => void;
   onDeleteClick: () => void;
 }
+
+// The page owns its own width: the date header spans the full viewport as a
+// sibling of the content, and only the content is constrained to `sm`. The
+// route therefore renders this WITHOUT a wrapping Container.
+const CONTENT_MAX_WIDTH = 'sm';
 
 const JournalDetail: React.FC<JournalDetailProps> = ({
   journal,
@@ -63,7 +69,7 @@ const JournalDetail: React.FC<JournalDetailProps> = ({
 
   if (isLoading) {
     return (
-      <Box sx={{ p: 2 }}>
+      <Container maxWidth={CONTENT_MAX_WIDTH} sx={{ pt: 2, pb: 8 }}>
         <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
           <IconButton onClick={onBackClick} sx={{ mr: 1 }}>
             <ArrowBackIcon fontSize="medium" />
@@ -93,13 +99,13 @@ const JournalDetail: React.FC<JournalDetailProps> = ({
             <Skeleton width={180} height={16} />
           </Box>
         </Paper>
-      </Box>
+      </Container>
     );
   }
 
   if (!journal) {
     return (
-      <Box sx={{ p: 2 }}>
+      <Container maxWidth={CONTENT_MAX_WIDTH} sx={{ pt: 2, pb: 8 }}>
         <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
           <IconButton onClick={onBackClick} sx={{ mr: 1 }}>
             <ArrowBackIcon fontSize="medium" />
@@ -112,7 +118,7 @@ const JournalDetail: React.FC<JournalDetailProps> = ({
             Journal entry not found.
           </Typography>
         </Paper>
-      </Box>
+      </Container>
     );
   }
 
@@ -120,26 +126,20 @@ const JournalDetail: React.FC<JournalDetailProps> = ({
   const isEdited = journal.updatedAt !== journal.createdAt;
 
   return (
-    <Box sx={{ p: 2 }}>
-      {/* Pin the date under the app bar so long entries never lose the "which
-          day am I reading" context. Rendered as an AppBar so it reuses the
-          theme's frosted header surface (light + dark) instead of a hardcoded
-          colour, reading as a seamless second row of the header. */}
+    <>
+      {/* Full-width sticky date header. It's a sibling of the content (a direct
+          child of the full-width page layout), so it spans the viewport
+          naturally — no `100vw` breakout, which used to include the scrollbar
+          width and give the whole page a horizontal scrollbar (SWO-371). It
+          pins the date under the main app bar so long entries never lose the
+          "which day am I reading" context, and renders as an AppBar to reuse
+          the theme's frosted header surface as a seamless second row. */}
       <AppBar
         position="sticky"
         color="default"
         elevation={0}
         sx={{
-          // Full-bleed to match the full-width app bar exactly (the page
-          // Container is maxWidth=sm, so plain margins leave it inset and
-          // misaligned). No card-like border or radius — AppBar extends Paper,
-          // so we clear the theme's Paper border — it reads as a seamless
-          // second row of the header, flush beneath it.
           top: { xs: 56, sm: 64 },
-          width: '100vw',
-          ml: 'calc(50% - 50vw)',
-          mt: -2,
-          mb: 2,
           border: 'none',
           borderRadius: 0,
           borderBottom: (theme) => `1px solid ${theme.palette.divider}`,
@@ -155,102 +155,105 @@ const JournalDetail: React.FC<JournalDetailProps> = ({
         </Toolbar>
       </AppBar>
 
-      <Paper sx={{ p: 3, borderRadius: 3 }}>
-        <Box
-          sx={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            mb: 2.5,
-          }}
-        >
-          {mood ? (
-            <Chip
-              icon={<MoodIcon mood={journal.mood as MoodType} size={18} />}
-              label={mood.label}
-              sx={{
-                fontWeight: 600,
-                color: `${mood.color}.main`,
-                // The glassmorphism theme paints chips with a purple gradient
-                // (a background-image), so clear it before applying our tint.
-                backgroundImage: 'none',
-                bgcolor: (theme) => alpha(theme.palette[mood.color].main, 0.12),
-                border: 'none',
-                '& .MuiChip-icon': { color: 'inherit', ml: 0.5 },
-              }}
-            />
-          ) : (
-            <Box />
-          )}
-
-          <IconButton
-            aria-label="entry actions"
-            onClick={handleMenuOpen}
-            size="small"
+      <Container maxWidth={CONTENT_MAX_WIDTH} sx={{ pt: 2, pb: 8 }}>
+        <Paper sx={{ p: 3, borderRadius: 3 }}>
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              mb: 2.5,
+            }}
           >
-            <MoreVertIcon fontSize="small" />
-          </IconButton>
-          <Menu
-            anchorEl={menuAnchor}
-            open={isMenuOpen}
-            onClose={handleMenuClose}
-            anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-            transformOrigin={{ vertical: 'top', horizontal: 'right' }}
-          >
-            <MenuItem onClick={handleEdit}>
-              <ListItemIcon>
-                <EditOutlinedIcon fontSize="small" />
-              </ListItemIcon>
-              <ListItemText>Edit</ListItemText>
-            </MenuItem>
-            <MenuItem onClick={handleDelete} sx={{ color: 'error.main' }}>
-              <ListItemIcon>
-                <DeleteOutlineIcon fontSize="small" color="error" />
-              </ListItemIcon>
-              <ListItemText>Delete</ListItemText>
-            </MenuItem>
-          </Menu>
-        </Box>
-
-        <Typography
-          variant="body1"
-          component="pre"
-          sx={{
-            whiteSpace: 'pre-wrap',
-            fontFamily: 'inherit',
-            fontSize: '1.05rem',
-            lineHeight: 1.7,
-          }}
-        >
-          {journal.content}
-        </Typography>
-
-        {journal.tags.length > 0 && (
-          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75, mt: 2.5 }}>
-            {journal.tags.map((tag: string) => (
+            {mood ? (
               <Chip
-                key={tag}
-                label={tag}
-                size="small"
+                icon={<MoodIcon mood={journal.mood as MoodType} size={18} />}
+                label={mood.label}
                 sx={{
+                  fontWeight: 600,
+                  color: `${mood.color}.main`,
+                  // The glassmorphism theme paints chips with a purple gradient
+                  // (a background-image), so clear it before applying our tint.
                   backgroundImage: 'none',
-                  bgcolor: 'action.hover',
+                  bgcolor: (theme) =>
+                    alpha(theme.palette[mood.color].main, 0.12),
                   border: 'none',
+                  '& .MuiChip-icon': { color: 'inherit', ml: 0.5 },
                 }}
               />
-            ))}
+            ) : (
+              <Box />
+            )}
+
+            <IconButton
+              aria-label="entry actions"
+              onClick={handleMenuOpen}
+              size="small"
+            >
+              <MoreVertIcon fontSize="small" />
+            </IconButton>
+            <Menu
+              anchorEl={menuAnchor}
+              open={isMenuOpen}
+              onClose={handleMenuClose}
+              anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+              transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+            >
+              <MenuItem onClick={handleEdit}>
+                <ListItemIcon>
+                  <EditOutlinedIcon fontSize="small" />
+                </ListItemIcon>
+                <ListItemText>Edit</ListItemText>
+              </MenuItem>
+              <MenuItem onClick={handleDelete} sx={{ color: 'error.main' }}>
+                <ListItemIcon>
+                  <DeleteOutlineIcon fontSize="small" color="error" />
+                </ListItemIcon>
+                <ListItemText>Delete</ListItemText>
+              </MenuItem>
+            </Menu>
           </Box>
-        )}
 
-        <Divider sx={{ mt: 3, mb: 1.5 }} />
+          <Typography
+            variant="body1"
+            component="pre"
+            sx={{
+              whiteSpace: 'pre-wrap',
+              fontFamily: 'inherit',
+              fontSize: '1.05rem',
+              lineHeight: 1.7,
+            }}
+          >
+            {journal.content}
+          </Typography>
 
-        <Typography variant="caption" color="text.secondary">
-          {isEdited
-            ? `Edited ${formatDateTime(journal.updatedAt)}`
-            : formatDateTime(journal.createdAt)}
-        </Typography>
-      </Paper>
-    </Box>
+          {journal.tags.length > 0 && (
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75, mt: 2.5 }}>
+              {journal.tags.map((tag: string) => (
+                <Chip
+                  key={tag}
+                  label={tag}
+                  size="small"
+                  sx={{
+                    backgroundImage: 'none',
+                    bgcolor: 'action.hover',
+                    border: 'none',
+                  }}
+                />
+              ))}
+            </Box>
+          )}
+
+          <Divider sx={{ mt: 3, mb: 1.5 }} />
+
+          <Typography variant="caption" color="text.secondary">
+            {isEdited
+              ? `Edited ${formatDateTime(journal.updatedAt)}`
+              : formatDateTime(journal.createdAt)}
+          </Typography>
+        </Paper>
+      </Container>
+    </>
   );
 };
 


### PR DESCRIPTION
## SWO-371 — journal day header caused page-wide horizontal scroll

### Root cause (structural)
The sticky "second header" (back + date) lived **inside** the `maxWidth="sm"` content container and broke back out to full width with `width: 100vw` + `ml: calc(50% - 50vw)`. Wrong structure — and `100vw` includes the vertical scrollbar width, so once the page scrolls the header is ~15px wider than the content area → the whole main screen gets a horizontal scrollbar.

### Fix (restructure, not clip)
`JournalDetail` (used only by the day route) now owns its layout:
- Full-width sticky `AppBar` as a **sibling** of the content — a direct child of the full-width Layout, so it spans the viewport naturally (`width: 100%`, not `100vw`; no negative-margin hack).
- Content `Paper` in its own `maxWidth="sm"` `Container`.
- The route drops its outer `maxWidth="sm"` container (the dialogs portal to `body`, so they don't need it).

### Test
- Unit: journal-detail (8) + journal-list (8) green.
- E2E: journal flow (2) green.
- Visual: full-width sticky header, content centred at `sm`, no layout regression (screenshot attached to the ticket).

### Why no scroll-assertion test
The symptom only appears with **layout-occupying** scrollbars. Headless Chromium uses 0px overlay scrollbars that can't be forced to reserve space (tried `scrollbar-gutter: stable` and `::-webkit-scrollbar` sizing) — so `100vw` never overflows there and a headless test would *pass on the bug*. The fix is instead correct **by construction**: the header is `100%` (content width, excludes scrollbar) rather than `100vw` (includes it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated journal pages so the date header stays full width while the journal content is better constrained for easier reading.
  * Improved loading and “journal not found” views with cleaner spacing and consistent page layout.
  * Kept edit, delete, and notification dialogs working as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->