### PR TITLE
[WIP] fix(ui): site switcher Main link opens the main site

### DIFF
--- a/apps/listen/src/config.ts
+++ b/apps/listen/src/config.ts
@@ -13,7 +13,7 @@ const queryConfig = {
 const mainDomain = import.meta.env.VITE_MAIN_SITE_URL;
 const appConfig = {
   sites: {
-    main: mainDomain,
+    main: `https://${mainDomain}`,
     listen: `https://listen.${mainDomain}`,
     watch: `https://watch.${mainDomain}`,
     til: `https://til.${mainDomain}`,

--- a/apps/main/src/config.ts
+++ b/apps/main/src/config.ts
@@ -20,7 +20,7 @@ const rollbarConfig = {
 const mainDomain = import.meta.env.VITE_MAIN_SITE_URL;
 const appConfig = {
   sites: {
-    main: import.meta.env.VITE_MAIN_SITE_URL,
+    main: `https://${mainDomain}`,
     listen: `https://listen.${mainDomain}`,
     watch: `https://watch.${mainDomain}`,
     til: `https://til.${mainDomain}`,

--- a/apps/til/src/config.ts
+++ b/apps/til/src/config.ts
@@ -15,7 +15,7 @@ const queryConfig = {
 const mainDomain = import.meta.env.VITE_MAIN_SITE_URL;
 const appConfig = {
   sites: {
-    main: mainDomain,
+    main: `https://${mainDomain}`,
     listen: `https://listen.${mainDomain}`,
     watch: `https://watch.${mainDomain}`,
     til: `https://til.${mainDomain}`,

--- a/apps/watch/src/config.ts
+++ b/apps/watch/src/config.ts
@@ -21,7 +21,7 @@ const queryConfig = {
 const mainDomain = import.meta.env.VITE_MAIN_SITE_URL;
 const appConfig = {
   sites: {
-    main: import.meta.env.VITE_MAIN_SITE_URL,
+    main: `https://${mainDomain}`,
     listen: `https://listen.${mainDomain}`,
     watch: `https://watch.${mainDomain}`,
     til: `https://til.${mainDomain}`,

--- a/packages/ui/src/universal/site-choices/index.test.tsx
+++ b/packages/ui/src/universal/site-choices/index.test.tsx
@@ -91,6 +91,20 @@ describe('SiteChoices', () => {
     expect(menuItems[3]).toHaveAttribute('href', 'http://til.example.com');
   });
 
+  // Regression guard for SWO-393: the Main entry (added in SWO-380) shipped as a
+  // scheme-less bare domain, which the browser treats as a relative path. Every
+  // site link, Main included, must be an absolute URL with a scheme.
+  it('renders every site link as an absolute URL', () => {
+    render(<SiteChoices {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    const menuItems = screen.getAllByRole('menuitem');
+    for (const menuItem of menuItems) {
+      expect(menuItem.getAttribute('href')).toMatch(/^https?:\/\//);
+    }
+  });
+
   it('shows correct selected state for active site', () => {
     render(<SiteChoices {...defaultProps} />);
 


### PR DESCRIPTION
## Summary

Fixes the **Main** entry in the site switcher menu (top of the Watch, Listen, and TIL apps). Before, clicking **Main** went to a broken address and 404'd; now it opens the main site correctly. This fixes a regression introduced in #398 (SWO-380) when the Main entry was first added. SWO-393.

## Test plan

- [ ] Open the **Watch**, **Listen**, or **TIL** app, click the site switcher at the top, and choose **Main**. It should open the main site, not a "page not found".
- [ ] From the same menu, confirm **Watch**, **Listen**, and **TIL** still open their own sites.
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured the main site URL is always built with a secure `https://` scheme across affected apps.
  * Fixed site selector links so all menu destinations use full absolute URLs instead of bare domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->