### PR TITLE
[WIP] feat(ui): swap Play for Main in site switcher

### DIFF
--- a/apps/listen/src/config.ts
+++ b/apps/listen/src/config.ts
@@ -16,7 +16,6 @@ const appConfig = {
     main: mainDomain,
     listen: `https://listen.${mainDomain}`,
     watch: `https://watch.${mainDomain}`,
-    play: `https://play.${mainDomain}`,
     til: `https://til.${mainDomain}`,
   },
 };

--- a/apps/main/src/config.ts
+++ b/apps/main/src/config.ts
@@ -23,7 +23,6 @@ const appConfig = {
     main: import.meta.env.VITE_MAIN_SITE_URL,
     listen: `https://listen.${mainDomain}`,
     watch: `https://watch.${mainDomain}`,
-    play: `https://play.${mainDomain}`,
     til: `https://til.${mainDomain}`,
   },
 };

--- a/apps/til/src/config.ts
+++ b/apps/til/src/config.ts
@@ -18,7 +18,6 @@ const appConfig = {
     main: mainDomain,
     listen: `https://listen.${mainDomain}`,
     watch: `https://watch.${mainDomain}`,
-    play: `https://play.${mainDomain}`,
     til: `https://til.${mainDomain}`,
   },
 };

--- a/apps/watch/src/config.ts
+++ b/apps/watch/src/config.ts
@@ -24,7 +24,6 @@ const appConfig = {
     main: import.meta.env.VITE_MAIN_SITE_URL,
     listen: `https://listen.${mainDomain}`,
     watch: `https://watch.${mainDomain}`,
-    play: `https://play.${mainDomain}`,
     til: `https://til.${mainDomain}`,
   },
 };

--- a/packages/ui/src/listen/minimalism/header/index.stories.tsx
+++ b/packages/ui/src/listen/minimalism/header/index.stories.tsx
@@ -60,7 +60,10 @@ The header is built using Material-UI's AppBar and Toolbar components with the f
       description: 'Site choices for navigation links',
       control: 'object',
       table: {
-        type: { summary: '{ listen: string; watch: string; play: string }' },
+        type: {
+          summary:
+            '{ main: string; listen: string; watch: string; til: string }',
+        },
       },
     },
   },
@@ -74,9 +77,10 @@ const defaultArgs = {
     console.log('Profile clicked');
   },
   sites: {
+    main: 'Main',
     listen: 'Listen',
     watch: 'Watch',
-    play: 'Play',
+    til: 'TIL',
   },
 };
 

--- a/packages/ui/src/listen/minimalism/header/index.test.tsx
+++ b/packages/ui/src/listen/minimalism/header/index.test.tsx
@@ -16,9 +16,10 @@ describe('Header', () => {
   const defaultProps = {
     onProfileClick: vi.fn(),
     sites: {
+      main: 'main',
       listen: 'listen',
       watch: 'watch',
-      play: 'play',
+      til: 'til',
     },
     user: null,
   };

--- a/packages/ui/src/listen/minimalism/header/index.tsx
+++ b/packages/ui/src/listen/minimalism/header/index.tsx
@@ -11,9 +11,9 @@ import SiteChoices from '../../../universal/site-choices';
 interface HeaderProps {
   onProfileClick: () => void;
   sites: {
+    main: string;
     listen: string;
     watch: string;
-    play: string;
     til: string;
   };
   user: Auth.CustomUser | null;

--- a/packages/ui/src/listen/minimalism/listening-screen/index.stories.tsx
+++ b/packages/ui/src/listen/minimalism/listening-screen/index.stories.tsx
@@ -17,7 +17,7 @@ const meta: Meta<typeof ListeningScreen> = {
   component: ListeningScreen,
   parameters: { layout: 'fullscreen' },
   args: {
-    sites: { listen: '#', watch: '#', play: '#', til: '#' },
+    sites: { main: '#', listen: '#', watch: '#', til: '#' },
     user: null,
     onSignIn: () => {},
     onLogout: () => {},

--- a/packages/ui/src/listen/minimalism/listening-screen/index.test.tsx
+++ b/packages/ui/src/listen/minimalism/listening-screen/index.test.tsx
@@ -26,7 +26,7 @@ vi.mock('../collection-select', () => ({
 }));
 
 const baseProps = {
-  sites: { listen: '', watch: '', play: '', til: '' },
+  sites: { main: '', listen: '', watch: '', til: '' },
   user: null,
   onSignIn: vi.fn(),
   onLogout: vi.fn(),

--- a/packages/ui/src/listen/minimalism/listening-screen/index.tsx
+++ b/packages/ui/src/listen/minimalism/listening-screen/index.tsx
@@ -14,9 +14,9 @@ import { SettingsPanel } from '../home/settings';
 import { CreatePlaylistDialog } from '../playlists/create-dialog';
 
 interface HeaderSites {
+  main: string;
   listen: string;
   watch: string;
-  play: string;
   til: string;
 }
 

--- a/packages/ui/src/til/header/index.test.tsx
+++ b/packages/ui/src/til/header/index.test.tsx
@@ -21,9 +21,9 @@ vi.mock('../../universal/site-choices', () => ({
 
 describe('Header', () => {
   const mockSites = {
+    main: '/main',
     listen: '/listen',
     watch: '/watch',
-    play: '/play',
     til: '/til',
   };
 

--- a/packages/ui/src/til/header/index.tsx
+++ b/packages/ui/src/til/header/index.tsx
@@ -12,9 +12,9 @@ import type { WithLinkComponent } from '../../watch/videos/types';
 
 interface HeaderProps extends WithLinkComponent {
   sites: {
+    main: string;
     listen: string;
     watch: string;
-    play: string;
     til: string;
   };
   user: Auth.CustomUser | null;

--- a/packages/ui/src/universal/site-choices/index.stories.tsx
+++ b/packages/ui/src/universal/site-choices/index.stories.tsx
@@ -18,9 +18,10 @@ export const Default: Story = {
   args: {
     activeSite: 'listen',
     sites: {
+      main: 'https://example.com',
       listen: 'https://listen.example.com',
       watch: 'https://watch.example.com',
-      play: 'https://play.example.com',
+      til: 'https://til.example.com',
     },
   },
 };

--- a/packages/ui/src/universal/site-choices/index.test.tsx
+++ b/packages/ui/src/universal/site-choices/index.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import SiteChoices from './index';
 import '@testing-library/jest-dom';
 
@@ -7,9 +7,9 @@ describe('SiteChoices', () => {
   const defaultProps = {
     activeSite: 'listen',
     sites: {
+      main: 'http://example.com',
       listen: 'http://listen.example.com',
       watch: 'http://watch.example.com',
-      play: 'http://play.example.com',
       til: 'http://til.example.com',
     },
   };
@@ -45,10 +45,10 @@ describe('SiteChoices', () => {
     const menuItems = screen.getAllByRole('menuitem');
     expect(menuItems).toHaveLength(4);
 
-    // Check all menu items are present
-    expect(menuItems[0]).toHaveTextContent('Watch');
-    expect(menuItems[1]).toHaveTextContent('Listen');
-    expect(menuItems[2]).toHaveTextContent('Play');
+    // Check all menu items are present, Main first
+    expect(menuItems[0]).toHaveTextContent('Main');
+    expect(menuItems[1]).toHaveTextContent('Watch');
+    expect(menuItems[2]).toHaveTextContent('Listen');
     expect(menuItems[3]).toHaveTextContent('TIL');
   });
 
@@ -62,20 +62,18 @@ describe('SiteChoices', () => {
     const menuItems = screen.getAllByRole('menuitem');
 
     // Check icons within menu items
-    const watchIcon = menuItems[0].querySelector(
+    const mainIcon = menuItems[0].querySelector('[data-testid="HomeIcon"]');
+    const watchIcon = menuItems[1].querySelector(
       '[data-testid="OndemandVideoIcon"]',
     );
-    const listenIcon = menuItems[1].querySelector(
+    const listenIcon = menuItems[2].querySelector(
       '[data-testid="HeadphonesIcon"]',
-    );
-    const playIcon = menuItems[2].querySelector(
-      '[data-testid="PlayCircleIcon"]',
     );
     const tilIcon = menuItems[3].querySelector('[data-testid="MenuBookIcon"]');
 
+    expect(mainIcon).toBeInTheDocument();
     expect(watchIcon).toBeInTheDocument();
     expect(listenIcon).toBeInTheDocument();
-    expect(playIcon).toBeInTheDocument();
     expect(tilIcon).toBeInTheDocument();
   });
 
@@ -87,9 +85,9 @@ describe('SiteChoices', () => {
 
     // Check hrefs
     const menuItems = screen.getAllByRole('menuitem');
-    expect(menuItems[0]).toHaveAttribute('href', 'http://watch.example.com');
-    expect(menuItems[1]).toHaveAttribute('href', 'http://listen.example.com');
-    expect(menuItems[2]).toHaveAttribute('href', 'http://play.example.com');
+    expect(menuItems[0]).toHaveAttribute('href', 'http://example.com');
+    expect(menuItems[1]).toHaveAttribute('href', 'http://watch.example.com');
+    expect(menuItems[2]).toHaveAttribute('href', 'http://listen.example.com');
     expect(menuItems[3]).toHaveAttribute('href', 'http://til.example.com');
   });
 
@@ -102,12 +100,13 @@ describe('SiteChoices', () => {
     // Get all menu items
     const menuItems = screen.getAllByRole('menuitem');
 
-    // Listen should be selected (index 1 in the menu items array)
-    expect(menuItems[1]).toHaveClass('Mui-selected');
+    // Listen should be selected (index 2 in the menu items array)
+    expect(menuItems[2]).toHaveClass('Mui-selected');
 
     // Others should not be selected
     expect(menuItems[0]).not.toHaveClass('Mui-selected');
-    expect(menuItems[2]).not.toHaveClass('Mui-selected');
+    expect(menuItems[1]).not.toHaveClass('Mui-selected');
+    expect(menuItems[3]).not.toHaveClass('Mui-selected');
   });
 
   it('closes menu when clicking outside', () => {
@@ -139,11 +138,11 @@ describe('SiteChoices', () => {
     ).toBeInTheDocument();
 
     // Rerender with different active site
-    rerender(<SiteChoices {...defaultProps} activeSite="play" />);
+    rerender(<SiteChoices {...defaultProps} activeSite="main" />);
 
-    const playButton = screen.getByRole('button', { name: /site choices/i });
+    const mainButton = screen.getByRole('button', { name: /site choices/i });
     expect(
-      playButton.querySelector('[data-testid="PlayCircleIcon"]'),
+      mainButton.querySelector('[data-testid="HomeIcon"]'),
     ).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/universal/site-choices/index.tsx
+++ b/packages/ui/src/universal/site-choices/index.tsx
@@ -1,8 +1,8 @@
 import { MenuBook } from '@mui/icons-material';
 import Headphones from '@mui/icons-material/Headphones';
+import Home from '@mui/icons-material/Home';
 import KeyboardArrowDown from '@mui/icons-material/KeyboardArrowDown';
 import OndemandVideo from '@mui/icons-material/OndemandVideo';
-import PlayCircle from '@mui/icons-material/PlayCircle';
 import Button from '@mui/material/Button';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
@@ -12,6 +12,10 @@ import { useState } from 'react';
 
 const sites = [
   {
+    name: 'Main',
+    value: 'main',
+  },
+  {
     name: 'Watch',
     value: 'watch',
   },
@@ -20,30 +24,26 @@ const sites = [
     value: 'listen',
   },
   {
-    name: 'Play',
-    value: 'play',
-  },
-  {
     name: 'TIL',
     value: 'til',
   },
 ];
 
 const siteIcons = {
+  main: <Home fontSize="small" />,
   listen: <Headphones fontSize="small" />,
   watch: <OndemandVideo fontSize="small" />,
-  play: <PlayCircle fontSize="small" />,
   til: <MenuBook fontSize="small" />,
 } as const;
 
-type SiteName = 'listen' | 'watch' | 'play' | 'til';
+type SiteName = 'main' | 'listen' | 'watch' | 'til';
 
 interface SiteChoicesProps {
   activeSite: string;
   sites: {
+    main: string;
     listen: string;
     watch: string;
-    play: string;
     til: string;
   };
 }

--- a/packages/ui/src/watch/header/index.stories.tsx
+++ b/packages/ui/src/watch/header/index.stories.tsx
@@ -62,7 +62,10 @@ The header is built using Material-UI's AppBar and Toolbar components with the f
       description: 'Site choices for navigation links',
       control: 'object',
       table: {
-        type: { summary: '{ listen: string; watch: string; play: string }' },
+        type: {
+          summary:
+            '{ main: string; listen: string; watch: string; til: string }',
+        },
       },
     },
   },
@@ -76,9 +79,10 @@ const defaultArgs = {
     console.log(value);
   },
   sites: {
+    main: 'Main',
     listen: 'Listen',
     watch: 'Watch',
-    play: 'Play',
+    til: 'TIL',
   },
 };
 

--- a/packages/ui/src/watch/header/index.test.tsx
+++ b/packages/ui/src/watch/header/index.test.tsx
@@ -27,9 +27,9 @@ describe('Header', () => {
   const defaultProps = {
     toggleSetting: vi.fn(),
     sites: {
+      main: 'main',
       listen: 'listen',
       watch: 'watch',
-      play: 'play',
       til: 'til',
     },
     user: null,

--- a/packages/ui/src/watch/header/index.tsx
+++ b/packages/ui/src/watch/header/index.tsx
@@ -19,9 +19,9 @@ const Notifications = lazy(() => import('./notifications'));
 interface HeaderProps extends RequiredLinkComponentWithoutLinkProps {
   toggleSetting: React.Dispatch<React.SetStateAction<boolean>>;
   sites: {
+    main: string;
     listen: string;
     watch: string;
-    play: string;
     til: string;
   };
   user: Auth.CustomUser | null;


### PR DESCRIPTION
## Summary

Removes the dead **Play** entry from the site switcher (the game app is retired) and adds **Main** as the first switcher item with a Home icon, so satellite apps (listen, watch, til) can navigate back to the hub. The Main app itself intentionally keeps no switcher.

- `packages/ui/src/universal/site-choices` — drop `play` from the sites array, icons map, `SiteName` type and props; add `main` first with a `Home` icon (menu order: Main, Watch, Listen, TIL)
- `apps/{listen,watch,til,main}/src/config.ts` — drop the dead `play` URL (`main` was already present)
- Header (`listen`/`watch`/`til`) and listening-screen `sites` prop types, plus their tests and stories, updated to the new shape

Closes SWO-380.

## Test plan

- `packages/ui` typecheck green; `listen`/`watch`/`til`/`main` app typechecks green
- 47 affected UI tests pass (site-choices, listen/watch/til headers, listening-screen)
- Biome clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new main site link across navigation and headers.
  * Updated site menus and story previews to show the current set of sites: main, listen, watch, and til.

* **Bug Fixes**
  * Removed the outdated play site link from app configurations and UI components.
  * Aligned headers, menus, and tests with the updated site link set and ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->