### PR TITLE
[WIP] docs(skills): replace Linear MCP with linear CLI in workflow skills

### DIFF
--- a/.claude/skills/parallel-workflow/SKILL.md
+++ b/.claude/skills/parallel-workflow/SKILL.md
@@ -18,10 +18,10 @@ user-invocable: false
 
 ## Before starting
 
-1. Read the current Linear issue (`get_issue`) and confirm its `state`.
+1. Read the current Linear issue (`linear issue view SWO-NNN`) and confirm its `state`. All Linear operations go through the `linear` CLI via Bash — NEVER through Linear MCP tools (they authenticate as the wrong account).
 2. Verify an issue exists for this work — a sub-issue under a feature's parent issue, or a standalone issue. If none exists, create it first (`writing-task-specs`).
-3. Check the issue's blocking relations (`blockedBy`); resolve those blockers first.
-4. Set the issue's `state` to `In Progress` (`save_issue`) before starting.
+3. Check the issue's blocking relations (`linear issue relation list SWO-NNN`); resolve those blockers first.
+4. Set the issue's `state` to `In Progress` (`linear issue update SWO-NNN -s "In Progress"`) before starting.
 
 ## Creating a worktree
 
@@ -56,7 +56,7 @@ user-invocable: false
 - Create PR with `[WIP]` prefix (not draft).
 - Reference the Linear issue in the PR description (e.g. `SWO-123`) so the integration links them.
 - ALWAYS assign PR to the user (`--assignee "@me"`).
-- Set the issue's `state` to `In Review` (`save_issue`) after the PR is created.
+- Set the issue's `state` to `In Review` (`linear issue update SWO-NNN -s "In Review"`) after the PR is created.
 - Ensure PR is independent and mergeable without other PRs.
 - Run the CI loop after pushing.
 
@@ -69,7 +69,7 @@ Before entering the gates, push any unpushed local commits so the remote PR refl
 ### Step 1: Check merge status
 
 - Run `gh pr view <number> --json state` as the **ONLY** command. Do NOT batch it with anything else.
-- If `MERGED` → set the issue's `state` to `Done` (`save_issue`), clean up worktree + delete local branch. Loop is done.
+- If `MERGED` → set the issue's `state` to `Done` (`linear issue update SWO-NNN -s "Done"`), clean up worktree + delete local branch. Loop is done.
 - If `CLOSED` → stop the loop. Report to user that the PR was closed without merging.
 - If `OPEN` → proceed to Step 2.
 
@@ -110,7 +110,7 @@ After each iteration, report what you found and fixed. Lead with unresolved comm
 
 - States follow the SWorld team lifecycle: `Backlog → Todo → In Progress → In Review → Done`.
 - A **project** is an app (Til, Watch, Listen, Game, Docs, Main) — a long-lived container, never marked `Done`. Only issues move through the lifecycle.
-- Starting work on a large feature (even planning) → set the **parent issue** to `In Progress` (`save_issue`).
+- Starting work on a large feature (even planning) → set the **parent issue** to `In Progress` (`linear issue update SWO-NNN -s "In Progress"`).
 - Each sub-task **sub-issue** carries its own `state` (`Todo → In Progress → In Review → Done`), driven by the steps above.
 - Last sub-issue of a parent done → set the **parent issue** to `Done`.
 

--- a/.claude/skills/product-planning/SKILL.md
+++ b/.claude/skills/product-planning/SKILL.md
@@ -41,7 +41,7 @@ and offer**, you don't enforce.
 Don't assume where the user is. They may have planned this deeply with an agent already, or may be
 starting cold and have skipped straight to "let's build it." Find out before you start:
 
-- If they reference a Linear issue or project, pull it (`get_issue` / `get_project`) and work from it.
+- If they reference a Linear issue or project, pull it (`linear issue view SWO-NNN` / `linear project view` — always the `linear` CLI, never Linear MCP tools) and work from it.
 - Check whether a Linear **document** already exists for the concept in play — if it does, that's
   a strong signal they've already worked the concept through. If it doesn't and the work needs one,
   that's a signal it's missing.
@@ -90,7 +90,7 @@ bring it back to pressure-test their model — exactly as you'd research anythin
 the path.
 
 **Capture the domain/feature concept as a short Linear document if it's non-obvious** — pure concept
-truth ("what is it", "how it works", "the rules"). Use `save_document`: attach it to the app's
+truth ("what is it", "how it works", "the rules"). Use `linear document create -t "…" -f <doc.md>`: attach it (`--project`) to the app's
 **project** for a feature concept, or to the **SWorld team** for a cross-cutting domain concept. Write it
 **before** the code, not retrofitted after — defining it first is the point. Keep the feature's
 architecture and trade-offs out of it — those live in the parent issue (Step 3).

--- a/.claude/skills/writing-task-specs/SKILL.md
+++ b/.claude/skills/writing-task-specs/SKILL.md
@@ -7,25 +7,25 @@ description: This skill should be used whenever the user asks to "create a ticke
 
 Produce clear, consistent task specs in **Linear** that match the shape of the work. A great spec lets a developer (or AI agent) pick it up and start without asking questions.
 
-Tasks live in Linear — there is no in-repo task tracker. Everything goes in the **SWorld** team (`SWO`). Create and edit through the connected **Linear MCP tools** (`save_issue`, `save_project`, `save_document`) — these come from the session's Linear MCP server, not from any code in this repo. They take `state`, `project`, and `labels` **by name** (e.g. `state: "In Progress"`, `project: "Main"`) and resolve them to the workspace's IDs for you — you never pass raw UUIDs. If the matching project for an app doesn't exist yet, create it with `save_project` first. The short version of the model:
+Tasks live in Linear — there is no in-repo task tracker. Everything goes in the **SWorld** team (`SWO`). Create and edit through the **`linear` CLI** ([schpet/linear-cli](https://github.com/schpet/linear-cli), installed via `brew install schpet/tap/linear`, authenticated with `linear auth login`) run with Bash — **never through any Linear MCP tools** (a connected Linear MCP server authenticates as the wrong account; if the CLI is missing or broken, stop and tell the user instead of falling back to MCP). The CLI takes `--state`, `--project`, and `--label` **by name** (e.g. `-s "In Progress"`, `--project "Main"`) and resolves them to the workspace's IDs for you — you never pass raw UUIDs. Pass markdown bodies with `--description-file` (issues) / `--content-file` (documents) rather than inline strings, and add `--no-interactive` when creating issues so it never prompts. If the matching project for an app doesn't exist yet, create it with `linear project create` first. For anything the CLI doesn't expose (e.g. querying parent/sub-issue relationships), use `linear auth token` + a direct Linear GraphQL API call with curl. The short version of the model:
 
-**A `project` is an app** — the long-lived container for everything in one app: `Til`, `Watch`, `Listen`, `Game`, `Docs`, and `Main` (the main app, covering its finance, journal, and library areas). For a brand-new app surface, create the project with `save_project` first. A project is *never* a single feature, and is never marked `Done`. Every issue belongs to exactly one project — its app.
+**A `project` is an app** — the long-lived container for everything in one app: `Til`, `Watch`, `Listen`, `Game`, `Docs`, and `Main` (the main app, covering its finance, journal, and library areas). For a brand-new app surface, create the project with `linear project create` first. A project is *never* a single feature, and is never marked `Done`. Every issue belongs to exactly one project — its app.
 
-- **Bug / small feature** → a single **issue** (`save_issue`) in the app's project. Bugs carry the `bug` label.
+- **Bug / small feature** → a single **issue** (`linear issue create`) in the app's project. Bugs carry the `bug` label.
 - **User story** → an **issue in `Backlog`** in the app's project, written in plain language, not technically scoped. When a developer picks it up and scopes it, it spawns a large feature.
-- **Large feature (scoped)** → a **parent issue** in the app's project, with one **sub-issue** per sub-task (`parentId` = the parent issue). The parent issue's description + (for a heavy concept) a **Linear document** hold the spec; **waves** are encoded by **blocking relations** between sub-issues (optionally a `wave-N` label); **blocked-by** is a **blocking relation**; **estimate** is the issue **estimate** field.
+- **Large feature (scoped)** → a **parent issue** in the app's project, with one **sub-issue** per sub-task (`--parent SWO-NNN` = the parent issue). The parent issue's description + (for a heavy concept) a **Linear document** hold the spec; **waves** are encoded by **blocking relations** between sub-issues (`linear issue relation add`, optionally a `wave-N` label); **blocked-by** is a **blocking relation**; **estimate** is the issue **estimate** field (`--estimate`).
 
 The fields that an in-repo tracker would keep in frontmatter are native Linear fields:
 
-| Was frontmatter | Linear field (via `save_issue`) |
-|-----------------|---------------------------------|
-| `status:` | `state` — `Backlog` / `Todo` / `In Progress` / `In Review` / `Done` |
-| `estimate:` | `estimate` |
-| which app | `project` |
-| `parent:` (which feature) | `parentId` (the feature's parent issue) |
-| `blocked-by:` | `blockedBy` (issue identifiers) |
-| wave grouping | `blockedBy` relations (optionally a `wave-N` label) |
-| bug / user-story tagging | `labels` |
+| Was frontmatter | Linear field (via `linear issue create` / `update`) |
+|-----------------|------------------------------------------------------|
+| `status:` | `-s/--state` — `Backlog` / `Todo` / `In Progress` / `In Review` / `Done` |
+| `estimate:` | `--estimate` |
+| which app | `--project` |
+| `parent:` (which feature) | `--parent SWO-NNN` (the feature's parent issue) |
+| `blocked-by:` | `linear issue relation add SWO-child blocked-by SWO-dep` |
+| wave grouping | blocked-by relations (optionally a `wave-N` label) |
+| bug / user-story tagging | `-l/--label` (repeatable) |
 
 ## Critical rules
 
@@ -114,7 +114,7 @@ For a specific, reproducible issue. Direct, short, focused on getting the fix ri
 
 ### Example — the library progress bug
 
-Created with `save_issue`: `team: "SWorld"`, `project: "Main"` (library is a feature area of the main app), `labels: ["bug"]`, `state: "Todo"`, `estimate: 1`, `title: "Library reading progress bar loses its label on long books"`, and this description:
+Created with `linear issue create --team SWO --project "Main" -l bug -s "Todo" --estimate 1 -t "Library reading progress bar loses its label on long books" --description-file <spec.md> --no-interactive` (library is a feature area of the main app), where the description file holds:
 
 ```markdown
 **Problem**
@@ -171,7 +171,7 @@ For a single focused change that maps to one PR. Short spec, no sub-tasks. A sin
 
 ### Example
 
-`save_issue`: `team: "SWorld"`, `project: "Listen"`, `state: "Todo"`, `estimate: 4`, `title: "Add bulk import for listen playlist tracks"`, description:
+`linear issue create --team SWO --project "Listen" -s "Todo" --estimate 4 -t "Add bulk import for listen playlist tracks" --description-file <spec.md> --no-interactive`, description:
 
 ```markdown
 **Problem**
@@ -248,7 +248,7 @@ A user story captures a user need or product direction in plain language. It doe
 
 ### Example — document ingestion for the til app
 
-`save_issue`: `team: "SWorld"`, `project: "Til"`, `state: "Backlog"`, `title: "Import notes from existing documents into til"`, description:
+`linear issue create --team SWO --project "Til" -s "Backlog" -t "Import notes from existing documents into til" --description-file <spec.md> --no-interactive`, description:
 
 ```markdown
 **The user's problem**
@@ -313,7 +313,7 @@ Out of scope: file upload, AI extraction, auto-tagging, duplicate detection. The
 
 ## Shape 4 — Large feature (scoped)
 
-A technically broken-down feature with sequenced sub-tasks. This is the *output* of scoping — usually produced when a developer takes a user story and works out the implementation. It is a **parent issue** (`save_issue`, `team: "SWorld"`, attached to the app's `project`) whose **description** carries the technical scope, with one **sub-issue per sub-task** (`parentId` = the parent issue), and **blocking relations** for the dependency graph (which also encode the waves).
+A technically broken-down feature with sequenced sub-tasks. This is the *output* of scoping — usually produced when a developer takes a user story and works out the implementation. It is a **parent issue** (`linear issue create --team SWO --project "<app>" …`) whose **description** carries the technical scope, with one **sub-issue per sub-task** (`--parent SWO-NNN` = the parent issue), and **blocking relations** (`linear issue relation add`) for the dependency graph (which also encode the waves).
 
 ### When this shape is created
 
@@ -394,7 +394,7 @@ For features involving data models or complex logic, include sections like:
 
 ### Sub-task issue structure
 
-Each sub-task is one sub-issue under the parent, and a small focused PR. It inherits context from the parent issue — do not repeat the architecture or rationale. Create with `save_issue`: `team: "SWorld"`, `project: "<app>"`, `parentId: "SWO-NNN"` (the parent issue), `state: "Todo"`, `estimate`, and `blockedBy: ["SWO-NNN", …]` for its dependencies.
+Each sub-task is one sub-issue under the parent, and a small focused PR. It inherits context from the parent issue — do not repeat the architecture or rationale. Create with `linear issue create --team SWO --project "<app>" --parent SWO-NNN -s "Todo" --estimate N …`, then `linear issue relation add SWO-<new> blocked-by SWO-<dep>` for each dependency.
 
 ```markdown
 **What**
@@ -449,7 +449,7 @@ When Claude has been working with the developer and a spec is needed:
 2. **For user stories** — focus on capturing the user's problem and ideas in plain language, as an issue in `Backlog`. Do not jump to technical scoping.
 3. **For large features** — run the scoping conversation before creating anything. Confirm the breakdown with the user. If there's an existing user story, start from it.
 4. **Draft the spec** matching the shape's structure. Use the developer's existing context, do not re-investigate things already discussed.
-5. **Create in Linear** — `save_issue` for a bug / small feature / user story; for a large feature: `save_issue` for the parent (attached to the app `project`), then `save_issue` per sub-task with `parentId`, `project`, `estimate`, and `blockedBy` set. For a heavy domain concept, add a `save_document` attached to the app's project.
+5. **Create in Linear** — `linear issue create` for a bug / small feature / user story; for a large feature: `linear issue create` for the parent (attached to the app `--project`), then `linear issue create` per sub-task with `--parent`, `--project`, and `--estimate` set, plus `linear issue relation add … blocked-by …` for dependencies. For a heavy domain concept, add a `linear document create --project "<app>" -t "…" -f <doc.md>`.
 6. **Confirm to the user** what was created, with the issue identifiers and URLs.
 
 ## Validation checklist
@@ -460,7 +460,7 @@ Before creating a spec:
 - Created in the **SWorld** team and attached to the right app **project**
 - Shape matches the work (bug / small feature / user story / large feature)
 - Detail level matches the shape — not over-documented, not under-documented
-- Linear fields set: `state`, plus `estimate` / `labels` / `parentId` / `blockedBy` where relevant
+- Linear fields set: `--state`, plus `--estimate` / `--label` / `--parent` / blocked-by relations where relevant
 - For bugs: `bug` label; problem, root cause (or note that it's unknown), solution (if known), acceptance criteria
 - For small features: problem, proposed solution, acceptance criteria
 - For user stories: `state: Backlog`, user problem front and centre, ideas explored but no technical spec, open questions listed honestly


### PR DESCRIPTION
## Summary

No user-facing changes. The writing-task-specs, parallel-workflow, and product-planning skills told agents to manage Linear through the connected Linear MCP tools, which authenticate as the wrong account. Every reference is rewritten to use the `linear` CLI (schpet/linear-cli) instead, with the exact commands and flags verified against the installed CLI (v2.0.0).

## Test plan

- [ ] Skill docs read correctly and every `linear …` command shown matches the CLI's real flags
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workflow guidance for creating, updating, and tracking work items with a more consistent command-line process.
  * Clarified how to handle issue states, dependencies, projects, labels, and parent/sub-task relationships.
  * Improved examples and validation steps to reflect the latest recommended workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->