### PR TITLE
[WIP] fix(ci): pass required app env vars to main deploy builds

### DIFF
--- a/.github/workflows/live-main-fe.yml
+++ b/.github/workflows/live-main-fe.yml
@@ -53,6 +53,14 @@ jobs:
           VITE_MESSAGING_SENDER_ID: ${{ secrets.VITE_MESSAGING_SENDER_ID }}
           VITE_APP_ID: ${{ secrets.VITE_APP_ID }}
           VITE_MEASUREMENT_ID: ${{ secrets.VITE_MEASUREMENT_ID }}
+          # Required by apps/main config.ts (validateEnvVars throws without
+          # them, blank page). Mirrors live-watch-fe.yml.
+          VITE_AUTH0_DOMAIN: ${{ secrets.VITE_AUTH0_DOMAIN }}
+          VITE_AUTH0_CLIENT_ID: ${{ secrets.VITE_AUTH0_CLIENT_ID }}
+          VITE_HASURA_DOMAIN: ${{ vars.VITE_HASURA_DOMAIN }}
+          VITE_MAIN_SITE_URL: ${{ vars.VITE_MAIN_SITE_URL }}
+          VITE_ROLLBAR_TOKEN: ${{ vars.VITE_ROLLBAR_TOKEN }}
+          VITE_ROLLBAR_ENV: 'development'
       - name: Deploy main
         uses: FirebaseExtended/action-hosting-deploy@v0.9.0
         with:
@@ -98,6 +106,14 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           VITE_PUBLIC_POSTHOG_KEY: ${{ vars.VITE_PUBLIC_POSTHOG_KEY }}
           VITE_PUBLIC_POSTHOG_HOST: ${{ vars.VITE_PUBLIC_POSTHOG_HOST }}
+          # Required by apps/main config.ts (validateEnvVars throws without
+          # them, blank page). Mirrors live-watch-fe.yml.
+          VITE_AUTH0_DOMAIN: ${{ secrets.VITE_AUTH0_DOMAIN }}
+          VITE_AUTH0_CLIENT_ID: ${{ secrets.VITE_AUTH0_CLIENT_ID }}
+          VITE_HASURA_DOMAIN: ${{ vars.VITE_HASURA_DOMAIN }}
+          VITE_MAIN_SITE_URL: ${{ vars.VITE_MAIN_SITE_URL }}
+          VITE_ROLLBAR_TOKEN: ${{ vars.VITE_ROLLBAR_TOKEN }}
+          VITE_ROLLBAR_ENV: 'production'
       - name: Deploy main
         uses: FirebaseExtended/action-hosting-deploy@v0.9.0
         with:


### PR DESCRIPTION
## Summary

Fixes the main app deploying as a blank page. The deploy workflow's Build steps never passed the env vars the app requires (Auth0, Hasura, site URL, Rollbar), so every CI-built bundle throws `Missing required environment variables` on load — prod only ever worked from manually-built deploys. The values already exist as GitHub environment secrets/vars (the watch deploy uses the identical block); main's workflow now passes them too, for both the dev and prod jobs. Merging triggers the prod deploy that ships a working bundle, completing #394.

## Test plan

- [ ] After the deploy this merge triggers, open the **Main** app in production (hard refresh). It loads to the normal app instead of a blank page.
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to include the required environment settings for frontend builds in both development and production.
  * This should help ensure more reliable builds and smoother deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->