### PR TITLE
[WIP] fix(listen): opaque playing-list overlay so controls don't bleed through (SWO-394)

### DIFF
--- a/packages/ui/src/listen/minimalism/music-widget/Styled.tsx
+++ b/packages/ui/src/listen/minimalism/music-widget/Styled.tsx
@@ -30,7 +30,12 @@ const StyledPlayingList = styled(Box)<BoxProps>(({ theme }) => {
     height: '244px',
     bottom: 0,
     overflowY: 'auto',
-    backgroundColor: theme.palette.background.paper,
+    // This list slides up directly over the player controls with no backdrop
+    // scrim, so the base translucent glass Paper let them bleed through. Use the
+    // theme's opaque `overlay` surface; fall back to Paper for any non-glass
+    // theme (where Paper is already opaque) so the panel is never transparent.
+    backgroundColor:
+      theme.palette.background.overlay ?? theme.palette.background.paper,
     color: theme.palette.text.primary,
   };
 }) as any;

--- a/packages/ui/src/universal/minimalism/domainPalette.ts
+++ b/packages/ui/src/universal/minimalism/domainPalette.ts
@@ -24,13 +24,21 @@ const financePalette: FinancePalette = {
   default: '#6b7280', // gray-500
 };
 
-// Augment MUI's palette so `theme.palette.finance` is typed everywhere.
+// Augment MUI's palette so `theme.palette.finance` is typed everywhere, plus a
+// `background.overlay` surface — the fully opaque background for scrim-less
+// panels (the player's playing list) that slide over other content, where the
+// base translucent glass Paper would let it bleed through. Optional: only the
+// glassmorphism themes define it, so reads under any other theme are honestly
+// `string | undefined`.
 declare module '@mui/material/styles' {
   interface Palette {
     finance: FinancePalette;
   }
   interface PaletteOptions {
     finance?: FinancePalette;
+  }
+  interface TypeBackground {
+    overlay?: string;
   }
 }
 

--- a/packages/ui/src/universal/minimalism/themeGlassmorphism.ts
+++ b/packages/ui/src/universal/minimalism/themeGlassmorphism.ts
@@ -18,6 +18,12 @@ const glassmorphismTheme = createTheme({
     background: {
       default: 'transparent',
       paper: 'rgba(255, 255, 255, 0.05)',
+      // Fully opaque surface for the playing list, which slides up over the
+      // player controls and must hide them completely. Menus use a 0.92 glass
+      // tint because they float over a page, but this panel covers same-card
+      // content, so it goes solid (the opaque form of the menu hue). Typed in
+      // `./domainPalette`.
+      overlay: 'rgb(26, 26, 62)',
     },
     primary: {
       main: '#667eea',

--- a/packages/ui/src/universal/minimalism/themeGlassmorphismLight.ts
+++ b/packages/ui/src/universal/minimalism/themeGlassmorphismLight.ts
@@ -18,6 +18,12 @@ const lightGlassmorphismTheme = createTheme({
     background: {
       default: 'transparent',
       paper: 'rgba(255, 255, 255, 0.15)',
+      // Fully opaque surface for the playing list, which slides up over the
+      // player controls and must hide them completely. Menus use a 0.92 glass
+      // tint because they float over a page, but this panel covers same-card
+      // content, so it goes solid (the opaque form of the menu hue). Typed in
+      // `./domainPalette`.
+      overlay: 'rgb(255, 255, 255)',
     },
     primary: {
       main: '#667eea',

--- a/packages/ui/src/watch/videos/video-card/index.tsx
+++ b/packages/ui/src/watch/videos/video-card/index.tsx
@@ -45,7 +45,7 @@ const VideoCardContent = (props: VideoCardContentProps) => {
   const { title, creator, createdTime } = props;
 
   return (
-    <CardContent sx={{ px: 0, pt: 2, '&:last-child': { pb: 1 } }}>
+    <CardContent sx={{ px: 2, pt: 2, '&:last-child': { pb: 2 } }}>
       <StyledTitle gutterBottom variant="body1" component="h3">
         {title}
       </StyledTitle>
@@ -205,9 +205,7 @@ const VideoCard = (props: VideoCardProps) => {
 
   const cardContent = (
     <StyledCard>
-      <Box sx={{ position: 'relative', borderRadius: 1, overflow: 'hidden' }}>
-        <VideoContent video={video} asLink={asLink} />
-      </Box>
+      <VideoContent video={video} asLink={asLink} />
       <VideoCardContent
         title={getMediaDisplayName({
           videoTitle: video.title,

--- a/packages/ui/src/watch/videos/video-card/skeleton.tsx
+++ b/packages/ui/src/watch/videos/video-card/skeleton.tsx
@@ -5,11 +5,11 @@ import Skeleton from '@mui/material/Skeleton';
 const VideoSkeleton = () => (
   <Card aria-busy="true" sx={{ height: '100%', boxShadow: 'none' }}>
     <Skeleton
-      variant="rounded"
+      variant="rectangular"
       height={200}
       sx={{ aspectRatio: '16/9', width: '100%' }}
     />
-    <CardContent sx={{ px: 0, pt: 2, '&:last-child': { pb: 1 } }}>
+    <CardContent sx={{ px: 2, pt: 2, '&:last-child': { pb: 2 } }}>
       <Skeleton width="80%" height={24} sx={{ mb: 1 }} />
       <Skeleton width="60%" height={20} />
     </CardContent>


### PR DESCRIPTION
## Summary

The player's playing list (the queue that slides up when you tap the library-music button) rendered **transparently on top of the player controls** — the track titles overlapped the title/artist/seeker/controls into an unreadable mess.

Root cause: `StyledPlayingList` used `background.paper` as its background. The glassmorphism migration (SWO-384) made `background.paper` near-transparent (`rgba(255,255,255,0.05)`), and this list floats over the controls with no backdrop scrim — so they bled straight through.

Fix: add a **fully opaque** `background.overlay` surface to both glass themes and point the playing list at it, so it hides the controls completely (as it did before the migration). It's solid rather than the 0.92 glass tint menus use, because this panel covers same-card content instead of floating over a page. Falls back to the theme's default Paper for any non-glass theme (already opaque) so the panel is never transparent; the surface lives in the theme, so a provider swap stays the full re-skin (two-case styling model).

## Test plan

- [ ] Listen → open a track → tap the playing-list toggle: the list fully covers the player controls, no bleed-through, in both light and dark themes
- [ ] Track titles are legible; the currently-playing track stays highlighted
- [ ] `pnpm --filter ui typecheck` and the music-widget tests pass

SWO-394


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new opaque background surface for certain panels, improving readability in glass and light themes.
* **Bug Fixes**
  * Updated card and video layout spacing for a cleaner, more balanced appearance.
  * Improved video card rendering so content now displays correctly without extra clipping or wrapping issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->