### PR TITLE
[WIP] fix(main): declare posthog-js react peer so prod bundle resolves one React

### DIFF
--- a/.github/workflows/live-main-fe.yml
+++ b/.github/workflows/live-main-fe.yml
@@ -14,6 +14,11 @@ name: Deploy Live Main Frontend
       - 'apps/main/**'
       - 'packages/core/**'
       - 'packages/ui/**'
+      # The lockfile and workspace config change what gets bundled (dependency
+      # versions, packageExtensions) — a fix landing only there (like the
+      # duplicate-React removal in #392) must still deploy.
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
       - '.github/workflows/live-main-fe.yml'
 jobs:
   dev_deploy:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,8 @@ overrides:
   preact@>=10.26.5 <10.26.10: 10.26.10
   '@testing-library/dom': 10.4.0
 
+packageExtensionsChecksum: sha256-Z4VzRPmKENuiiMGZ9FrMLoVVMQAi0jexcBOQ/Zpa4pM=
+
 importers:
 
   .:
@@ -284,7 +286,7 @@ importers:
         version: link:../../packages/core
       posthog-js:
         specifier: ^1.395.0
-        version: 1.395.0
+        version: 1.395.0(react@19.2.7)
       react:
         specifier: ^19.2.0
         version: 19.2.7
@@ -10029,6 +10031,11 @@ packages:
 
   posthog-js@1.395.0:
     resolution: {integrity: sha512-5iTb00CGt2eQUUiBQysQiX89RAbCN6wK2sDNzvs9zv0alaY8mJ0ZySrUD3LQ+XyLhgM5pCpacBuUwChqiYDLDw==}
+    peerDependencies:
+      react: '*'
+    peerDependenciesMeta:
+      react:
+        optional: true
 
   preact@10.29.3:
     resolution: {integrity: sha512-D9NL1GAnJZhc3RndVs4gDdxEeU9TcHgywMrhhOsnpdlvFjdbx0gAsLUnH6JEhlJH5giL7Tx5biWPUSEXE/HPzw==}
@@ -24325,7 +24332,7 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  posthog-js@1.395.0:
+  posthog-js@1.395.0(react@19.2.7):
     dependencies:
       '@posthog/core': 1.38.0
       '@posthog/types': 1.391.1
@@ -24335,6 +24342,8 @@ snapshots:
       preact: 10.29.3
       query-selector-shadow-dom: 1.0.1
       web-vitals: 5.3.0
+    optionalDependencies:
+      react: 19.2.7
 
   preact@10.29.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,3 +19,16 @@ minimumReleaseAgeExclude:
 # Dependency lifecycle scripts are blocked (pnpm 10 default); nothing in the
 # workspace needs one — build/test verified green with all scripts ignored.
 onlyBuiltDependencies: []
+
+# posthog-js's react entry does a bare `import 'react'` without declaring it,
+# so resolution falls to whatever react pnpm happens to hoist — the cause of
+# the prod duplicate-React crash (#392) and, once react 18 was removed, of
+# builds failing to resolve react at all. Declare the peer so pnpm links the
+# importing app's own react next to posthog-js deterministically.
+packageExtensions:
+  posthog-js:
+    peerDependencies:
+      react: "*"
+    peerDependenciesMeta:
+      react:
+        optional: true


### PR DESCRIPTION
## Summary

Fixes the main app still crashing in production after #392. Two problems: the #392 fix never deployed (the deploy workflow's path filter ignores `pnpm-lock.yaml`), and with React 18 gone, `posthog-js`'s undeclared `react` import now fails to resolve at build time — so main was undeployable anyway. A pnpm `packageExtensions` entry gives `posthog-js` a proper react peer (it always links the app's own React), and the deploy workflow now also triggers on lockfile/workspace-config changes. Merging this triggers the prod deploy that actually ships the fix.

## Test plan

- [ ] After the deploy this merge triggers, open the **Main** app in production (hard refresh). It loads normally instead of the error screen.
- [ ] Verified locally: prod build with the PostHog key baked in compiles (it failed before), and a headless-browser probe of the built bundle renders the app with PostHogProvider mounted and zero React errors.
- [ ] CI green