### PR TITLE
build(ui): upgrade MUI 6 to 9 with per-major codemods

### DIFF
--- a/apps/main/src/routes/finance.lazy.tsx
+++ b/apps/main/src/routes/finance.lazy.tsx
@@ -171,11 +171,17 @@ const Content = () => {
       <Container maxWidth="xl">
         <Grid
           container
-          justifyContent="space-between"
-          alignItems="center"
-          sx={{ mb: 4 }}
+          sx={{
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            mb: 4,
+          }}
         >
-          <Typography variant="h4" component="h1" fontWeight="bold" py={2}>
+          <Typography
+            variant="h4"
+            component="h1"
+            sx={{ fontWeight: 'bold', py: 2 }}
+          >
             Finance Dashboard
           </Typography>
 
@@ -193,10 +199,10 @@ const Content = () => {
       <Container maxWidth="xl" component="main" sx={{ mb: 12 }}>
         <Grid container spacing={3}>
           {/* Summary Cards */}
-          <Grid item xs={12}>
+          <Grid size={12}>
             <Grid container spacing={2}>
               {categories?.map((data) => (
-                <Grid item xs={6} md={3} key={data.category}>
+                <Grid size={{ xs: 6, md: 3 }} key={data.category}>
                   <SummaryCard
                     isLoading={isLoading}
                     category={data.category}
@@ -211,7 +217,7 @@ const Content = () => {
           </Grid>
 
           {/* Charts Section */}
-          <Grid item xs={12} md={6}>
+          <Grid size={{ xs: 12, md: 6 }}>
             <SpendingBreakdown
               isLoading={isLoading}
               categoryData={data?.categories}
@@ -220,7 +226,7 @@ const Content = () => {
             />
           </Grid>
 
-          {/* <Grid item xs={12} md={6}>
+          {/* <Grid size={{ xs: 12, md: 6 }}>
             <MonthComparison data={monthlyData} currentMonthIndex={currentMonthIndex} />
           </Grid> */}
         </Grid>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -65,8 +65,8 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
-    "@mui/icons-material": "^6.0.0",
-    "@mui/material": "^6.0.0",
+    "@mui/icons-material": "^9.1.1",
+    "@mui/material": "^9.1.2",
     "@tanstack/react-router": "^1.170.16",
     "core": "workspace:*",
     "echarts": "^6.1.0",

--- a/packages/ui/src/game/minimalism/containers/card-list/CardList.tsx
+++ b/packages/ui/src/game/minimalism/containers/card-list/CardList.tsx
@@ -15,7 +15,14 @@ const CardList = (props: CardListProps) => {
     <Box sx={{ width: '100%' }}>
       <Grid container rowSpacing={1} columnSpacing={{ xs: 1, sm: 2, md: 3 }}>
         {items.map((item) => (
-          <Grid item xs={6} md={3} xl={3} key={item.id}>
+          <Grid
+            key={item.id}
+            size={{
+              xs: 6,
+              md: 3,
+              xl: 3,
+            }}
+          >
             <GameCard {...item} />
           </Grid>
         ))}

--- a/packages/ui/src/game/minimalism/containers/home/HomeContainer.tsx
+++ b/packages/ui/src/game/minimalism/containers/home/HomeContainer.tsx
@@ -16,9 +16,18 @@ const HomeContainer = (props: HomeContainerProps) => {
       {/* <Helmet>
         <title>{htmlTitle}</title>
       </Helmet> */}
-
-      <Box my={4}>
-        <Typography variant="h3" component="h1" fontWeight={700}>
+      <Box
+        sx={{
+          my: 4,
+        }}
+      >
+        <Typography
+          variant="h3"
+          component="h1"
+          sx={{
+            fontWeight: 700,
+          }}
+        >
           Just play
         </Typography>
       </Box>

--- a/packages/ui/src/game/minimalism/dialogs/signin/SignIn.tsx
+++ b/packages/ui/src/game/minimalism/dialogs/signin/SignIn.tsx
@@ -21,7 +21,11 @@ const SignIn = (props: SignInProps) => {
           image="/assets/beach.png"
           title="beach"
         />
-        <Box mt={2}>
+        <Box
+          sx={{
+            mt: 2,
+          }}
+        >
           <Button
             fullWidth
             variant="outlined"

--- a/packages/ui/src/journal/edit-dialog/index.tsx
+++ b/packages/ui/src/journal/edit-dialog/index.tsx
@@ -29,7 +29,6 @@ const EditDialog = (props: EditDialogProps) => {
         }
         onClose();
       }}
-      disableEscapeKeyDown
       keepMounted
       fullWidth
       fullScreen={isMobile}

--- a/packages/ui/src/journal/journal-detail/index.tsx
+++ b/packages/ui/src/journal/journal-detail/index.tsx
@@ -2,7 +2,7 @@
 
 // MUI Icons imports
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
-import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutlined';
 import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import AppBar from '@mui/material/AppBar';
@@ -17,7 +17,6 @@ import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Paper from '@mui/material/Paper';
 import Skeleton from '@mui/material/Skeleton';
-import { alpha } from '@mui/material/styles';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import type { Journal, MoodType } from 'core/src/journal';
@@ -112,9 +111,13 @@ const JournalDetail: React.FC<JournalDetailProps> = ({
           </IconButton>
           <Typography variant="h6">Journal Entry</Typography>
         </Box>
-
         <Paper sx={{ p: 3, borderRadius: 3, textAlign: 'center' }}>
-          <Typography variant="body1" color="text.secondary">
+          <Typography
+            variant="body1"
+            sx={{
+              color: 'text.secondary',
+            }}
+          >
             Journal entry not found.
           </Typography>
         </Paper>
@@ -154,7 +157,6 @@ const JournalDetail: React.FC<JournalDetailProps> = ({
           </Typography>
         </Toolbar>
       </AppBar>
-
       <Container maxWidth={CONTENT_MAX_WIDTH} sx={{ pt: 2, pb: 8 }}>
         <Paper sx={{ p: 3, borderRadius: 3 }}>
           <Box
@@ -176,7 +178,7 @@ const JournalDetail: React.FC<JournalDetailProps> = ({
                   // (a background-image), so clear it before applying our tint.
                   backgroundImage: 'none',
                   bgcolor: (theme) =>
-                    alpha(theme.palette[mood.color].main, 0.12),
+                    theme.alpha(theme.palette[mood.color].main, 0.12),
                   border: 'none',
                   '& .MuiChip-icon': { color: 'inherit', ml: 0.5 },
                 }}
@@ -246,7 +248,12 @@ const JournalDetail: React.FC<JournalDetailProps> = ({
 
           <Divider sx={{ mt: 3, mb: 1.5 }} />
 
-          <Typography variant="caption" color="text.secondary">
+          <Typography
+            variant="caption"
+            sx={{
+              color: 'text.secondary',
+            }}
+          >
             {isEdited
               ? `Edited ${formatDateTime(journal.updatedAt)}`
               : formatDateTime(journal.createdAt)}

--- a/packages/ui/src/journal/journal-edit/index.tsx
+++ b/packages/ui/src/journal/journal-edit/index.tsx
@@ -4,7 +4,6 @@ import SentimentVeryDissatisfiedIcon from '@mui/icons-material/SentimentVeryDiss
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
-import { alpha } from '@mui/material/styles';
 import TextField from '@mui/material/TextField';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
@@ -138,11 +137,11 @@ export const JournalEdit: React.FC<JournalEditProps> = ({
               color: 'error.main',
               '&.Mui-selected': {
                 backgroundColor: (theme) =>
-                  alpha(theme.palette.error.main, 0.16),
+                  theme.alpha(theme.palette.error.main, 0.16),
                 color: 'error.main',
                 '&:hover': {
                   backgroundColor: (theme) =>
-                    alpha(theme.palette.error.main, 0.24),
+                    theme.alpha(theme.palette.error.main, 0.24),
                 },
               },
             }}
@@ -156,11 +155,11 @@ export const JournalEdit: React.FC<JournalEditProps> = ({
               color: 'info.main',
               '&.Mui-selected': {
                 backgroundColor: (theme) =>
-                  alpha(theme.palette.info.main, 0.16),
+                  theme.alpha(theme.palette.info.main, 0.16),
                 color: 'info.main',
                 '&:hover': {
                   backgroundColor: (theme) =>
-                    alpha(theme.palette.info.main, 0.24),
+                    theme.alpha(theme.palette.info.main, 0.24),
                 },
               },
             }}
@@ -174,11 +173,11 @@ export const JournalEdit: React.FC<JournalEditProps> = ({
               color: 'success.main',
               '&.Mui-selected': {
                 backgroundColor: (theme) =>
-                  alpha(theme.palette.success.main, 0.16),
+                  theme.alpha(theme.palette.success.main, 0.16),
                 color: 'success.main',
                 '&:hover': {
                   backgroundColor: (theme) =>
-                    alpha(theme.palette.success.main, 0.24),
+                    theme.alpha(theme.palette.success.main, 0.24),
                 },
               },
             }}

--- a/packages/ui/src/journal/journal-list/index.tsx
+++ b/packages/ui/src/journal/journal-list/index.tsx
@@ -122,16 +122,32 @@ export const JournalList: React.FC<JournalListProps> = ({
             >
               {icon}
             </Box>
-            <Typography variant="body2" fontWeight="medium">
+            <Typography
+              variant="body2"
+              sx={{
+                fontWeight: 'medium',
+              }}
+            >
               {label}
             </Typography>
           </Box>
 
-          <Typography variant="h5" component="div" fontWeight="bold">
+          <Typography
+            variant="h5"
+            component="div"
+            sx={{
+              fontWeight: 'bold',
+            }}
+          >
             {count}
           </Typography>
 
-          <Typography variant="caption" color="text.secondary">
+          <Typography
+            variant="caption"
+            sx={{
+              color: 'text.secondary',
+            }}
+          >
             entries this month
           </Typography>
         </CardContent>
@@ -156,7 +172,12 @@ export const JournalList: React.FC<JournalListProps> = ({
             }}
           >
             <Box>
-              <Typography variant="body1" fontWeight="medium">
+              <Typography
+                variant="body1"
+                sx={{
+                  fontWeight: 'medium',
+                }}
+              >
                 {formatDate(journal.date)}
               </Typography>
               <Box
@@ -181,8 +202,8 @@ export const JournalList: React.FC<JournalListProps> = ({
 
           <Typography
             variant="body2"
-            color="text.secondary"
             sx={{
+              color: 'text.secondary',
               mt: 1,
               overflow: 'hidden',
               textOverflow: 'ellipsis',
@@ -232,7 +253,12 @@ export const JournalList: React.FC<JournalListProps> = ({
           mb: 3,
         }}
       >
-        <Typography variant="h5" fontWeight="bold">
+        <Typography
+          variant="h5"
+          sx={{
+            fontWeight: 'bold',
+          }}
+        >
           Journals
         </Typography>
 
@@ -250,7 +276,6 @@ export const JournalList: React.FC<JournalListProps> = ({
           </IconButton>
         </Box>
       </Box>
-
       {/* Stats Cards */}
       <Box
         sx={{
@@ -280,11 +305,15 @@ export const JournalList: React.FC<JournalListProps> = ({
               renderStatCard(category.mood, category.count),
             )}
       </Box>
-
-      <Typography variant="h6" fontWeight="medium" sx={{ mb: 2 }}>
+      <Typography
+        variant="h6"
+        sx={{
+          fontWeight: 'medium',
+          mb: 2,
+        }}
+      >
         Recent Entries
       </Typography>
-
       {isLoading ? (
         Array(3)
           .fill(0)
@@ -299,10 +328,20 @@ export const JournalList: React.FC<JournalListProps> = ({
             bgcolor: 'background.default',
           }}
         >
-          <Typography variant="body1" color="text.secondary">
+          <Typography
+            variant="body1"
+            sx={{
+              color: 'text.secondary',
+            }}
+          >
             No journal entries for this month.
           </Typography>
-          <Typography variant="body2" color="text.secondary">
+          <Typography
+            variant="body2"
+            sx={{
+              color: 'text.secondary',
+            }}
+          >
             Click the + button to create your first entry.
           </Typography>
         </Paper>

--- a/packages/ui/src/listen/minimalism/collection-select/index.stories.tsx
+++ b/packages/ui/src/listen/minimalism/collection-select/index.stories.tsx
@@ -10,7 +10,11 @@ const meta: Meta<typeof CollectionSelect> = {
   },
   decorators: [
     (Story) => (
-      <Box width={'240px'}>
+      <Box
+        sx={{
+          width: '240px',
+        }}
+      >
         <Story />
       </Box>
     ),

--- a/packages/ui/src/listen/minimalism/home/audio-list.tsx
+++ b/packages/ui/src/listen/minimalism/home/audio-list.tsx
@@ -91,7 +91,7 @@ const Content = (props: AudioListProps) => {
   return (
     <Grid container spacing={2}>
       {showPlayingList && (
-        <Grid item md={8} sm={6} xs={0}>
+        <Grid size={{ md: 8, sm: 6 }}>
           <Card
             elevation={0}
             sx={{
@@ -112,7 +112,17 @@ const Content = (props: AudioListProps) => {
           </Card>
         </Grid>
       )}
-      <Grid item md={4} sm={6} xs={12} container justifyContent="center">
+      <Grid
+        container
+        size={{
+          md: 4,
+          sm: 6,
+          xs: 12,
+        }}
+        sx={{
+          justifyContent: 'center',
+        }}
+      >
         <MusicWidget
           audioList={list}
           hookResult={hookResult}
@@ -132,12 +142,21 @@ const AudioList = (props: AudioListProps) => {
     return (
       <Grid container spacing={2}>
         {!isMobile && (
-          <Grid item md={8} sm={6} xs={0}>
+          <Grid size={{ md: 8, sm: 6 }}>
             <PlayingListSkeleton />
           </Grid>
         )}
-
-        <Grid item md={4} sm={6} xs={12} container justifyContent="center">
+        <Grid
+          container
+          size={{
+            md: 4,
+            sm: 6,
+            xs: 12,
+          }}
+          sx={{
+            justifyContent: 'center',
+          }}
+        >
           <MusicWidgetSkeleton />
         </Grid>
       </Grid>

--- a/packages/ui/src/listen/minimalism/home/feeling-list/index.stories.tsx
+++ b/packages/ui/src/listen/minimalism/home/feeling-list/index.stories.tsx
@@ -10,7 +10,11 @@ const meta: Meta<typeof FeelingList> = {
   },
   decorators: [
     (Story) => (
-      <Box width={'600px'}>
+      <Box
+        sx={{
+          width: '600px',
+        }}
+      >
         <Story />
       </Box>
     ),

--- a/packages/ui/src/listen/minimalism/home/feeling-list/skeleton.tsx
+++ b/packages/ui/src/listen/minimalism/home/feeling-list/skeleton.tsx
@@ -4,11 +4,13 @@ import Skeleton from '@mui/material/Skeleton';
 const FeelingListSkeleton = () => {
   return (
     <Box
-      display="flex"
-      gap={1.5}
-      my={2}
       role="status"
       aria-label="Loading feelings list"
+      sx={{
+        display: 'flex',
+        gap: 1.5,
+        my: 2,
+      }}
     >
       {[1, 2, 3, 4, 5].map((item) => (
         <Skeleton key={item} variant="rounded" width={66} height={32} />

--- a/packages/ui/src/listen/minimalism/home/playing-list-skeleton.stories.tsx
+++ b/packages/ui/src/listen/minimalism/home/playing-list-skeleton.stories.tsx
@@ -10,7 +10,11 @@ const meta: Meta<typeof PlayingListSkeleton> = {
   },
   decorators: [
     (Story) => (
-      <Box width={'600px'}>
+      <Box
+        sx={{
+          width: '600px',
+        }}
+      >
         <Story />
       </Box>
     ),

--- a/packages/ui/src/listen/minimalism/home/playing-list.stories.tsx
+++ b/packages/ui/src/listen/minimalism/home/playing-list.stories.tsx
@@ -11,7 +11,11 @@ const meta: Meta<typeof PlayingList> = {
   },
   decorators: [
     (Story) => (
-      <Box width={'600px'}>
+      <Box
+        sx={{
+          width: '600px',
+        }}
+      >
         <Story />
       </Box>
     ),

--- a/packages/ui/src/listen/minimalism/home/playing-list.tsx
+++ b/packages/ui/src/listen/minimalism/home/playing-list.tsx
@@ -109,19 +109,31 @@ const Item = (props: ItemProps) => {
       </ListItemAvatar>
       <ListItemText
         primary={name}
-        primaryTypographyProps={{
-          fontWeight: 600,
-          color: isPlaying ? 'primary.main' : 'text.primary',
-          noWrap: true,
+        slotProps={{
+          primary: {
+            noWrap: true,
+            sx: {
+              fontWeight: 600,
+              color: isPlaying ? 'primary.main' : 'text.primary',
+            },
+          },
         }}
         secondary={
           <Stack
             component="span"
             direction="row"
             spacing={1}
-            alignItems="center"
+            sx={{
+              alignItems: 'center',
+            }}
           >
-            <Typography component="span" variant="body2" color="text.secondary">
+            <Typography
+              component="span"
+              variant="body2"
+              sx={{
+                color: 'text.secondary',
+              }}
+            >
               {artistName}
             </Typography>
             {isPlaying && <NowPlayingIndicator />}

--- a/packages/ui/src/listen/minimalism/music-widget/music-widget-skeleton.tsx
+++ b/packages/ui/src/listen/minimalism/music-widget/music-widget-skeleton.tsx
@@ -10,14 +10,22 @@ const MusicWidgetSkeleton = () => {
       aria-label="Loading music player"
       aria-busy="true"
     >
-      <Box p={2}>
+      <Box
+        sx={{
+          p: 2,
+        }}
+      >
         <Skeleton
           variant="rectangular"
           width="100%"
           height={194}
           animation="wave"
         />
-        <Box mt={2}>
+        <Box
+          sx={{
+            mt: 2,
+          }}
+        >
           <Skeleton variant="text" width="20%" animation="wave" />
           <Skeleton
             sx={{ fontSize: '2rem' }}

--- a/packages/ui/src/listen/minimalism/music-widget/music-widget.tsx
+++ b/packages/ui/src/listen/minimalism/music-widget/music-widget.tsx
@@ -139,8 +139,10 @@ const MusicWidget = (props: MusicWidgetProps) => {
             aria-label="audio artist"
             variant="body2"
             align="center"
-            color="text.secondary"
             gutterBottom
+            sx={{
+              color: 'text.secondary',
+            }}
           >
             {artistName}
           </Typography>

--- a/packages/ui/src/listen/minimalism/music-widget/playing-list.tsx
+++ b/packages/ui/src/listen/minimalism/music-widget/playing-list.tsx
@@ -29,7 +29,13 @@ const PlayingList = (
   return (
     <StyledPlayingList ref={ref}>
       <Divider />
-      <Box height="100%" pb={2} mb={2}>
+      <Box
+        sx={{
+          height: '100%',
+          pb: 2,
+          mb: 2,
+        }}
+      >
         <List aria-label="audio tracks" role="listbox">
           {audioList.map((a) => {
             const selected = a.id === currentId;

--- a/packages/ui/src/main/home-page/landing-grid/index.test.tsx
+++ b/packages/ui/src/main/home-page/landing-grid/index.test.tsx
@@ -72,11 +72,13 @@ describe('LandingGrid', () => {
     expect(container).toBeInTheDocument();
 
     // Check for Grid items with correct props
-    const items = document.querySelectorAll('.MuiGrid-item');
+    const items = document.querySelectorAll(
+      '.MuiGrid-root:not(.MuiGrid-container)',
+    );
     expect(items.length).toBe(4);
 
     items.forEach((item) => {
-      // Check for xs={6} and md={3} classes
+      // Check for size={{ xs: 6, md: 3 }} classes
       expect(item.className).toContain('MuiGrid-grid-xs-6');
       expect(item.className).toContain('MuiGrid-grid-md-3');
     });

--- a/packages/ui/src/main/home-page/landing-grid/index.tsx
+++ b/packages/ui/src/main/home-page/landing-grid/index.tsx
@@ -9,9 +9,21 @@ interface LandingGridProps {
 
 const LandingGrid = ({ items, LinkComponent }: LandingGridProps) => {
   return (
-    <Grid container spacing={2} my={2}>
+    <Grid
+      container
+      spacing={2}
+      sx={{
+        my: 2,
+      }}
+    >
       {items.map((item) => (
-        <Grid item xs={6} md={3} key={item.to}>
+        <Grid
+          key={item.to}
+          size={{
+            xs: 6,
+            md: 3,
+          }}
+        >
           <LandingCard
             icon={item.icon}
             title={item.title}

--- a/packages/ui/src/main/home-page/month-comparison/index.tsx
+++ b/packages/ui/src/main/home-page/month-comparison/index.tsx
@@ -132,7 +132,12 @@ const MonthComparison = ({ data, currentMonthIndex }: MonthComparisonProps) => {
                 {percentage.toFixed(1)}%
               </Typography>
             </Box>
-            <Typography variant="body2" color="text.secondary">
+            <Typography
+              variant="body2"
+              sx={{
+                color: 'text.secondary',
+              }}
+            >
               {isIncrease ? 'more than' : 'less than'} last month
             </Typography>
           </Box>
@@ -148,7 +153,12 @@ const MonthComparison = ({ data, currentMonthIndex }: MonthComparisonProps) => {
                 justifyContent: 'center',
               }}
             >
-              <Typography variant="body1" color="text.secondary">
+              <Typography
+                variant="body1"
+                sx={{
+                  color: 'text.secondary',
+                }}
+              >
                 No data available
               </Typography>
             </Box>

--- a/packages/ui/src/main/home-page/month-selector/index.tsx
+++ b/packages/ui/src/main/home-page/month-selector/index.tsx
@@ -35,7 +35,13 @@ const MonthSelector = ({
         <ChevronLeft />
       </IconButton>
 
-      <Typography variant="h6" component="div" fontWeight="medium">
+      <Typography
+        variant="h6"
+        component="div"
+        sx={{
+          fontWeight: 'medium',
+        }}
+      >
         {displayMonth}
       </Typography>
 

--- a/packages/ui/src/main/home-page/spending-breakdown/donut-chart.tsx
+++ b/packages/ui/src/main/home-page/spending-breakdown/donut-chart.tsx
@@ -176,7 +176,6 @@ const DonutChart = ({
         opts={{ renderer: 'canvas' }}
         onEvents={handleChartEvents}
       />
-
       {/* Center text */}
       <Box
         sx={{
@@ -188,7 +187,12 @@ const DonutChart = ({
           pointerEvents: 'none', // So clicks pass through to the chart
         }}
       >
-        <Typography variant="body2" color="text.secondary">
+        <Typography
+          variant="body2"
+          sx={{
+            color: 'text.secondary',
+          }}
+        >
           Total
         </Typography>
         <Typography variant="h6" sx={{ fontWeight: 'bold' }}>

--- a/packages/ui/src/main/home-page/summary-card/index.tsx
+++ b/packages/ui/src/main/home-page/summary-card/index.tsx
@@ -53,7 +53,12 @@ const SummaryCard = (props: SummaryCardProps) => {
           {formatNumber(amount)}
         </StyledAmount>
 
-        <Typography variant="body2" color="text.secondary">
+        <Typography
+          variant="body2"
+          sx={{
+            color: 'text.secondary',
+          }}
+        >
           {count > 0
             ? `${count} transaction${count !== 1 ? 's' : ''}`
             : '\u00A0'}

--- a/packages/ui/src/main/home-page/summary-card/skeleton.test.tsx
+++ b/packages/ui/src/main/home-page/summary-card/skeleton.test.tsx
@@ -43,8 +43,8 @@ vi.mock('@mui/material', () => ({
       data-height={height}
     />
   ),
-  Typography: ({ children, variant, color }: any) => (
-    <div data-testid={`typography-${variant}`} data-color={color}>
+  Typography: ({ children, variant, sx }: any) => (
+    <div data-testid={`typography-${variant}`} data-color={sx?.color}>
       {children}
     </div>
   ),

--- a/packages/ui/src/main/home-page/summary-card/skeleton.tsx
+++ b/packages/ui/src/main/home-page/summary-card/skeleton.tsx
@@ -27,7 +27,12 @@ const SummaryCardSkeleton = () => {
           <Skeleton width={100} height={40} />
         </StyledAmount>
 
-        <Typography variant="body2" color="text.secondary">
+        <Typography
+          variant="body2"
+          sx={{
+            color: 'text.secondary',
+          }}
+        >
           <Skeleton width={80} />
         </Typography>
       </CardContent>

--- a/packages/ui/src/main/home-page/transactions-dialog/index.tsx
+++ b/packages/ui/src/main/home-page/transactions-dialog/index.tsx
@@ -114,11 +114,14 @@ const TransactionsDialog = ({
           </IconButton>
         </DialogTitle>
       )}
-
       <DialogContent dividers sx={{ p: 0 }}>
         {filteredTransactions.length === 0 ? (
           <Box sx={{ py: 4, textAlign: 'center' }}>
-            <Typography color="text.secondary">
+            <Typography
+              sx={{
+                color: 'text.secondary',
+              }}
+            >
               No expenses found for this category
             </Typography>
           </Box>
@@ -146,7 +149,12 @@ const TransactionsDialog = ({
                     <Typography variant="subtitle1">
                       {transaction.name}
                     </Typography>
-                    <Typography variant="caption" color="text.secondary">
+                    <Typography
+                      variant="caption"
+                      sx={{
+                        color: 'text.secondary',
+                      }}
+                    >
                       {new Date(transaction.createdAt).toLocaleDateString()}
                     </Typography>
                   </Box>
@@ -167,7 +175,12 @@ const TransactionsDialog = ({
                         ),
                       }}
                     >
-                      <Typography variant="body2" fontSize="0.75rem">
+                      <Typography
+                        variant="body2"
+                        sx={{
+                          fontSize: '0.75rem',
+                        }}
+                      >
                         {
                           getCategoryLabel(
                             transaction.category as CategoryType,
@@ -175,7 +188,12 @@ const TransactionsDialog = ({
                         }
                       </Typography>
                     </Box>
-                    <Typography variant="subtitle1" fontWeight="bold">
+                    <Typography
+                      variant="subtitle1"
+                      sx={{
+                        fontWeight: 'bold',
+                      }}
+                    >
                       {formatNumber(transaction.amount)}
                     </Typography>
                   </Box>
@@ -192,7 +210,12 @@ const TransactionsDialog = ({
                       borderRadius: 1,
                     }}
                   >
-                    <Typography variant="body2" color="text.secondary">
+                    <Typography
+                      variant="body2"
+                      sx={{
+                        color: 'text.secondary',
+                      }}
+                    >
                       {transaction.note}
                     </Typography>
                   </Box>

--- a/packages/ui/src/main/library-page/book-card/index.tsx
+++ b/packages/ui/src/main/library-page/book-card/index.tsx
@@ -127,13 +127,12 @@ const BookCard: React.FC<BookCardProps> = ({ book, onClick }) => {
             </Box>
           )}
       </Box>
-
       {/* Book Info */}
       <Box>
         <Typography
           variant="body2"
-          fontWeight="medium"
           sx={{
+            fontWeight: 'medium',
             mb: 0.5,
             lineHeight: 1.3,
             display: '-webkit-box',
@@ -144,7 +143,12 @@ const BookCard: React.FC<BookCardProps> = ({ book, onClick }) => {
         >
           {book.title}
         </Typography>
-        <Typography variant="caption" color="text.secondary">
+        <Typography
+          variant="caption"
+          sx={{
+            color: 'text.secondary',
+          }}
+        >
           {book.author}
         </Typography>
       </Box>

--- a/packages/ui/src/main/library-page/home-books-grid/index.tsx
+++ b/packages/ui/src/main/library-page/home-books-grid/index.tsx
@@ -125,11 +125,18 @@ const BooksGridSkeleton = ({ count = 12 }: { count?: number }) => {
           </Box>
         </Box>
       </Box>
-
       {/* Books Grid Skeleton */}
       <Grid container spacing={{ xs: 2, md: 3 }}>
         {Array.from({ length: count }).map((_, index) => (
-          <Grid item xs={6} sm={4} md={3} lg={2} key={`skeleton-${index}`}>
+          <Grid
+            key={`skeleton-${index}`}
+            size={{
+              xs: 6,
+              sm: 4,
+              md: 3,
+              lg: 2,
+            }}
+          >
             <BookCardSkeleton />
           </Grid>
         ))}
@@ -184,7 +191,6 @@ const BooksGridEmpty = () => {
           </Box>
         </Box>
       </Box>
-
       {/* Empty State */}
       <Box
         sx={{
@@ -211,13 +217,20 @@ const BooksGridEmpty = () => {
 
         <Typography
           variant="h4"
-          fontSize="1.25rem"
-          fontWeight="medium"
-          sx={{ mb: 1 }}
+          sx={{
+            fontSize: '1.25rem',
+            fontWeight: 'medium',
+            mb: 1,
+          }}
         >
           No books in your library
         </Typography>
-        <Typography color="text.secondary" fontSize="0.875rem">
+        <Typography
+          sx={{
+            color: 'text.secondary',
+            fontSize: '0.875rem',
+          }}
+        >
           Add your first book to start building your personal library
         </Typography>
       </Box>
@@ -295,11 +308,18 @@ const BooksGrid: React.FC<BooksGridProps> = (props) => {
           </Box>
         </Box>
       </Box>
-
       {/* Books Grid */}
       <Grid container spacing={{ xs: 2, md: 3 }}>
         {books?.map((book) => (
-          <Grid item xs={6} sm={4} md={3} lg={2} key={book.id}>
+          <Grid
+            key={book.id}
+            size={{
+              xs: 6,
+              sm: 4,
+              md: 3,
+              lg: 2,
+            }}
+          >
             <BookCard book={book} onClick={onBookClick} />
           </Grid>
         ))}
@@ -307,7 +327,6 @@ const BooksGrid: React.FC<BooksGridProps> = (props) => {
           <BookCardSkeleton />
         </Grid> */}
       </Grid>
-
       {/* Load More */}
       {hasMore && (
         <Box sx={{ textAlign: 'center', mt: 4 }}>

--- a/packages/ui/src/main/library-page/home-continue-reading/index.tsx
+++ b/packages/ui/src/main/library-page/home-continue-reading/index.tsx
@@ -213,13 +213,20 @@ const ContinueReadingEmpty = () => {
 
               <Typography
                 variant="h4"
-                fontSize="1.125rem"
-                fontWeight="medium"
-                sx={{ mb: 0.5 }}
+                sx={{
+                  fontSize: '1.125rem',
+                  fontWeight: 'medium',
+                  mb: 0.5,
+                }}
               >
                 No books in progress
               </Typography>
-              <Typography color="text.secondary" fontSize="0.875rem">
+              <Typography
+                sx={{
+                  color: 'text.secondary',
+                  fontSize: '0.875rem',
+                }}
+              >
                 Start reading a book to see your progress here
               </Typography>
             </Box>
@@ -299,9 +306,9 @@ const ContinueReading: React.FC<ContinueReadingProps> = ({
               <Box sx={{ flex: 1, minWidth: 0 }}>
                 <Typography
                   variant="h4"
-                  fontSize={{ xs: '1rem', sm: '1.125rem' }}
-                  fontWeight="medium"
                   sx={{
+                    fontSize: { xs: '1rem', sm: '1.125rem' },
+                    fontWeight: 'medium',
                     mb: 0.5,
                     lineHeight: 1.3,
                   }}
@@ -309,9 +316,11 @@ const ContinueReading: React.FC<ContinueReadingProps> = ({
                   {book.title}
                 </Typography>
                 <Typography
-                  color="text.secondary"
-                  fontSize={{ xs: '0.8125rem', sm: '0.875rem' }}
-                  sx={{ mb: { xs: 1, sm: 1.5 } }}
+                  sx={{
+                    color: 'text.secondary',
+                    fontSize: { xs: '0.8125rem', sm: '0.875rem' },
+                    mb: { xs: 1, sm: 1.5 },
+                  }}
                 >
                   by {book.author}
                 </Typography>
@@ -320,8 +329,10 @@ const ContinueReading: React.FC<ContinueReadingProps> = ({
                 <Box sx={{ display: { xs: 'block', sm: 'none' }, mb: 1 }}>
                   <Typography
                     variant="body2"
-                    color="text.secondary"
-                    fontSize="0.8125rem"
+                    sx={{
+                      color: 'text.secondary',
+                      fontSize: '0.8125rem',
+                    }}
                   >
                     Last read {book.lastReadAt}
                   </Typography>
@@ -353,9 +364,11 @@ const ContinueReading: React.FC<ContinueReadingProps> = ({
                 />
                 <Typography
                   variant="body2"
-                  color="text.secondary"
-                  fontSize={{ xs: '0.8125rem', sm: '0.875rem' }}
-                  sx={{ whiteSpace: 'nowrap' }}
+                  sx={{
+                    color: 'text.secondary',
+                    fontSize: { xs: '0.8125rem', sm: '0.875rem' },
+                    whiteSpace: 'nowrap',
+                  }}
                 >
                   Page {book.currentPage} of {book.totalPages}
                 </Typography>
@@ -372,16 +385,20 @@ const ContinueReading: React.FC<ContinueReadingProps> = ({
             >
               <Typography
                 variant="body2"
-                color="text.secondary"
-                fontSize="0.875rem"
-                sx={{ mb: 0.5 }}
+                sx={{
+                  color: 'text.secondary',
+                  fontSize: '0.875rem',
+                  mb: 0.5,
+                }}
               >
                 Last read
               </Typography>
               <Typography
                 variant="body2"
-                fontWeight="medium"
-                fontSize="0.875rem"
+                sx={{
+                  fontWeight: 'medium',
+                  fontSize: '0.875rem',
+                }}
               >
                 {book.lastReadAt}
               </Typography>

--- a/packages/ui/src/main/library-page/home-stats/index.tsx
+++ b/packages/ui/src/main/library-page/home-stats/index.tsx
@@ -70,7 +70,13 @@ const StatsGridSkeleton = () => {
           const IconComponent = item.icon;
 
           return (
-            <Grid item xs={6} md={3} key={item.key}>
+            <Grid
+              key={item.key}
+              size={{
+                xs: 6,
+                md: 3,
+              }}
+            >
               <Card>
                 <CardContent sx={{ textAlign: 'center', p: 3 }}>
                   {/* Icon - Same as actual with muted colors */}
@@ -141,7 +147,13 @@ const StatsGrid: React.FC<StatsGridProps> = (props) => {
           }
 
           return (
-            <Grid item xs={6} md={3} key={item.key}>
+            <Grid
+              key={item.key}
+              size={{
+                xs: 6,
+                md: 3,
+              }}
+            >
               <Card>
                 <CardContent sx={{ textAlign: 'center', p: 3 }}>
                   <Box
@@ -164,7 +176,12 @@ const StatsGrid: React.FC<StatsGridProps> = (props) => {
                     {value ?? 0}
                     {item.suffix || ''}
                   </Typography>
-                  <Typography variant="body2" color="text.secondary">
+                  <Typography
+                    variant="body2"
+                    sx={{
+                      color: 'text.secondary',
+                    }}
+                  >
                     {item.label}
                   </Typography>
                 </CardContent>

--- a/packages/ui/src/main/library-page/reading-content/index.tsx
+++ b/packages/ui/src/main/library-page/reading-content/index.tsx
@@ -46,12 +46,16 @@ const ReadingContent = (props: ReadingContentProps) => {
           }}
         >
           <CircularProgress />
-          <Typography variant="body2" color="text.secondary">
+          <Typography
+            variant="body2"
+            sx={{
+              color: 'text.secondary',
+            }}
+          >
             Loading PDF...
           </Typography>
         </Box>
       )}
-
       {/* Error State */}
       {error && !isLoading && (
         <Box sx={{ width: '100%', maxWidth: 600, mt: 4 }}>
@@ -63,7 +67,6 @@ const ReadingContent = (props: ReadingContentProps) => {
           </Button>
         </Box>
       )}
-
       {notAvailable && (
         <Box
           sx={{
@@ -81,7 +84,6 @@ const ReadingContent = (props: ReadingContentProps) => {
           </Alert>
         </Box>
       )}
-
       {/* PDF Document */}
       {!error && !isLoading && pdfUrl && (
         <Box

--- a/packages/ui/src/til/editor/menu-bar.tsx
+++ b/packages/ui/src/til/editor/menu-bar.tsx
@@ -45,7 +45,13 @@ const EditorMenuBar = (props: EditorMenuBarProps) => {
   const { items } = props;
 
   return (
-    <Stack direction="row" spacing={0.5} alignItems="center">
+    <Stack
+      direction="row"
+      spacing={0.5}
+      sx={{
+        alignItems: 'center',
+      }}
+    >
       {items.map((item) =>
         item.type === 'divider' ? (
           <Box

--- a/packages/ui/src/til/editor/write-form.tsx
+++ b/packages/ui/src/til/editor/write-form.tsx
@@ -74,7 +74,9 @@ const WriteForm = (props: WriteFormProps) => {
         <Stack
           direction={{ xs: 'column', sm: 'row' }}
           spacing={2}
-          justifyContent="flex-end"
+          sx={{
+            justifyContent: 'flex-end',
+          }}
         >
           <Button
             variant="outlined"

--- a/packages/ui/src/til/home-container/index.tsx
+++ b/packages/ui/src/til/home-container/index.tsx
@@ -13,7 +13,15 @@ const Loading = () => {
       {Array(12)
         .fill(0)
         .map((_, i) => (
-          <Grid item xs={12} sm={6} md={4} lg={3} key={i}>
+          <Grid
+            key={i}
+            size={{
+              xs: 12,
+              sm: 6,
+              md: 4,
+              lg: 3,
+            }}
+          >
             <SkeletonPostCard />
           </Grid>
         ))}
@@ -39,7 +47,15 @@ const HomeContainer = (props: HomeContainerProps) => {
       ) : posts.length > 0 ? (
         <Grid container spacing={2}>
           {posts.map((p) => (
-            <Grid item xs={12} sm={6} md={4} lg={3} key={p.id}>
+            <Grid
+              key={p.id}
+              size={{
+                xs: 12,
+                sm: 6,
+                md: 4,
+                lg: 3,
+              }}
+            >
               <PostCard post={p} LinkComponent={Link} />
             </Grid>
           ))}

--- a/packages/ui/src/til/post-detail-page/edit-footer.tsx
+++ b/packages/ui/src/til/post-detail-page/edit-footer.tsx
@@ -21,7 +21,9 @@ const PostEditFooter = (props: PostEditFooterProps) => {
       <Stack
         direction={{ xs: 'column', sm: 'row' }}
         spacing={2}
-        justifyContent="flex-end"
+        sx={{
+          justifyContent: 'flex-end',
+        }}
       >
         <Button variant="outlined" onClick={onCancel} disabled={isSaving}>
           Cancel

--- a/packages/ui/src/til/post-detail-page/metadata.tsx
+++ b/packages/ui/src/til/post-detail-page/metadata.tsx
@@ -22,12 +22,15 @@ const PostMetadata = (props: Props) => {
         variant="h4"
         component="h1"
         gutterBottom
-        fontWeight="bold"
-        sx={sx}
+        sx={[
+          {
+            fontWeight: 'bold',
+          },
+          ...(Array.isArray(sx) ? sx : [sx]),
+        ]}
       >
         {title}
       </Typography>
-
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 2 }}>
         <Chip
           label={status || 'Published'}
@@ -36,19 +39,27 @@ const PostMetadata = (props: Props) => {
           variant="outlined"
         />
         {createdAt && (
-          <Typography variant="body2" color="text.secondary">
+          <Typography
+            variant="body2"
+            sx={{
+              color: 'text.secondary',
+            }}
+          >
             {formatDateTime(createdAt)}
           </Typography>
         )}
       </Box>
-
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
         <AccessTimeIcon fontSize="small" color="action" />
-        <Typography variant="body2" color="text.secondary">
+        <Typography
+          variant="body2"
+          sx={{
+            color: 'text.secondary',
+          }}
+        >
           {readTimeInMinutes} min read
         </Typography>
       </Box>
-
       <Divider />
     </>
   );

--- a/packages/ui/src/til/posts/post-card/index.tsx
+++ b/packages/ui/src/til/posts/post-card/index.tsx
@@ -22,9 +22,11 @@ export const PostCard = (props: PostCardProps) => {
         <CardContent>
           <Stack
             direction="row"
-            alignItems="flex-start"
-            justifyContent="space-between"
             spacing={1}
+            sx={{
+              alignItems: 'flex-start',
+              justifyContent: 'space-between',
+            }}
           >
             <Typography variant="h6" gutterBottom>
               {title}
@@ -40,12 +42,23 @@ export const PostCard = (props: PostCardProps) => {
           <StyledDescription variant="body2" color="text.secondary">
             {brief}
           </StyledDescription>
-          <Stack direction="row" spacing={2} alignItems="center">
+          <Stack
+            direction="row"
+            spacing={2}
+            sx={{
+              alignItems: 'center',
+            }}
+          >
             <ReadTimeBadge variant="caption">
               {readTimeInMinutes} min read
             </ReadTimeBadge>
             {createdAt && (
-              <Typography variant="caption" color="text.secondary">
+              <Typography
+                variant="caption"
+                sx={{
+                  color: 'text.secondary',
+                }}
+              >
                 {formatDateTime(createdAt)}
               </Typography>
             )}

--- a/packages/ui/src/universal/LoadingBackdrop/LoadingBackdrop.tsx
+++ b/packages/ui/src/universal/LoadingBackdrop/LoadingBackdrop.tsx
@@ -14,9 +14,21 @@ const LoadingBackdrop = (props: LoadingBackdropProps) => {
 
   return (
     <Backdrop {...props} open={true}>
-      <Box textAlign="center">
+      <Box
+        sx={{
+          textAlign: 'center',
+        }}
+      >
         <CircularProgress />
-        {!!message && <Typography color="common.white">{message}</Typography>}
+        {!!message && (
+          <Typography
+            sx={{
+              color: 'common.white',
+            }}
+          >
+            {message}
+          </Typography>
+        )}
       </Box>
     </Backdrop>
   );

--- a/packages/ui/src/universal/dialogs/login/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/universal/dialogs/login/__snapshots__/index.test.tsx.snap
@@ -17,12 +17,12 @@ exports[`LoginDialog > matches snapshot 1`] = `
           Welcome Back
         </h5>
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary css-orhv2b-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-sizeMedium MuiButton-colorPrimary css-orhv2b-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
           <span
-            class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1sh91j5-MuiButton-startIcon"
+            class="MuiButton-icon MuiButton-startIcon css-1lxyhll-MuiButton-startIcon"
           >
             <svg
               aria-hidden="true"

--- a/packages/ui/src/universal/dialogs/login/index.test.tsx
+++ b/packages/ui/src/universal/dialogs/login/index.test.tsx
@@ -55,7 +55,7 @@ describe('LoginDialog', () => {
 
     const button = screen.getByText('FLOW').closest('button');
     expect(button).toHaveClass('MuiButton-outlined');
-    expect(button).toHaveClass('MuiButton-outlinedPrimary');
+    expect(button).toHaveClass('MuiButton-colorPrimary');
   });
 
   it('renders dialog content with correct MUI classes', () => {

--- a/packages/ui/src/universal/dialogs/login/index.tsx
+++ b/packages/ui/src/universal/dialogs/login/index.tsx
@@ -18,7 +18,7 @@ export const LoginDialog = (props: LoginDialogProps) => {
   const { onAction } = props;
 
   return (
-    <Dialog open={true} onClose={() => {}} disableEscapeKeyDown={true}>
+    <Dialog open={true} onClose={() => {}}>
       <DialogContent sx={{ width: 400, maxWidth: '100%', py: 4 }}>
         <Box
           sx={{

--- a/packages/ui/src/universal/error-boundary/index.tsx
+++ b/packages/ui/src/universal/error-boundary/index.tsx
@@ -1,4 +1,4 @@
-import { ErrorOutline } from '@mui/icons-material';
+import { ErrorOutlined } from '@mui/icons-material';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
@@ -17,31 +17,48 @@ const ErrorFallback = (props: ErrorFallbackProps) => {
 
   return (
     <Box
-      display="flex"
-      alignItems="center"
-      justifyContent="center"
-      minHeight="100vh"
-      bgcolor="background.default"
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: '100vh',
+        bgcolor: 'background.default',
+      }}
     >
       <Container maxWidth="sm">
         <Card elevation={12}>
           <CardContent sx={{ textAlign: 'center' }}>
-            <ErrorOutline
+            <ErrorOutlined
               color="error"
               sx={{
                 fontSize: 80,
                 mb: 2,
               }}
             />
-            <Box textAlign="center" py={2}>
+            <Box
+              sx={{
+                textAlign: 'center',
+                py: 2,
+              }}
+            >
               <Typography variant="h5" component="h2" gutterBottom>
                 {texts.title}
               </Typography>
-              <Typography color="text.secondary" variant="body2" gutterBottom>
+              <Typography
+                variant="body2"
+                gutterBottom
+                sx={{
+                  color: 'text.secondary',
+                }}
+              >
                 {errorMessage}
               </Typography>
               {canRetry && (
-                <Box mt={3}>
+                <Box
+                  sx={{
+                    mt: 3,
+                  }}
+                >
                   <Button
                     variant="contained"
                     fullWidth

--- a/packages/ui/src/universal/font-analyzer/index.tsx
+++ b/packages/ui/src/universal/font-analyzer/index.tsx
@@ -69,14 +69,23 @@ const FontWeightAnalyzer = () => {
             <Typography variant="h6" className="mb-2">
               Weight {weight} ({count} occurrences)
             </Typography>
-            <Typography variant="body2" color="text.secondary">
+            <Typography
+              variant="body2"
+              sx={{
+                color: 'text.secondary',
+              }}
+            >
               Used in: {Array.from(components).join(', ')}
             </Typography>
           </Box>
         ))}
 
         {fontUsage.size === 0 && (
-          <Typography color="text.secondary">
+          <Typography
+            sx={{
+              color: 'text.secondary',
+            }}
+          >
             Analyzing font usage... Interact with your app to see results.
           </Typography>
         )}

--- a/packages/ui/src/universal/images/responsive-image.stories.tsx
+++ b/packages/ui/src/universal/images/responsive-image.stories.tsx
@@ -81,7 +81,11 @@ export const CloudinaryImage: Story = {
   render: (args) => (
     <Box sx={{ border: '1px solid #ddd' }}>
       <ResponsiveImage {...args} />
-      <Box px={2}>
+      <Box
+        sx={{
+          px: 2,
+        }}
+      >
         <p>Responsive Cloudinary Image with automatic srcSet generation</p>
       </Box>
     </Box>
@@ -107,7 +111,11 @@ export const StandardImage: Story = {
   render: (args) => (
     <Box sx={{ border: '1px solid #ddd' }}>
       <ResponsiveImage {...args} />
-      <Box px={2}>
+      <Box
+        sx={{
+          px: 2,
+        }}
+      >
         <p>Standard image without Cloudinary-specific optimizations</p>
       </Box>
     </Box>
@@ -134,7 +142,11 @@ export const CustomSizesImage: Story = {
   render: (args) => (
     <Box sx={{ border: '1px solid #ddd' }}>
       <ResponsiveImage {...args} />
-      <Box px={2}>
+      <Box
+        sx={{
+          px: 2,
+        }}
+      >
         <p>Image with custom sizes and srcSet generation</p>
       </Box>
     </Box>
@@ -186,7 +198,11 @@ export const NoSourceImage: Story = {
   render: (args) => (
     <Box sx={{ border: '1px solid #ddd' }}>
       <ResponsiveImage {...args} />
-      <Box px={2}>
+      <Box
+        sx={{
+          px: 2,
+        }}
+      >
         <p>Handling scenario with no image source</p>
       </Box>
     </Box>

--- a/packages/ui/src/watch/dialogs/upload/dialog.tsx
+++ b/packages/ui/src/watch/dialogs/upload/dialog.tsx
@@ -262,16 +262,14 @@ const DialogComponent = (props: DialogComponentProps) => {
             onChange={onFormFieldChange('videoPositionInPlaylist')}
             {...videoPositionInPlaylistTextFieldProps}
             slotProps={{
-              input: {
-                inputProps: {
-                  min: 0,
-                },
+              htmlInput: {
+                min: 0,
               },
             }}
           />
 
           <Grid container spacing={1} sx={{ mt: 2, mb: 2 }}>
-            <Grid item xs={12}>
+            <Grid size={12}>
               <FormControlLabel
                 control={
                   <Checkbox
@@ -283,7 +281,7 @@ const DialogComponent = (props: DialogComponentProps) => {
                 label="Keep original source"
               />
             </Grid>
-            <Grid item xs={12}>
+            <Grid size={12}>
               <FormControlLabel
                 control={
                   <Checkbox

--- a/packages/ui/src/watch/dialogs/upload/styled.tsx
+++ b/packages/ui/src/watch/dialogs/upload/styled.tsx
@@ -19,7 +19,7 @@ export const StyledCloseButton = styled(IconButton)(({ theme }) => ({
 })) as typeof IconButton;
 
 export const StyledResultsStack = styled(Stack)(({ theme }) => {
-  const { borderRadius } = theme.shape;
+  const borderRadius = Number(theme.shape.borderRadius);
 
   return {
     maxHeight: '200px',

--- a/packages/ui/src/watch/header/notification-item.test.tsx
+++ b/packages/ui/src/watch/header/notification-item.test.tsx
@@ -1,4 +1,4 @@
-import { Link } from '@mui/material';
+import { Link, MenuList } from '@mui/material';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
@@ -24,10 +24,19 @@ describe('NotificationItem', () => {
     LinkComponent: Link,
   };
 
+  // MenuItems must live inside a Menu/MenuList since MUI v9 — mirror the
+  // production wrapping from notifications-menu.
+  const renderItem = (props: typeof defaultProps) =>
+    render(
+      <MenuList>
+        <NotificationItem {...props} />
+      </MenuList>,
+    );
+
   // Update test case for click handler
   it('calls onClick when clicked', async () => {
     const user = userEvent.setup();
-    render(<NotificationItem {...defaultProps} />);
+    renderItem(defaultProps);
 
     await user.click(screen.getByRole('menuitem'));
     expect(defaultProps.onClick).toHaveBeenCalledTimes(1); // Changed from onClose to onClick
@@ -36,7 +45,7 @@ describe('NotificationItem', () => {
   // Remove onClose references from read/unread tests
   describe('read/unread states', () => {
     it('shows unread state for notification without readAt', () => {
-      render(<NotificationItem {...defaultProps} />);
+      renderItem(defaultProps);
       const title = screen.getByText((content) =>
         content.includes(
           NOTIFICATION_TEXTS[NOTIFICATION_TYPES.VIDEO_READY].title,
@@ -54,7 +63,7 @@ describe('NotificationItem', () => {
         },
       };
 
-      render(<NotificationItem {...readProps} />);
+      renderItem(readProps);
 
       const title = screen.getByText((content) =>
         content.includes(
@@ -67,7 +76,7 @@ describe('NotificationItem', () => {
 
   describe('notification icons', () => {
     it('shows correct icon for video ready notification', () => {
-      const { container } = render(<NotificationItem {...defaultProps} />);
+      const { container } = renderItem(defaultProps);
       expect(container.textContent).toContain('🎥');
     });
 
@@ -80,7 +89,7 @@ describe('NotificationItem', () => {
         },
       };
 
-      const { container } = render(<NotificationItem {...unknownTypeProps} />);
+      const { container } = renderItem(unknownTypeProps);
       expect(container.textContent).toContain('📢');
     });
   });

--- a/packages/ui/src/watch/header/notifications-menu.tsx
+++ b/packages/ui/src/watch/header/notifications-menu.tsx
@@ -63,12 +63,16 @@ const NotificationsMenu = ({
         ))
       ) : (
         <MenuItem disabled>
-          <Typography variant="body2" color="text.secondary">
+          <Typography
+            variant="body2"
+            sx={{
+              color: 'text.secondary',
+            }}
+          >
             No notifications
           </Typography>
         </MenuItem>
       )}
-
       {(notifications.data?.length ?? 0) > 0 && (
         <>
           <Divider />

--- a/packages/ui/src/watch/history-page/container/index.tsx
+++ b/packages/ui/src/watch/history-page/container/index.tsx
@@ -11,7 +11,15 @@ const Loading = () => {
       {Array(12)
         .fill(0)
         .map((_, i) => (
-          <Grid item xs={12} sm={6} md={4} lg={3} key={i}>
+          <Grid
+            key={i}
+            size={{
+              xs: 12,
+              sm: 6,
+              md: 4,
+              lg: 3,
+            }}
+          >
             <VideoSkeleton />
           </Grid>
         ))}
@@ -32,7 +40,16 @@ const HistoryContainer = (props: HistoryContainerProps) => {
         {isLoading && <Loading />}
         {!isLoading &&
           videos.map((video) => (
-            <Grid item xs={12} sm={6} md={4} lg={3} xl={2.4} key={video.id}>
+            <Grid
+              key={video.id}
+              size={{
+                xs: 12,
+                sm: 6,
+                md: 4,
+                lg: 3,
+                xl: 2.4,
+              }}
+            >
               <VideoCard
                 video={video}
                 asLink={true}

--- a/packages/ui/src/watch/home-page/columns.ts
+++ b/packages/ui/src/watch/home-page/columns.ts
@@ -1,5 +1,5 @@
 // Single source of truth for the watch home-page grid responsive layout.
-// GRID_COLUMN_PROPS feeds the MUI <Grid item> size props; COLUMNS_PER_ROW is
+// GRID_COLUMN_PROPS feeds the MUI <Grid> `size` prop; COLUMNS_PER_ROW is
 // the matching number of cards that fit one row at each breakpoint — used to
 // slice the "Continue watching" row so it never wraps. Keep the two in sync.
 const GRID_COLUMN_PROPS = { xs: 12, sm: 6, md: 4, lg: 3, xl: 2.4 } as const;

--- a/packages/ui/src/watch/home-page/container/index.tsx
+++ b/packages/ui/src/watch/home-page/container/index.tsx
@@ -19,7 +19,7 @@ const Loading = () => {
   return (
     <>
       {SKELETON_KEYS.map((key) => (
-        <Grid item {...GRID_COLUMN_PROPS} key={key}>
+        <Grid size={GRID_COLUMN_PROPS} key={key}>
           <VideoSkeleton />
         </Grid>
       ))}
@@ -72,7 +72,13 @@ const HomeContainer = (props: HomeContainerProps) => {
             <HomeSearch onQueryChange={setQuery} />
           </Box>
           {noResults ? (
-            <Typography variant="body2" color="text.secondary" sx={{ py: 4 }}>
+            <Typography
+              variant="body2"
+              sx={{
+                color: 'text.secondary',
+                py: 4,
+              }}
+            >
               No videos match “{query.trim()}”.
             </Typography>
           ) : (
@@ -80,7 +86,7 @@ const HomeContainer = (props: HomeContainerProps) => {
               {isLoading && <Loading />}
               {!isLoading &&
                 filteredVideos.map((video) => (
-                  <Grid item {...GRID_COLUMN_PROPS} key={video.id}>
+                  <Grid size={GRID_COLUMN_PROPS} key={video.id}>
                     <VideoCard
                       video={video}
                       asLink={true}

--- a/packages/ui/src/watch/home-page/continue-watching/index.tsx
+++ b/packages/ui/src/watch/home-page/continue-watching/index.tsx
@@ -60,7 +60,7 @@ const ContinueWatchingSection = (props: ContinueWatchingSectionProps) => {
       </Box>
       <Grid container spacing={3}>
         {visibleVideos.map((video) => (
-          <Grid item {...GRID_COLUMN_PROPS} key={video.id}>
+          <Grid size={GRID_COLUMN_PROPS} key={video.id}>
             <VideoCard
               video={video}
               asLink={true}

--- a/packages/ui/src/watch/home-page/empty-state/index.tsx
+++ b/packages/ui/src/watch/home-page/empty-state/index.tsx
@@ -32,7 +32,13 @@ const WatchEmptyState = () => {
       }}
     >
       <CloudUpload sx={{ fontSize: 64, opacity: 0.4 }} />
-      <Typography variant="h6" component="p" color="text.primary">
+      <Typography
+        variant="h6"
+        component="p"
+        sx={{
+          color: 'text.primary',
+        }}
+      >
         No videos yet
       </Typography>
       <Typography variant="body2" sx={{ maxWidth: 360 }}>
@@ -47,7 +53,6 @@ const WatchEmptyState = () => {
           Upload a video
         </Button>
       )}
-
       {open && uploadEnabled && (
         <Suspense fallback={null}>
           <VideoUploadDialog open={open} onOpenChange={setOpen} />

--- a/packages/ui/src/watch/home-page/settings/index.tsx
+++ b/packages/ui/src/watch/home-page/settings/index.tsx
@@ -66,7 +66,7 @@ const SettingsPanel = (props: SettingsPanelProps) => {
               onChange={(event) =>
                 onStandaloneModeChange?.(event.target.checked)
               }
-              inputProps={{ 'aria-label': texts.standalone }}
+              slotProps={{ input: { 'aria-label': texts.standalone } }}
             />
           </ListItem>
         </List>

--- a/packages/ui/src/watch/video-detail-page/containers/index.tsx
+++ b/packages/ui/src/watch/video-detail-page/containers/index.tsx
@@ -225,7 +225,7 @@ const MainContent = (props: VideoDetailContainerProps) => {
   // Conditional rendering after all hooks
   if (isLoading) {
     return (
-      <Grid item sx={{ width: '100%', px: 2 }}>
+      <Grid sx={{ width: '100%', px: 2 }}>
         <MainContentSkeleton />
       </Grid>
     );
@@ -236,7 +236,7 @@ const MainContent = (props: VideoDetailContainerProps) => {
   }
 
   return (
-    <Grid item sx={{ width: '100%', px: 2 }}>
+    <Grid sx={{ width: '100%', px: 2 }}>
       <Box
         sx={{
           width: '100%',
@@ -257,7 +257,14 @@ const MainContent = (props: VideoDetailContainerProps) => {
           getVideoElementRef={getVideoElementRef}
         />
       </Box>
-      <Stack direction="row" alignItems="center" spacing={1} sx={{ mt: 2 }}>
+      <Stack
+        direction="row"
+        spacing={1}
+        sx={{
+          alignItems: 'center',
+          mt: 2,
+        }}
+      >
         {isPlaylist && (
           <Tooltip title="Playlist">
             <PlaylistPlayIcon color="action" titleAccess="Playlist" />
@@ -308,14 +315,19 @@ const MainContent = (props: VideoDetailContainerProps) => {
           </IconButton>
         </Tooltip>
       </Stack>
-
       {videoDetail.subtitles && videoDetail.subtitles.length > 0 && (
         <Stack
           direction="row"
           spacing={1}
           sx={{ mt: 1, alignItems: 'center', flexWrap: 'wrap', gap: 1 }}
         >
-          <Typography variant="body2" color="text.secondary" sx={{ mr: 0.5 }}>
+          <Typography
+            variant="body2"
+            sx={{
+              color: 'text.secondary',
+              mr: 0.5,
+            }}
+          >
             Subtitle(s):
           </Typography>
           <Stack
@@ -339,7 +351,6 @@ const MainContent = (props: VideoDetailContainerProps) => {
           </Stack>
         </Stack>
       )}
-
       <Suspense fallback={null}>
         <ShareDialog
           open={shareDialogOpen}
@@ -402,14 +413,34 @@ const VideoDetailContainer = (props: VideoDetailContainerProps) => {
 
   return (
     <Grid container spacing={2} sx={{ mt: 0 }}>
-      <Grid container item alignItems="flex-start" xs={12} sm={6} md={8} lg={9}>
+      <Grid
+        container
+        size={{
+          xs: 12,
+          sm: 6,
+          md: 8,
+          lg: 9,
+        }}
+        sx={{
+          alignItems: 'flex-start',
+        }}
+      >
         <MainContent
           {...props}
           onVideoEnded={handleVideoEnded}
           autoPlay={autoPlay}
         />
       </Grid>
-      <Grid container direction="column" item xs={12} sm={6} md={4} lg={3}>
+      <Grid
+        container
+        size={{
+          xs: 12,
+          sm: 6,
+          md: 4,
+          lg: 3,
+        }}
+        sx={{ flexDirection: 'column' }}
+      >
         <StyledRelatedContainer>
           <RelatedContent
             {...props}

--- a/packages/ui/src/watch/videos/list-item/styled.tsx
+++ b/packages/ui/src/watch/videos/list-item/styled.tsx
@@ -2,18 +2,16 @@ import type { StyledComponent } from '@emotion/styled';
 import Box, { type BoxProps } from '@mui/material/Box';
 import { styled } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
-import type { CSSProperties } from 'react';
-
 // Constants
 export const THUMBNAIL_HEIGHT = 64;
 export const THUMBNAIL_WIDTH = (THUMBNAIL_HEIGHT / 9) * 16;
 
 // Shared styles
-export const thumbnailImgStyle: CSSProperties = {
+export const thumbnailImgStyle = {
   width: '100%',
   height: '100%',
   objectFit: 'cover',
-};
+} as const;
 
 // Styled components
 const ListItemContainer: StyledComponent<BoxProps & { isActive?: boolean }> =

--- a/packages/ui/src/watch/videos/video-card/index.stories.tsx
+++ b/packages/ui/src/watch/videos/video-card/index.stories.tsx
@@ -10,7 +10,11 @@ const meta: Meta<typeof VideoCard> = {
   },
   decorators: [
     (Story) => (
-      <Box width={'400px'}>
+      <Box
+        sx={{
+          width: '400px',
+        }}
+      >
         <Story />
       </Box>
     ),

--- a/packages/ui/src/watch/videos/video-card/index.tsx
+++ b/packages/ui/src/watch/videos/video-card/index.tsx
@@ -49,7 +49,13 @@ const VideoCardContent = (props: VideoCardContentProps) => {
       <StyledTitle gutterBottom variant="body1" component="h3">
         {title}
       </StyledTitle>
-      <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
+      <Typography
+        variant="body2"
+        sx={{
+          color: 'text.secondary',
+          mb: 0.5,
+        }}
+      >
         {creator} • {createdTime}
       </Typography>
     </CardContent>

--- a/packages/ui/src/watch/videos/video-player/index.tsx
+++ b/packages/ui/src/watch/videos/video-player/index.tsx
@@ -400,7 +400,7 @@ const VideoPlayer = (props: VideoPlayerProps) => {
       data-testid="video-player-wrapper"
       sx={(theme) => ({
         aspectRatio: '16/9',
-        borderRadius: theme.shape.borderRadius / 12,
+        borderRadius: Number(theme.shape.borderRadius) / 12,
         overflow: 'hidden',
         width: '100%',
         height: '100%',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,7 +181,7 @@ importers:
         version: link:../../packages/jest-dom-preset
       '@tanstack/router-devtools':
         specifier: ^1.167.0
-        version: 1.167.0(@tanstack/react-router@1.170.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@tanstack/router-core@1.171.13)(csstype@3.1.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 1.167.0(@tanstack/react-router@1.170.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@tanstack/router-core@1.171.13)(csstype@3.2.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/router-plugin':
         specifier: ^1.168.18
         version: 1.168.18(@tanstack/react-router@1.170.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(esbuild@0.28.1)(rolldown@1.1.4)(rollup@2.79.2)(vite@6.4.3(@types/node@18.19.80)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.28.1))
@@ -550,11 +550,11 @@ importers:
         specifier: ^11.10.5
         version: 11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)
       '@mui/icons-material':
-        specifier: ^6.0.0
-        version: 6.5.0(@mui/material@6.5.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)
+        specifier: ^9.1.1
+        version: 9.1.1(@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)
       '@mui/material':
-        specifier: ^6.0.0
-        version: 6.5.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^9.1.2
+        version: 9.1.2(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/react-router':
         specifier: ^1.170.16
         version: 1.170.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -585,13 +585,13 @@ importers:
         version: 29.7.0
       '@storybook/addon-docs':
         specifier: 10.4.6
-        version: 10.4.6(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.18)(prettier@3.8.5)(react@18.3.1))(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.28.1))
+        version: 10.4.6(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(esbuild@0.24.2)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.18)(prettier@3.8.5)(react@18.3.1))(vite@8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.24.2))
       '@storybook/addon-links':
         specifier: 10.4.6
         version: 10.4.6(@types/react@18.3.18)(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.18)(prettier@3.8.5)(react@18.3.1))
       '@storybook/tanstack-react':
         specifier: 10.4.6
-        version: 10.4.6(@tanstack/react-router@1.170.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@tanstack/router-core@1.171.13)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.18)(prettier@3.8.5)(react@18.3.1))(typescript@5.8.2)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.28.1))
+        version: 10.4.6(@tanstack/react-router@1.170.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@tanstack/router-core@1.171.13)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(esbuild@0.24.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.18)(prettier@3.8.5)(react@18.3.1))(typescript@5.8.2)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.24.2))
       '@sworld/jest-dom-preset':
         specifier: workspace:*
         version: link:../jest-dom-preset
@@ -3781,27 +3781,27 @@ packages:
   '@mikewesthad/dungeon@2.0.1':
     resolution: {integrity: sha512-VfbXkueto+GpAWBk4IpAhDJ15ta/fctkfok4lK+Jxnvs2kUly3RALZnbriLwkez2N4lxaRWN3qrhyWzVWPIE0A==}
 
-  '@mui/core-downloads-tracker@6.5.0':
-    resolution: {integrity: sha512-LGb8t8i6M2ZtS3Drn3GbTI1DVhDY6FJ9crEey2lZ0aN2EMZo8IZBZj9wRf4vqbZHaWjsYgtbOnJw5V8UWbmK2Q==}
+  '@mui/core-downloads-tracker@9.1.2':
+    resolution: {integrity: sha512-ZMufoA/YFOEVp48lskcAOTlQYwpdBk4Z++4yUgPDEfuLHIpxBx9g+urGmIBKOtr+7M0ZlYfCxSvrJpEE/S32sg==}
 
-  '@mui/icons-material@6.5.0':
-    resolution: {integrity: sha512-VPuPqXqbBPlcVSA0BmnoE4knW4/xG6Thazo8vCLWkOKusko6DtwFV6B665MMWJ9j0KFohTIf3yx2zYtYacvG1g==}
+  '@mui/icons-material@9.1.1':
+    resolution: {integrity: sha512-OXhm9DajemStb58AumM06DuPhHTa3XD36TFD4yf6WtJyNRO5DfEZbbnHlBg/US2Y2oOXwM/XurMTBOD6L/YYZw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      '@mui/material': ^6.5.0
+      '@mui/material': ^9.1.1
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
 
-  '@mui/material@6.5.0':
-    resolution: {integrity: sha512-yjvtXoFcrPLGtgKRxFaH6OQPtcLPhkloC0BML6rBG5UeldR0nPULR/2E2BfXdo5JNV7j7lOzrrLX2Qf/iSidow==}
+  '@mui/material@9.1.2':
+    resolution: {integrity: sha512-CN2U1etAL+6qZT2XjJR1Ibv7nyE2wBN3/28b5XpXjQFMtBKNlD45wQupODfJrm9PLanJ1DefocHWIQZ5PkSipQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@emotion/react': ^11.5.0
       '@emotion/styled': ^11.3.0
-      '@mui/material-pigment-css': ^6.5.0
+      '@mui/material-pigment-css': ^9.1.1
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -3815,8 +3815,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@mui/private-theming@6.4.9':
-    resolution: {integrity: sha512-LktcVmI5X17/Q5SkwjCcdOLBzt1hXuc14jYa7NPShog0GBDCDvKtcnP0V7a2s6EiVRlv7BzbWEJzH6+l/zaCxw==}
+  '@mui/private-theming@9.1.1':
+    resolution: {integrity: sha512-oH6c+d6sJ1CZT0Vg2/fHdUQ5zvo9Pn+f+WWk0tlQliHqqIRdN32DZ7UxjalW3LUj4OkHbdWR31biWuLxK9i7Cg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -3825,8 +3825,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@mui/styled-engine@6.5.0':
-    resolution: {integrity: sha512-8woC2zAqF4qUDSPIBZ8v3sakj+WgweolpyM/FXf8jAx6FMls+IE4Y8VDZc+zS805J7PRz31vz73n2SovKGaYgw==}
+  '@mui/styled-engine@9.1.1':
+    resolution: {integrity: sha512-neaYKdJfvEG54q8efHLJR7swpHG/gfSv9xGqW5iTSMsubD7yPCPFrhVBt284j1DOF3uZaaDJSHQL7gz6jGF21Q==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@emotion/react': ^11.4.1
@@ -3838,8 +3838,8 @@ packages:
       '@emotion/styled':
         optional: true
 
-  '@mui/system@6.5.0':
-    resolution: {integrity: sha512-XcbBYxDS+h/lgsoGe78ExXFZXtuIlSBpn/KsZq8PtZcIkUNJInkuDqcLd2rVBQrDC1u+rvVovdaWPf2FHKJf3w==}
+  '@mui/system@9.1.2':
+    resolution: {integrity: sha512-oJxyyummOR6nV8ODF/yugasJ//pSsQxxfYCE9q9RU2Hef0f5RRzJ75M9zr5NvHDhzhGgrPstkaNrJtmcuz/Pdg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@emotion/react': ^11.5.0
@@ -3854,16 +3854,16 @@ packages:
       '@types/react':
         optional: true
 
-  '@mui/types@7.2.24':
-    resolution: {integrity: sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==}
+  '@mui/types@9.1.1':
+    resolution: {integrity: sha512-Zjt7u8wNvDg40rPTGoL+TnfkpuSKjwubsNSFRH1KAVZLcaV4I3AFNHIFbvH7p4F3alEibSbdd90xAgn5Rnfndg==}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
 
-  '@mui/utils@6.4.9':
-    resolution: {integrity: sha512-Y12Q9hbK9g+ZY0T3Rxrx9m2m10gaphDuUMgWxyV5kNJevVxXYCLclYUCC9vXaIk1/NdNDTcW2Yfr2OGvNFNmHg==}
+  '@mui/utils@9.1.1':
+    resolution: {integrity: sha512-qSNfnkzZMptaaWFFklpDf4NPJztgwsMDVfM/sSDt+wq4ssYSBhLYwwjuB6eS/+p2IUYbeRzHluzXbw0Zn7aI4A==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -5442,6 +5442,9 @@ packages:
   '@types/prop-types@15.7.14':
     resolution: {integrity: sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==}
 
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
   '@types/qs@6.9.18':
     resolution: {integrity: sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA==}
 
@@ -6649,6 +6652,9 @@ packages:
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
@@ -10315,8 +10321,8 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
-  react-is@19.0.0:
-    resolution: {integrity: sha512-H91OHcwjZsbq3ClIDHMzBShc1rotbfACdWENsmEf0IFvZ3FgGPtdHMcsv45bQ1hAbgdfiA8SnxTKfDS+x/8m2g==}
+  react-is@19.2.7:
+    resolution: {integrity: sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==}
 
   react-json-view-lite@2.4.2:
     resolution: {integrity: sha512-m7uTsXDgPQp8R9bJO4HD/66+i218eyQPAb+7/dGQpwg8i4z2afTFqtHJPQFHvJfgDCjGQ1HSGlL3HtrZDa3Tdg==}
@@ -15986,7 +15992,7 @@ snapshots:
       '@emotion/memoize': 0.9.0
       '@emotion/unitless': 0.10.0
       '@emotion/utils': 1.4.2
-      csstype: 3.1.3
+      csstype: 3.2.3
 
   '@emotion/sheet@1.4.0': {}
 
@@ -16995,11 +17001,11 @@ snapshots:
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.8.2)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.8.2)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))':
     dependencies:
       glob: 13.0.6
       react-docgen-typescript: 2.2.2(typescript@5.8.2)
-      vite: 8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0)
     optionalDependencies:
       typescript: 5.8.2
 
@@ -17234,68 +17240,68 @@ snapshots:
       core-js: 3.41.0
       seedrandom: 3.0.5
 
-  '@mui/core-downloads-tracker@6.5.0': {}
+  '@mui/core-downloads-tracker@9.1.2': {}
 
-  '@mui/icons-material@6.5.0(@mui/material@6.5.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)':
+  '@mui/icons-material@9.1.1(@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.26.10
-      '@mui/material': 6.5.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@babel/runtime': 7.29.7
+      '@mui/material': 9.1.2(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.18
 
-  '@mui/material@6.5.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@mui/material@9.1.2(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.26.10
-      '@mui/core-downloads-tracker': 6.5.0
-      '@mui/system': 6.5.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)
-      '@mui/types': 7.2.24(@types/react@18.3.18)
-      '@mui/utils': 6.4.9(@types/react@18.3.18)(react@18.3.1)
+      '@babel/runtime': 7.29.7
+      '@mui/core-downloads-tracker': 9.1.2
+      '@mui/system': 9.1.2(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)
+      '@mui/types': 9.1.1(@types/react@18.3.18)
+      '@mui/utils': 9.1.1(@types/react@18.3.18)(react@18.3.1)
       '@popperjs/core': 2.11.8
       '@types/react-transition-group': 4.4.12(@types/react@18.3.18)
       clsx: 2.1.1
-      csstype: 3.1.3
+      csstype: 3.2.3
       prop-types: 15.8.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-is: 19.0.0
+      react-is: 19.2.7
       react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     optionalDependencies:
       '@emotion/react': 11.14.0(@types/react@18.3.18)(react@18.3.1)
       '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)
       '@types/react': 18.3.18
 
-  '@mui/private-theming@6.4.9(@types/react@18.3.18)(react@18.3.1)':
+  '@mui/private-theming@9.1.1(@types/react@18.3.18)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@mui/utils': 6.4.9(@types/react@18.3.18)(react@18.3.1)
+      '@mui/utils': 9.1.1(@types/react@18.3.18)(react@18.3.1)
       prop-types: 15.8.1
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.18
 
-  '@mui/styled-engine@6.5.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)':
+  '@mui/styled-engine@9.1.1(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@emotion/cache': 11.14.0
       '@emotion/serialize': 1.3.3
       '@emotion/sheet': 1.4.0
-      csstype: 3.1.3
+      csstype: 3.2.3
       prop-types: 15.8.1
       react: 18.3.1
     optionalDependencies:
       '@emotion/react': 11.14.0(@types/react@18.3.18)(react@18.3.1)
       '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)
 
-  '@mui/system@6.5.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)':
+  '@mui/system@9.1.2(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@mui/private-theming': 6.4.9(@types/react@18.3.18)(react@18.3.1)
-      '@mui/styled-engine': 6.5.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
-      '@mui/types': 7.2.24(@types/react@18.3.18)
-      '@mui/utils': 6.4.9(@types/react@18.3.18)(react@18.3.1)
+      '@mui/private-theming': 9.1.1(@types/react@18.3.18)(react@18.3.1)
+      '@mui/styled-engine': 9.1.1(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
+      '@mui/types': 9.1.1(@types/react@18.3.18)
+      '@mui/utils': 9.1.1(@types/react@18.3.18)(react@18.3.1)
       clsx: 2.1.1
-      csstype: 3.1.3
+      csstype: 3.2.3
       prop-types: 15.8.1
       react: 18.3.1
     optionalDependencies:
@@ -17303,19 +17309,21 @@ snapshots:
       '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)
       '@types/react': 18.3.18
 
-  '@mui/types@7.2.24(@types/react@18.3.18)':
+  '@mui/types@9.1.1(@types/react@18.3.18)':
+    dependencies:
+      '@babel/runtime': 7.29.7
     optionalDependencies:
       '@types/react': 18.3.18
 
-  '@mui/utils@6.4.9(@types/react@18.3.18)(react@18.3.1)':
+  '@mui/utils@9.1.1(@types/react@18.3.18)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@mui/types': 7.2.24(@types/react@18.3.18)
-      '@types/prop-types': 15.7.14
+      '@mui/types': 9.1.1(@types/react@18.3.18)
+      '@types/prop-types': 15.7.15
       clsx: 2.1.1
       prop-types: 15.8.1
       react: 18.3.1
-      react-is: 19.0.0
+      react-is: 19.2.7
     optionalDependencies:
       '@types/react': 18.3.18
 
@@ -18004,10 +18012,10 @@ snapshots:
       micromark-util-character: 1.2.0
       micromark-util-symbol: 1.1.0
 
-  '@storybook/addon-docs@10.4.6(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.18)(prettier@3.8.5)(react@18.3.1))(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.28.1))':
+  '@storybook/addon-docs@10.4.6(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(esbuild@0.24.2)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.18)(prettier@3.8.5)(react@18.3.1))(vite@8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.24.2))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@18.3.18)(react@18.3.1)
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.18)(prettier@3.8.5)(react@18.3.1))(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.28.1))
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.24.2)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.18)(prettier@3.8.5)(react@18.3.1))(vite@8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.24.2))
       '@storybook/icons': 2.1.0(react@18.3.1)
       '@storybook/react-dom-shim': 10.4.6(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.18)(prettier@3.8.5)(react@18.3.1))
       react: 18.3.1
@@ -18031,26 +18039,26 @@ snapshots:
       '@types/react': 18.3.18
       react: 18.3.1
 
-  '@storybook/builder-vite@10.4.6(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.18)(prettier@3.8.5)(react@18.3.1))(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.28.1))':
+  '@storybook/builder-vite@10.4.6(esbuild@0.24.2)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.18)(prettier@3.8.5)(react@18.3.1))(vite@8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.24.2))':
     dependencies:
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.18)(prettier@3.8.5)(react@18.3.1))(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.28.1))
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.24.2)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.18)(prettier@3.8.5)(react@18.3.1))(vite@8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.24.2))
       storybook: 10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.18)(prettier@3.8.5)(react@18.3.1)
       ts-dedent: 2.2.0
-      vite: 8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.4.6(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.18)(prettier@3.8.5)(react@18.3.1))(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.28.1))':
+  '@storybook/csf-plugin@10.4.6(esbuild@0.24.2)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.18)(prettier@3.8.5)(react@18.3.1))(vite@8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.24.2))':
     dependencies:
       storybook: 10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.18)(prettier@3.8.5)(react@18.3.1)
       unplugin: 2.3.11
     optionalDependencies:
-      esbuild: 0.28.1
+      esbuild: 0.24.2
       rollup: 4.62.2
-      vite: 8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0)
-      webpack: 5.98.0(esbuild@0.28.1)
+      vite: 8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0)
+      webpack: 5.98.0(esbuild@0.24.2)
 
   '@storybook/global@5.0.0': {}
 
@@ -18067,11 +18075,11 @@ snapshots:
       '@types/react': 18.3.18
       '@types/react-dom': 18.3.5(@types/react@18.3.18)
 
-  '@storybook/react-vite@10.4.6(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.18)(prettier@3.8.5)(react@18.3.1))(typescript@5.8.2)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.28.1))':
+  '@storybook/react-vite@10.4.6(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(esbuild@0.24.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.18)(prettier@3.8.5)(react@18.3.1))(typescript@5.8.2)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.24.2))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.8.2)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.8.2)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))
       '@rollup/pluginutils': 5.1.4(rollup@4.62.2)
-      '@storybook/builder-vite': 10.4.6(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.18)(prettier@3.8.5)(react@18.3.1))(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.28.1))
+      '@storybook/builder-vite': 10.4.6(esbuild@0.24.2)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.18)(prettier@3.8.5)(react@18.3.1))(vite@8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.24.2))
       '@storybook/react': 10.4.6(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.18)(prettier@3.8.5)(react@18.3.1))(typescript@5.8.2)
       empathic: 2.0.1
       magic-string: 0.30.21
@@ -18081,7 +18089,7 @@ snapshots:
       resolve: 1.22.12
       storybook: 10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.18)(prettier@3.8.5)(react@18.3.1)
       tsconfig-paths: 4.2.0
-      vite: 8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -18107,17 +18115,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/tanstack-react@10.4.6(@tanstack/react-router@1.170.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@tanstack/router-core@1.171.13)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.18)(prettier@3.8.5)(react@18.3.1))(typescript@5.8.2)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.28.1))':
+  '@storybook/tanstack-react@10.4.6(@tanstack/react-router@1.170.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@tanstack/router-core@1.171.13)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(esbuild@0.24.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.18)(prettier@3.8.5)(react@18.3.1))(typescript@5.8.2)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.24.2))':
     dependencies:
-      '@storybook/builder-vite': 10.4.6(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.18)(prettier@3.8.5)(react@18.3.1))(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.28.1))
+      '@storybook/builder-vite': 10.4.6(esbuild@0.24.2)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.18)(prettier@3.8.5)(react@18.3.1))(vite@8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.24.2))
       '@storybook/react': 10.4.6(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.18)(prettier@3.8.5)(react@18.3.1))(typescript@5.8.2)
-      '@storybook/react-vite': 10.4.6(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.18)(prettier@3.8.5)(react@18.3.1))(typescript@5.8.2)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.28.1))
+      '@storybook/react-vite': 10.4.6(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(esbuild@0.24.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.18)(prettier@3.8.5)(react@18.3.1))(typescript@5.8.2)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.24.2))
       '@tanstack/react-router': 1.170.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/router-core': 1.171.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       storybook: 10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.18)(prettier@3.8.5)(react@18.3.1)
-      vite: 8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -18241,10 +18249,10 @@ snapshots:
       '@tanstack/query-core': 5.101.1
       react: 18.3.1
 
-  '@tanstack/react-router-devtools@1.167.0(@tanstack/react-router@1.170.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@tanstack/router-core@1.171.13)(csstype@3.1.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@tanstack/react-router-devtools@1.167.0(@tanstack/react-router@1.170.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@tanstack/router-core@1.171.13)(csstype@3.2.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@tanstack/react-router': 1.170.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@tanstack/router-devtools-core': 1.168.0(@tanstack/router-core@1.171.13)(csstype@3.1.3)
+      '@tanstack/router-devtools-core': 1.168.0(@tanstack/router-core@1.171.13)(csstype@3.2.3)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
@@ -18275,24 +18283,24 @@ snapshots:
       seroval: 1.5.4
       seroval-plugins: 1.5.4(seroval@1.5.4)
 
-  '@tanstack/router-devtools-core@1.168.0(@tanstack/router-core@1.171.13)(csstype@3.1.3)':
+  '@tanstack/router-devtools-core@1.168.0(@tanstack/router-core@1.171.13)(csstype@3.2.3)':
     dependencies:
       '@tanstack/router-core': 1.171.13
       clsx: 2.1.1
-      goober: 2.1.16(csstype@3.1.3)
+      goober: 2.1.16(csstype@3.2.3)
     optionalDependencies:
-      csstype: 3.1.3
+      csstype: 3.2.3
 
-  '@tanstack/router-devtools@1.167.0(@tanstack/react-router@1.170.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@tanstack/router-core@1.171.13)(csstype@3.1.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@tanstack/router-devtools@1.167.0(@tanstack/react-router@1.170.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@tanstack/router-core@1.171.13)(csstype@3.2.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@tanstack/react-router': 1.170.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@tanstack/react-router-devtools': 1.167.0(@tanstack/react-router@1.170.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@tanstack/router-core@1.171.13)(csstype@3.1.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tanstack/react-router-devtools': 1.167.0(@tanstack/react-router@1.170.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@tanstack/router-core@1.171.13)(csstype@3.2.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1
-      goober: 2.1.16(csstype@3.1.3)
+      goober: 2.1.16(csstype@3.2.3)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      csstype: 3.1.3
+      csstype: 3.2.3
     transitivePeerDependencies:
       - '@tanstack/router-core'
 
@@ -18850,6 +18858,8 @@ snapshots:
   '@types/prismjs@1.26.5': {}
 
   '@types/prop-types@15.7.14': {}
+
+  '@types/prop-types@15.7.15': {}
 
   '@types/qs@6.9.18': {}
 
@@ -20290,6 +20300,8 @@ snapshots:
 
   csstype@3.1.3: {}
 
+  csstype@3.2.3: {}
+
   data-uri-to-buffer@4.0.1: {}
 
   data-urls@3.0.2:
@@ -20457,7 +20469,7 @@ snapshots:
   dom-helpers@5.2.1:
     dependencies:
       '@babel/runtime': 7.29.7
-      csstype: 3.1.3
+      csstype: 3.2.3
 
   dom-serializer@1.4.1:
     dependencies:
@@ -21394,9 +21406,9 @@ snapshots:
       merge2: 1.4.1
       slash: 4.0.0
 
-  goober@2.1.16(csstype@3.1.3):
+  goober@2.1.16(csstype@3.2.3):
     dependencies:
-      csstype: 3.1.3
+      csstype: 3.2.3
 
   gopd@1.2.0: {}
 
@@ -24701,7 +24713,7 @@ snapshots:
 
   react-is@18.3.1: {}
 
-  react-is@19.0.0: {}
+  react-is@19.2.7: {}
 
   react-json-view-lite@2.4.2(react@18.3.1):
     dependencies:
@@ -25849,6 +25861,18 @@ snapshots:
 
   term-size@2.2.1: {}
 
+  terser-webpack-plugin@5.3.14(esbuild@0.24.2)(webpack@5.98.0(esbuild@0.24.2)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      jest-worker: 27.5.1
+      schema-utils: 4.3.0
+      serialize-javascript: 6.0.2
+      terser: 5.39.0
+      webpack: 5.98.0(esbuild@0.24.2)
+    optionalDependencies:
+      esbuild: 0.24.2
+    optional: true
+
   terser-webpack-plugin@5.3.14(esbuild@0.28.1)(webpack@5.98.0(esbuild@0.28.1)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
@@ -26468,6 +26492,22 @@ snapshots:
       tsx: 4.19.3
       yaml: 2.7.0
 
+  vite@8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.5
+      postcss: 8.5.16
+      rolldown: 1.1.4
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 24.13.2
+      esbuild: 0.24.2
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      terser: 5.48.0
+      tsx: 4.19.3
+      yaml: 2.7.0
+
   vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0):
     dependencies:
       lightningcss: 1.32.0
@@ -26681,6 +26721,37 @@ snapshots:
       - '@swc/core'
       - esbuild
       - uglify-js
+
+  webpack@5.98.0(esbuild@0.24.2):
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.6
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.14.1
+      browserslist: 4.25.3
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.18.1
+      es-module-lexer: 1.6.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.0
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 4.3.0
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.14(esbuild@0.24.2)(webpack@5.98.0(esbuild@0.24.2))
+      watchpack: 2.4.2
+      webpack-sources: 3.2.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+    optional: true
 
   webpack@5.98.0(esbuild@0.28.1):
     dependencies:


### PR DESCRIPTION
## Summary

Upgrades MUI 6.5.0 → 9.1.2 in packages/ui (there is no MUI v8 — the registry jumps 7 → 9, so two verified stops: 7.3.11 then 9.1.2). Official codemods per major (grid-props ×13 files, theme-color-functions ×2, system-props ×42) plus the manual fixes each major required (Grid size props, removed Dialog `disableEscapeKeyDown`, `slotProps` migrations, removed icon aliases, borderRadius coercion). React stays 18.3.1. Owner visually verified Storybook and all four apps against this branch, including video playback. All 556 ui tests, full typecheck, builds and storybook build green. SWO-362; unblocks React 19 (SWO-364).

Visual hotspots already reviewed live: listen home lists (Grid gap gutters), watch card breakpoints, watch video-detail column, journal alpha tints, login dialog Escape behaviour.

## Test plan

- [ ] ui tests green (556)
- [ ] Storybook builds; stories render at MUI 9
- [ ] Apps visually verified by owner against the running branch (done pre-merge)
- [ ] CI green