### PR TITLE
[WIP] feat(listen): add audio update and delete mutation hooks (SWO-415)

### DIFF
--- a/packages/core/src/graphql/gql.ts
+++ b/packages/core/src/graphql/gql.ts
@@ -35,6 +35,8 @@ type Documents = {
     "\n  mutation AddAudioToPlaylist($object: playlist_audios_insert_input!) {\n    insert_playlist_audios_one(object: $object) {\n      playlist_id\n      audio_id\n      position\n    }\n  }\n": typeof types.AddAudioToPlaylistDocument,
     "\n  mutation RemoveAudioFromPlaylist($playlistId: uuid!, $audioId: uuid!) {\n    delete_playlist_audios_by_pk(playlist_id: $playlistId, audio_id: $audioId) {\n      playlist_id\n      audio_id\n    }\n  }\n": typeof types.RemoveAudioFromPlaylistDocument,
     "\n  mutation ReorderPlaylistAudios($updates: [playlist_audios_updates!]!) {\n    update_playlist_audios_many(updates: $updates) {\n      affected_rows\n      returning {\n        playlist_id\n      }\n    }\n  }\n": typeof types.ReorderPlaylistAudiosDocument,
+    "\n  mutation UpdateAudio($id: uuid!, $set: audios_set_input!) {\n    update_audios_by_pk(pk_columns: { id: $id }, _set: $set) {\n      id\n    }\n  }\n": typeof types.UpdateAudioDocument,
+    "\n  mutation DeleteAudio($id: uuid!) {\n    delete_audios_by_pk(id: $id) {\n      id\n    }\n  }\n": typeof types.DeleteAudioDocument,
     "\n  fragment AudioFields on audios {\n    id\n    name\n    source\n    thumbnailUrl\n    artistName\n  }\n": typeof types.AudioFieldsFragmentDoc,
     "\n  fragment PlaylistAudioFields on playlist_audios {\n    position\n    audio {\n      ...AudioFields\n    }\n  }\n": typeof types.PlaylistAudioFieldsFragmentDoc,
     "\n  fragment ListenPlaylistFields on playlist {\n    id\n    title\n    thumbnailUrl\n    slug\n    createdAt\n    description\n    playlist_audios(order_by: { position: asc }) {\n      ...PlaylistAudioFields\n    }\n  }\n": typeof types.ListenPlaylistFieldsFragmentDoc,
@@ -90,6 +92,8 @@ const documents: Documents = {
     "\n  mutation AddAudioToPlaylist($object: playlist_audios_insert_input!) {\n    insert_playlist_audios_one(object: $object) {\n      playlist_id\n      audio_id\n      position\n    }\n  }\n": types.AddAudioToPlaylistDocument,
     "\n  mutation RemoveAudioFromPlaylist($playlistId: uuid!, $audioId: uuid!) {\n    delete_playlist_audios_by_pk(playlist_id: $playlistId, audio_id: $audioId) {\n      playlist_id\n      audio_id\n    }\n  }\n": types.RemoveAudioFromPlaylistDocument,
     "\n  mutation ReorderPlaylistAudios($updates: [playlist_audios_updates!]!) {\n    update_playlist_audios_many(updates: $updates) {\n      affected_rows\n      returning {\n        playlist_id\n      }\n    }\n  }\n": types.ReorderPlaylistAudiosDocument,
+    "\n  mutation UpdateAudio($id: uuid!, $set: audios_set_input!) {\n    update_audios_by_pk(pk_columns: { id: $id }, _set: $set) {\n      id\n    }\n  }\n": types.UpdateAudioDocument,
+    "\n  mutation DeleteAudio($id: uuid!) {\n    delete_audios_by_pk(id: $id) {\n      id\n    }\n  }\n": types.DeleteAudioDocument,
     "\n  fragment AudioFields on audios {\n    id\n    name\n    source\n    thumbnailUrl\n    artistName\n  }\n": types.AudioFieldsFragmentDoc,
     "\n  fragment PlaylistAudioFields on playlist_audios {\n    position\n    audio {\n      ...AudioFields\n    }\n  }\n": types.PlaylistAudioFieldsFragmentDoc,
     "\n  fragment ListenPlaylistFields on playlist {\n    id\n    title\n    thumbnailUrl\n    slug\n    createdAt\n    description\n    playlist_audios(order_by: { position: asc }) {\n      ...PlaylistAudioFields\n    }\n  }\n": types.ListenPlaylistFieldsFragmentDoc,
@@ -205,6 +209,14 @@ export function graphql(source: "\n  mutation RemoveAudioFromPlaylist($playlistI
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(source: "\n  mutation ReorderPlaylistAudios($updates: [playlist_audios_updates!]!) {\n    update_playlist_audios_many(updates: $updates) {\n      affected_rows\n      returning {\n        playlist_id\n      }\n    }\n  }\n"): typeof import('./graphql').ReorderPlaylistAudiosDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n  mutation UpdateAudio($id: uuid!, $set: audios_set_input!) {\n    update_audios_by_pk(pk_columns: { id: $id }, _set: $set) {\n      id\n    }\n  }\n"): typeof import('./graphql').UpdateAudioDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n  mutation DeleteAudio($id: uuid!) {\n    delete_audios_by_pk(id: $id) {\n      id\n    }\n  }\n"): typeof import('./graphql').DeleteAudioDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/packages/core/src/graphql/graphql.ts
+++ b/packages/core/src/graphql/graphql.ts
@@ -13290,6 +13290,21 @@ export type ReorderPlaylistAudiosMutationVariables = Exact<{
 
 export type ReorderPlaylistAudiosMutation = { __typename?: 'mutation_root', update_playlist_audios_many?: Array<{ __typename?: 'playlist_audios_mutation_response', affected_rows: number, returning: Array<{ __typename?: 'playlist_audios', playlist_id: any }> } | null> | null };
 
+export type UpdateAudioMutationVariables = Exact<{
+  id: Scalars['uuid']['input'];
+  set: Audios_Set_Input;
+}>;
+
+
+export type UpdateAudioMutation = { __typename?: 'mutation_root', update_audios_by_pk?: { __typename?: 'audios', id: any } | null };
+
+export type DeleteAudioMutationVariables = Exact<{
+  id: Scalars['uuid']['input'];
+}>;
+
+
+export type DeleteAudioMutation = { __typename?: 'mutation_root', delete_audios_by_pk?: { __typename?: 'audios', id: any } | null };
+
 export type AudioFieldsFragment = { __typename?: 'audios', id: any, name: string, source: string, thumbnailUrl?: string | null, artistName: string } & { ' $fragmentName'?: 'AudioFieldsFragment' };
 
 export type PlaylistAudioFieldsFragment = { __typename?: 'playlist_audios', position: number, audio: (
@@ -14052,6 +14067,20 @@ export const ReorderPlaylistAudiosDocument = new TypedDocumentString(`
   }
 }
     `) as unknown as TypedDocumentString<ReorderPlaylistAudiosMutation, ReorderPlaylistAudiosMutationVariables>;
+export const UpdateAudioDocument = new TypedDocumentString(`
+    mutation UpdateAudio($id: uuid!, $set: audios_set_input!) {
+  update_audios_by_pk(pk_columns: {id: $id}, _set: $set) {
+    id
+  }
+}
+    `) as unknown as TypedDocumentString<UpdateAudioMutation, UpdateAudioMutationVariables>;
+export const DeleteAudioDocument = new TypedDocumentString(`
+    mutation DeleteAudio($id: uuid!) {
+  delete_audios_by_pk(id: $id) {
+    id
+  }
+}
+    `) as unknown as TypedDocumentString<DeleteAudioMutation, DeleteAudioMutationVariables>;
 export const ListenHomeDocument = new TypedDocumentString(`
     query ListenHome @cached {
   audios {

--- a/packages/core/src/listen/mutation-hooks/index.test.ts
+++ b/packages/core/src/listen/mutation-hooks/index.test.ts
@@ -6,8 +6,10 @@ import { useMutationRequest } from '../../universal/hooks/useMutation';
 import {
   useAddAudioToPlaylist,
   useCreatePlaylist,
+  useDeleteAudio,
   useRemoveAudioFromPlaylist,
   useReorderPlaylistAudios,
+  useUpdateAudio,
 } from './index';
 
 vi.mock('../../providers/auth');
@@ -30,6 +32,7 @@ describe('Listen playlist mutation hooks', () => {
     vi.clearAllMocks();
     vi.mocked(useAuthContext).mockReturnValue({
       getAccessToken: mockAccessToken,
+      isSignedIn: true,
     });
     vi.mocked(useQueryContext).mockReturnValue({
       invalidateQuery: mockInvalidateQuery,
@@ -169,6 +172,50 @@ describe('Listen playlist mutation hooks', () => {
         'listen-playlist-detail',
         'p1',
       ]);
+    });
+  });
+
+  describe('useUpdateAudio', () => {
+    it('sends id plus only the provided fields as _set', () => {
+      const { result } = renderHook(() => useUpdateAudio());
+
+      result.current({ id: 'a1', name: 'New name', artistName: 'New artist' });
+
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        id: 'a1',
+        set: { name: 'New name', artistName: 'New artist' },
+      });
+    });
+
+    it('invalidates the manage and home lists on success', () => {
+      const onSuccess = vi.fn();
+      renderHook(() => useUpdateAudio({ onSuccess }));
+
+      const data = { update_audios_by_pk: { id: 'a1' } };
+      getOnSuccess()?.(data);
+
+      expect(mockInvalidateQuery).toHaveBeenCalledWith(['listen-manage']);
+      expect(mockInvalidateQuery).toHaveBeenCalledWith(['listen-home', true]);
+      expect(onSuccess).toHaveBeenCalledWith(data);
+    });
+  });
+
+  describe('useDeleteAudio', () => {
+    it('passes the id as the delete variable', () => {
+      const { result } = renderHook(() => useDeleteAudio());
+
+      result.current('a1');
+
+      expect(mockMutateAsync).toHaveBeenCalledWith({ id: 'a1' });
+    });
+
+    it('invalidates the manage and home lists on success', () => {
+      renderHook(() => useDeleteAudio());
+
+      getOnSuccess()?.({ delete_audios_by_pk: { id: 'a1' } });
+
+      expect(mockInvalidateQuery).toHaveBeenCalledWith(['listen-manage']);
+      expect(mockInvalidateQuery).toHaveBeenCalledWith(['listen-home', true]);
     });
   });
 });

--- a/packages/core/src/listen/mutation-hooks/index.test.ts
+++ b/packages/core/src/listen/mutation-hooks/index.test.ts
@@ -198,6 +198,17 @@ describe('Listen playlist mutation hooks', () => {
       expect(mockInvalidateQuery).toHaveBeenCalledWith(['listen-home', true]);
       expect(onSuccess).toHaveBeenCalledWith(data);
     });
+
+    it('does not invalidate when no row was updated', () => {
+      const onSuccess = vi.fn();
+      renderHook(() => useUpdateAudio({ onSuccess }));
+
+      const data = { update_audios_by_pk: null };
+      getOnSuccess()?.(data);
+
+      expect(mockInvalidateQuery).not.toHaveBeenCalled();
+      expect(onSuccess).toHaveBeenCalledWith(data);
+    });
   });
 
   describe('useDeleteAudio', () => {
@@ -216,6 +227,14 @@ describe('Listen playlist mutation hooks', () => {
 
       expect(mockInvalidateQuery).toHaveBeenCalledWith(['listen-manage']);
       expect(mockInvalidateQuery).toHaveBeenCalledWith(['listen-home', true]);
+    });
+
+    it('does not invalidate when no row was deleted', () => {
+      renderHook(() => useDeleteAudio());
+
+      getOnSuccess()?.({ delete_audios_by_pk: null });
+
+      expect(mockInvalidateQuery).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/core/src/listen/mutation-hooks/index.ts
+++ b/packages/core/src/listen/mutation-hooks/index.ts
@@ -236,8 +236,12 @@ const useUpdateAudio = (props: MutationProps = {}) => {
     getAccessToken,
     options: {
       onSuccess: (data) => {
-        invalidateQuery(MANAGE_QUERY_KEY);
-        invalidateQuery([HOME_QUERY_KEY, isSignedIn]);
+        // A null pk result means no row matched (absent or filtered by
+        // permissions) — nothing changed, so leave the caches untouched.
+        if (data.update_audios_by_pk) {
+          invalidateQuery(MANAGE_QUERY_KEY);
+          invalidateQuery([HOME_QUERY_KEY, isSignedIn]);
+        }
         onSuccess?.(data);
       },
       onError: (error) => {
@@ -267,8 +271,11 @@ const useDeleteAudio = (props: MutationProps = {}) => {
     getAccessToken,
     options: {
       onSuccess: (data) => {
-        invalidateQuery(MANAGE_QUERY_KEY);
-        invalidateQuery([HOME_QUERY_KEY, isSignedIn]);
+        // Only refresh caches when a row was actually deleted.
+        if (data.delete_audios_by_pk) {
+          invalidateQuery(MANAGE_QUERY_KEY);
+          invalidateQuery([HOME_QUERY_KEY, isSignedIn]);
+        }
         onSuccess?.(data);
       },
       onError: (error) => {

--- a/packages/core/src/listen/mutation-hooks/index.ts
+++ b/packages/core/src/listen/mutation-hooks/index.ts
@@ -44,6 +44,22 @@ const reorderAudiosMutation = graphql(/* GraphQL */ `
   }
 `);
 
+const updateAudioMutation = graphql(/* GraphQL */ `
+  mutation UpdateAudio($id: uuid!, $set: audios_set_input!) {
+    update_audios_by_pk(pk_columns: { id: $id }, _set: $set) {
+      id
+    }
+  }
+`);
+
+const deleteAudioMutation = graphql(/* GraphQL */ `
+  mutation DeleteAudio($id: uuid!) {
+    delete_audios_by_pk(id: $id) {
+      id
+    }
+  }
+`);
+
 interface MutationProps {
   onSuccess?: (data: any) => void;
   onError?: (error: unknown) => void;
@@ -63,6 +79,20 @@ interface PlaylistAudioRef {
 
 type AddAudioInput = PlaylistAudioRef & { position: number };
 type ReorderUpdate = PlaylistAudioRef & { position: number };
+
+interface UpdateAudioInput {
+  id: string;
+  name?: string;
+  artistName?: string;
+  thumbnailUrl?: string;
+}
+
+// The management dashboard (SWO-411) is a signed-in, user-only screen, so its
+// query has no anonymous variant — a single exact key is enough. Audio edits
+// also touch the home screen (a public audio the owner renamed), so both are
+// invalidated on success.
+const MANAGE_QUERY_KEY = ['listen-manage'];
+const HOME_QUERY_KEY = 'listen-home';
 
 const useCreatePlaylist = (props: MutationProps = {}) => {
   const { getAccessToken } = useAuthContext();
@@ -196,13 +226,73 @@ const useReorderPlaylistAudios = (props: MutationProps = {}) => {
   return reorderAudios;
 };
 
+const useUpdateAudio = (props: MutationProps = {}) => {
+  const { getAccessToken, isSignedIn } = useAuthContext();
+  const { invalidateQuery } = useQueryContext();
+  const { onSuccess, onError } = props;
+
+  const { mutateAsync } = useMutationRequest({
+    document: updateAudioMutation,
+    getAccessToken,
+    options: {
+      onSuccess: (data) => {
+        invalidateQuery(MANAGE_QUERY_KEY);
+        invalidateQuery([HOME_QUERY_KEY, isSignedIn]);
+        onSuccess?.(data);
+      },
+      onError: (error) => {
+        console.error('Update audio failed:', error);
+        onError?.(error);
+      },
+    },
+  });
+
+  // Only the provided fields are sent; undefined ones drop out on serialisation
+  // so they are left untouched.
+  const updateAudio = (input: UpdateAudioInput) => {
+    const { id, ...fields } = input;
+    return mutateAsync({ id, set: fields });
+  };
+
+  return updateAudio;
+};
+
+const useDeleteAudio = (props: MutationProps = {}) => {
+  const { getAccessToken, isSignedIn } = useAuthContext();
+  const { invalidateQuery } = useQueryContext();
+  const { onSuccess, onError } = props;
+
+  const { mutateAsync } = useMutationRequest({
+    document: deleteAudioMutation,
+    getAccessToken,
+    options: {
+      onSuccess: (data) => {
+        invalidateQuery(MANAGE_QUERY_KEY);
+        invalidateQuery([HOME_QUERY_KEY, isSignedIn]);
+        onSuccess?.(data);
+      },
+      onError: (error) => {
+        console.error('Delete audio failed:', error);
+        onError?.(error);
+      },
+    },
+  });
+
+  const deleteAudio = (id: string) => mutateAsync({ id });
+
+  return deleteAudio;
+};
+
 export {
   type AddAudioInput,
   type CreateListenPlaylistInput,
   type PlaylistAudioRef,
   type ReorderUpdate,
+  type UpdateAudioInput,
   useAddAudioToPlaylist,
   useCreatePlaylist,
+  useDeleteAudio,
   useRemoveAudioFromPlaylist,
   useReorderPlaylistAudios,
+  useUpdateAudio,
 };


### PR DESCRIPTION
## Summary

Adds `useUpdateAudio` (name/artist/thumbnail) and `useDeleteAudio` for the Listen management dashboard (SWO-411).

- Both invalidate the manage list (`['listen-manage']`) and the signed-in home query on success — but only when a row was actually affected (`update/delete_audios_by_pk` returns `null`, not an error, on a no-op), matching the sibling playlist-audio hooks.
- Only the two new operations are added to the generated types; `schema.graphql` is intentionally untouched (avoids unrelated local codegen drift).

## Test plan

- 14 unit tests pass (added: payload shaping, manage+home invalidation, and the null-row no-invalidation guard for both hooks)
- `pnpm typecheck` clean; Biome format clean

Notes: `onSuccess` still fires on a null-row result (forwarding data so the call site can react) — consistent with the file's 5 sibling hooks. Deleting an audio doesn't invalidate `['listen-playlist-detail', …]` caches (the delete result doesn't carry which playlists held the audio, and `invalidateQuery` is exact-match) — a minor staleness that self-heals on next playlist-detail load.

SWO-415

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for updating audio details and deleting audio entries.
  * Introduced new actions for managing audio records from the app.
* **Bug Fixes**
  * Cache updates now only refresh when an audio change actually succeeds, avoiding unnecessary reloads.
  * Added better handling for cases where no audio record is matched or removed.
* **Tests**
  * Expanded coverage for the new update and delete audio actions, including success and no-op cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->