### PR TITLE
[WIP] refactor(listen): drop unused public field from playlist create input (SWO-410)

### DIFF
--- a/packages/core/src/listen/mutation-hooks/index.test.ts
+++ b/packages/core/src/listen/mutation-hooks/index.test.ts
@@ -52,7 +52,6 @@ describe('Listen playlist mutation hooks', () => {
         slug: 'chill',
         thumbnailUrl: 'thumb.jpg',
         description: 'relax',
-        public: true,
       });
 
       expect(mockMutateAsync).toHaveBeenCalledWith({
@@ -61,7 +60,6 @@ describe('Listen playlist mutation hooks', () => {
           slug: 'chill',
           thumbnailUrl: 'thumb.jpg',
           description: 'relax',
-          public: true,
           site: 'listen',
         },
       });

--- a/packages/core/src/listen/mutation-hooks/index.ts
+++ b/packages/core/src/listen/mutation-hooks/index.ts
@@ -54,7 +54,6 @@ interface CreateListenPlaylistInput {
   slug: string;
   thumbnailUrl: string;
   description?: string;
-  public?: boolean;
 }
 
 interface PlaylistAudioRef {


### PR DESCRIPTION
## Summary

Removes the dead `public?: boolean` field from `CreateListenPlaylistInput`. No caller passes it — both `createPlaylist` call sites (`apps/listen/src/routes/index.lazy.tsx`, `playlists.$id.lazy.tsx`) send only `title/slug/thumbnailUrl`. The hook spreads `...input` into the insert object, so a stray `public` would be forwarded to Hasura.

This also removes a **trap** created by SWO-409 (parent SWO-404): once `public` is removed from the `user`-role `playlist` insert permission, any create that still forwarded `public` would fail the whole mutation with `field 'public' not found in type: 'playlist_insert_input'`. Deleting the unused field closes that window. (Playlists already default to private via the DB default.)

Part of SWO-404 — publishing is admin-only; the client never sends `public`.

## Test plan

- [x] `pnpm typecheck` (core) passes.
- [x] `pnpm vitest run src/listen/mutation-hooks/index.test.ts` — 8/8 pass; the create-playlist test no longer sends/expects `public`.
- [x] Confirmed no caller passes `public` to `createPlaylist`.

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Playlist creation now supports an optional description.
  * Created playlists are consistently labeled for the Listen experience.

* **Bug Fixes**
  * Updated validation expectations to match the latest playlist creation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->