### PR TITLE
fix(watch): video-card text padding and thumbnail corner rounding (SWO-395)

### DIFF
--- a/packages/ui/src/watch/videos/video-card/index.tsx
+++ b/packages/ui/src/watch/videos/video-card/index.tsx
@@ -45,7 +45,7 @@ const VideoCardContent = (props: VideoCardContentProps) => {
   const { title, creator, createdTime } = props;
 
   return (
-    <CardContent sx={{ px: 0, pt: 2, '&:last-child': { pb: 1 } }}>
+    <CardContent sx={{ px: 2, pt: 2, '&:last-child': { pb: 2 } }}>
       <StyledTitle gutterBottom variant="body1" component="h3">
         {title}
       </StyledTitle>
@@ -205,9 +205,7 @@ const VideoCard = (props: VideoCardProps) => {
 
   const cardContent = (
     <StyledCard>
-      <Box sx={{ position: 'relative', borderRadius: 1, overflow: 'hidden' }}>
-        <VideoContent video={video} asLink={asLink} />
-      </Box>
+      <VideoContent video={video} asLink={asLink} />
       <VideoCardContent
         title={getMediaDisplayName({
           videoTitle: video.title,

--- a/packages/ui/src/watch/videos/video-card/skeleton.tsx
+++ b/packages/ui/src/watch/videos/video-card/skeleton.tsx
@@ -5,11 +5,11 @@ import Skeleton from '@mui/material/Skeleton';
 const VideoSkeleton = () => (
   <Card aria-busy="true" sx={{ height: '100%', boxShadow: 'none' }}>
     <Skeleton
-      variant="rounded"
+      variant="rectangular"
       height={200}
       sx={{ aspectRatio: '16/9', width: '100%' }}
     />
-    <CardContent sx={{ px: 0, pt: 2, '&:last-child': { pb: 1 } }}>
+    <CardContent sx={{ px: 2, pt: 2, '&:last-child': { pb: 2 } }}>
       <Skeleton width="80%" height={24} sx={{ mb: 1 }} />
       <Skeleton width="60%" height={20} />
     </CardContent>


### PR DESCRIPTION
## Summary

The MUI 6→9 upgrade surfaced two pre-existing quirks in the watch video card that now read as visual bugs. Fixes both, scoped to the `video-card` component:

- **Text hugged the card edge** — `CardContent` had `px: 0`. Now `px: 2` (+ `pb: 2`) so the title / `creator • date` get horizontal breathing room.
- **Thumbnail's bottom corners were rounded** — the wrapper `Box` rounded all four corners against the card body, notching the progress bar. Dropped its `borderRadius`/`overflow`; the `Card`'s own `overflow: hidden` + 12px radius now clips **only the top** corners → rounded top, square bottom.
- Removed the now-redundant `position: relative` wrapper `Box` (each `VideoContent` branch already establishes its own positioning context).
- Kept the loading skeleton in lockstep (`rectangular` placeholder + matching padding) so there's no load→content layout shift.

Closes SWO-395.

## Test plan

- [x] Ran the watch app locally (`pnpm dev:watch`) and confirmed on the home grid: title/date now inset, thumbnail has rounded top / square bottom, progress bar runs edge-to-edge with no notch.
- [x] Verified all three `VideoContent` paths (thumbnail / playlist / inline-player) self-position, so removing the wrapper is structurally inert.
- [x] Biome clean; self-review + high-effort `/code-review` both clean.
