### PR TITLE
[WIP] fix(watch): related-list title colour on dark theme (SWO-398)

### DIFF
--- a/packages/ui/src/watch/videos/list-item/styled.tsx
+++ b/packages/ui/src/watch/videos/list-item/styled.tsx
@@ -79,14 +79,17 @@ const Progress = styled(Box)({
   height: '100%', // bgColor
 }) as typeof Box;
 
-const TitleText = styled(Typography)({
+const TitleText = styled(Typography)(({ theme }) => ({
+  // Explicit theme colour so the title doesn't inherit the surrounding
+  // anchor's default link colour (blue/visited-purple) — broken on dark theme.
+  color: theme.palette.text.primary,
   fontWeight: 500,
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   display: '-webkit-box',
   WebkitLineClamp: 2,
   WebkitBoxOrient: 'vertical',
-}) as typeof Typography;
+})) as typeof Typography;
 
 const UsernameText = styled(Typography)({
   display: 'block',


### PR DESCRIPTION
## Summary

Related-list video titles (watch app) inherited the surrounding anchor's default link colour (blue / visited-purple), which was broken on the dark theme. Pins `TitleText` to `theme.palette.text.primary` so titles use primary body-text colour in both light and dark themes.

Fixes SWO-398.

## Test plan

- `pnpm lint` (Biome) — clean
- `pnpm turbo run typecheck --filter=ui` — passes
- Visual: related-list titles render in primary text colour on both light and dark themes (no link blue/purple).