### PR TITLE
fix(watch): video detail page crashes on load since the vite 8 upgrade

### DIFF
--- a/packages/ui/src/watch/videos/video-player/index.tsx
+++ b/packages/ui/src/watch/videos/video-player/index.tsx
@@ -26,7 +26,14 @@ const RESUME_END_THRESHOLD_SECONDS = 10;
 
 // Lazy load the VideoJS component that contains video.js
 // const VideoJS = lazy(() => import('./videojs'));
-const ReactPlayer = lazy(() => import('react-player'));
+// react-player is CJS; rolldown-vite's prebundle exposes its exports object as
+// the ESM default instead of unwrapping `.default`, so unwrap both shapes here.
+const ReactPlayer = lazy(async () => {
+  const mod = await import('react-player');
+  const unwrapped = (mod.default as unknown as { default?: typeof mod.default })
+    .default;
+  return { default: unwrapped ?? mod.default };
+});
 
 interface VideoPlayerProps {
   video: PlayableVideo;


### PR DESCRIPTION
## Summary

Fixes the Watch app's video page crashing the moment it opens (blank page with an error) — broken since the vite 8 upgrade (#372), independent of the MUI work. The video player library is loaded lazily, and vite 8's new bundler hands it over in a different wrapper shape; the player now unwraps both shapes. Verified live against a running Watch dev server on the affected page. SWO-373.

## Test plan

- [ ] Open the **Watch** app, click any video. The page renders and the video plays (before: instant crash to error screen)
- [ ] ui tests green (556)
- [ ] CI green