### PR TITLE
[WIP] fix(til): recalculate reading time when editing a post (SWO-403)

### DIFF
--- a/apps/til/src/routes/posts.$slug.$id.tsx
+++ b/apps/til/src/routes/posts.$slug.$id.tsx
@@ -3,7 +3,7 @@ import { Auth } from 'core';
 import { POST_STATUS, POST_VISIBILITY } from 'core/til/constants';
 import { useUpdatePost } from 'core/til/mutation-hooks/updatePost';
 import { useLoadPostDetail } from 'core/til/query-hooks/post-detail';
-import { slugify } from 'core/universal/common';
+import { calculateReadTime, slugify } from 'core/universal/common';
 import { lazy, Suspense, useEffect, useRef, useState } from 'react';
 
 import {
@@ -88,12 +88,14 @@ const RouteComponent = () => {
     if (!editorRef.current) return;
     setIsSaving(true);
     const markdown = editorRef.current.getMarkdown() || '';
+    const text = editorRef.current.getText().trim() || '';
     await updatePost({
       id: postId,
       object: {
         title: editableTitle.trim(),
         slug: slugify(editableTitle),
         markdownContent: markdown,
+        readTimeInMinutes: calculateReadTime(text),
       },
     });
     setIsSaving(false);

--- a/apps/til/src/routes/write.tsx
+++ b/apps/til/src/routes/write.tsx
@@ -4,7 +4,7 @@ import {
   useNavigate,
 } from '@tanstack/react-router';
 import { useInsertPost } from 'core/til/mutation-hooks/insertPost';
-import { slugify } from 'core/universal/common';
+import { calculateReadTime, slugify } from 'core/universal/common';
 import { lazy, Suspense, useEffect, useRef, useState } from 'react';
 import { EditorLoading, WriteForm } from 'ui/til/editor';
 import { AuthRoute } from 'ui/universal/authRoute';
@@ -107,10 +107,7 @@ function WritePageContent() {
           slug,
           markdownContent: content,
           brief: text.substring(0, 200) + (text.length > 200 ? '...' : ''),
-          readTimeInMinutes: Math.max(
-            1,
-            Math.ceil(text.split(/\s+/).filter(Boolean).length / 200),
-          ),
+          readTimeInMinutes: calculateReadTime(text),
         },
       });
     } catch (error) {

--- a/packages/core/src/universal/common/index.ts
+++ b/packages/core/src/universal/common/index.ts
@@ -6,9 +6,10 @@ import {
   getStartEndDates,
 } from './dateHelpers';
 import { formatNumber } from './numberHelpers';
-import { compareString, slugify } from './stringHelpers';
+import { calculateReadTime, compareString, slugify } from './stringHelpers';
 
 export {
+  calculateReadTime,
   compareString,
   formatDate,
   formatDateTime,

--- a/packages/core/src/universal/common/stringHelpers.test.ts
+++ b/packages/core/src/universal/common/stringHelpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  calculateReadTime,
   compareString,
   isValidEmail,
   isValidId,
@@ -189,5 +190,24 @@ describe('isValidEmail', () => {
     expect(isValidEmail('user_name@example.com')).toBe(true);
     expect(isValidEmail("!#$%&'*+-/=?^_`{|}~@example.com")).toBe(true);
     expect(isValidEmail("user!#$%&'*+-/=?^_`{|}~tag@example.com")).toBe(true);
+  });
+});
+
+describe('calculateReadTime', () => {
+  it('should return at least 1 minute for empty or short text', () => {
+    expect(calculateReadTime('')).toBe(1);
+    expect(calculateReadTime('   ')).toBe(1);
+    expect(calculateReadTime('a few words here')).toBe(1);
+  });
+
+  it('should round up to the nearest minute at 200 words per minute', () => {
+    expect(calculateReadTime('word '.repeat(200).trim())).toBe(1);
+    expect(calculateReadTime('word '.repeat(201).trim())).toBe(2);
+    expect(calculateReadTime('word '.repeat(400).trim())).toBe(2);
+    expect(calculateReadTime('word '.repeat(401).trim())).toBe(3);
+  });
+
+  it('should ignore extra whitespace between words', () => {
+    expect(calculateReadTime('one    two\n\tthree')).toBe(1);
   });
 });

--- a/packages/core/src/universal/common/stringHelpers.ts
+++ b/packages/core/src/universal/common/stringHelpers.ts
@@ -149,4 +149,12 @@ const isValidEmail = (email: string): boolean => {
   return emailRegex.test(email);
 };
 
-export { compareString, slugify, isValidId, isValidEmail };
+// Average adult reading speed, used to estimate a post's read time.
+const WORDS_PER_MINUTE = 200;
+
+const calculateReadTime = (text: string): number => {
+  const wordCount = text.split(/\s+/).filter(Boolean).length;
+  return Math.max(1, Math.ceil(wordCount / WORDS_PER_MINUTE));
+};
+
+export { compareString, slugify, isValidId, isValidEmail, calculateReadTime };


### PR DESCRIPTION
## Summary

Fixes `SWO-403`: editing a TIL post did not recalculate its reading time.

`readTimeInMinutes` was only computed on the **create** path (`write.tsx`); the edit save handler (`posts.$slug.$id.tsx`) persisted `title`/`slug`/`markdownContent` but never recomputed it, leaving the stored value stale after any edit.

- Extract the read-time formula into a shared `calculateReadTime` helper in `packages/core` (`stringHelpers.ts`), removing the duplicated inline `Math.max(1, Math.ceil(words / 200))`.
- Use it in both the create (`write.tsx`) and edit (`handleSave`) flows so both persist an up-to-date read time.
- Unit tests cover empty text, the per-minute rounding boundaries, and whitespace handling.

## Test plan

- [ ] Create a post → read time reflects content length (unchanged behaviour).
- [ ] Edit an existing post, change content length substantially, save → the displayed "min read" updates.
- [ ] `pnpm vitest run` in `packages/core` — `calculateReadTime` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic read-time estimates for posts, shown when creating or editing content.
  * Read time is now calculated consistently across the app, including saved posts.

* **Bug Fixes**
  * Improved read-time accuracy by handling extra whitespace and ensuring very short content still shows at least 1 minute.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->