### PR TITLE
[WIP] fix(watch): add top spacing between header and video detail content (SWO-399)

### DIFF
--- a/packages/ui/src/watch/video-detail-page/containers/index.tsx
+++ b/packages/ui/src/watch/video-detail-page/containers/index.tsx
@@ -253,9 +253,10 @@ const MainContent = (props: VideoDetailContainerProps) => {
       <Box
         sx={{
           width: '100%',
-          // Cap the player so its 16:9 height never exceeds the viewport
-          // minus room for the header and the title/actions row below it.
-          maxWidth: 'calc((100vh - 220px) * 16 / 9)',
+          // Cap the player so its 16:9 height never exceeds the viewport minus
+          // room for the container's top padding (pt: 3 = 24px), the header,
+          // and the title/actions row below it.
+          maxWidth: 'calc((100vh - 244px) * 16 / 9)',
           mx: 'auto',
         }}
       >
@@ -452,7 +453,9 @@ const VideoDetailContainer = (props: VideoDetailContainerProps) => {
   };
 
   return (
-    <Grid container spacing={2} sx={{ mt: 0 }}>
+    // Top padding for breathing room below the sticky header, matching the
+    // home page's `py: 3` spacing.
+    <Grid container spacing={2} sx={{ pt: 3 }}>
       <Grid
         container
         size={{

--- a/packages/ui/src/watch/video-detail-page/containers/styled.tsx
+++ b/packages/ui/src/watch/video-detail-page/containers/styled.tsx
@@ -1,11 +1,13 @@
 import { Box } from '@mui/material';
 import { styled } from '@mui/material/styles';
 
+// Reserves include the container's `pt: 3` (24px) top padding so the scroll
+// region ends within the viewport (FullPageContainer clips at 100vh).
 const StyledRelatedContainer = styled(Box)(({ theme }) => ({
   overflowY: 'auto',
-  height: 'calc(100vh - 128px)',
+  height: 'calc(100vh - 152px)',
   [theme.breakpoints.down('sm')]: {
-    height: 'calc(100vh - 56.25vw - 180px)',
+    height: 'calc(100vh - 56.25vw - 204px)',
   },
 })) as typeof Box;
 


### PR DESCRIPTION
## Summary

The video detail and playlist detail pages rendered their content flush against the sticky header, with no breathing room. This adds `pt: 3` to the shared `VideoDetailContainer` root grid — one line, both routes benefit — matching the home page's `py: 3` spacing below the header.

Because `FullPageContainer` clips at `100vh` (`overflow: hidden`), the 24px of top padding shifts everything down 24px, so the layout's hardcoded viewport-height reserves were bumped by the same 24px to keep content from being clipped:
- Player height cap: `220px → 244px`
- Related-list column height: `128px → 152px` (desktop), `180px → 204px` (mobile)

Closes SWO-399.

## Test plan

- [ ] Open a video detail page (`/video/$slug/$id`) — content sits below the header with breathing room, no overlap.
- [ ] Open a playlist detail page (`/playlist/$slug/$playlistId/$videoId`) — same spacing applied.
- [ ] On a short/wide desktop viewport, confirm the title/actions row below the player stays fully visible (not clipped).
- [ ] On mobile, confirm the related-videos list scrolls and its last item is not clipped at the bottom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)