### PR TITLE
[WIP] perf(til): split vendor chunks so shiki/editor load lazily

### DIFF
--- a/apps/til/vite.config.ts
+++ b/apps/til/vite.config.ts
@@ -21,19 +21,39 @@ export default defineConfig({
         advancedChunks: {
           groups: [
             /**
-             * App broken if bundle mui separately
+             * Keep the React + MUI framework together in one eager chunk.
+             * App breaks if MUI is split into its own chunk (multiple emotion
+             * instances / init order), so react, react-dom, emotion and mui
+             * must ship together.
+             *
+             * The regex is anchored to `/node_modules/<pkg>/` so it matches the
+             * actual installed package, NOT pnpm's peer-suffixed store dirs
+             * (e.g. `.../@tiptap+react@3_react@19.2.7/...`). The previous
+             * `/node_modules.*react/` greedily swept every package with a React
+             * peer dep — tiptap, prosemirror, etc. — into this eager chunk,
+             * defeating the route-level `lazy()` splitting.
              */
-            { name: 'react-vendor', test: /node_modules.*react/ },
-            /** For error tracking, analytics */
-            { name: 'tracker-vendor', test: /\/node_modules\/rollbar/ },
-            { name: 'vendor', test: /node_modules/ },
+            {
+              name: 'react-vendor',
+              test: /[\\/]node_modules[\\/](react-dom|react|scheduler|use-sync-external-store|@emotion|@mui)[\\/]/,
+            },
+            /** Error tracking — kept separate so it can be evicted later. */
+            {
+              name: 'tracker-vendor',
+              test: /[\\/]node_modules[\\/]rollbar[\\/]/,
+            },
+            /**
+             * Everything else is intentionally left to rolldown's automatic
+             * code-splitting: the lazy editor (tiptap/prosemirror) and shiki's
+             * per-language grammars then load on demand instead of eagerly.
+             */
           ],
         },
       },
     },
   },
   plugins: [
-    TanStackRouterVite(),
+    TanStackRouterVite({ autoCodeSplitting: true }),
     react(),
     codecovVitePlugin({
       enableBundleAnalysis: !!codecovToken,


### PR DESCRIPTION
## Summary

Lighthouse flagged "unused JavaScript" on the til app, but the real issue was bigger: the entire vendor blob (~1.46 MB gzip in prod) was `modulepreload`ed eagerly on every page load — shiki (all grammars), the tiptap/prosemirror editor, and marked — none of which the home page needs.

Root cause was in `apps/til/vite.config.ts`:

- The catch-all `{ name: 'vendor', test: /node_modules/ }` chunk group force-merged every dependency into one eagerly-preloaded chunk, defeating the existing route-level `lazy()` editor import and shiki's own per-grammar splitting.
- The `react-vendor` regex `/node_modules.*react/` was greedy — pnpm's `_react@19.2.7` peer suffix appears in tiptap/prosemirror paths, so nearly everything with a React peer dep was swept into the eager framework chunk.
- The posts route (react-markdown + shiki core + material-theme) was statically imported in the route tree, so it loaded on the home page even though home renders no markdown.

Changes:

- Anchor the `react-vendor` regex to the real framework packages (react, react-dom, scheduler, use-sync-external-store, @emotion, @mui) — MUI stays with React (required), editor libs fall out.
- Drop the catch-all `vendor` group; let rolldown auto-split the rest.
- Enable `autoCodeSplitting: true` on the TanStack Router plugin so the posts route becomes a lazy chunk.

Rollbar left eager on purpose: its root ErrorBoundary must catch load-time crashes, and it's only ~24 KB gzip.

**Result: eager critical-path JS ~1.9 MB → 278 KB gzip (−85%).** shiki grammars, oniguruma WASM, and the tiptap editor are now on-demand chunks.

## Test plan

- `cd apps/til && npx vite build` succeeds; `dist/index.html` no longer preloads a multi-MB vendor chunk (eager JS ~278 KB gzip).
- Verified with a production build + Playwright: home renders fully (MUI/emotion intact), and both auto-split route chunks (`/write`, `/posts/$slug/$id`) load with HTTP 200 and zero dynamic-import/chunk-load errors.

SWO-396
