### PR TITLE
[WIP] feat(listen): add feeling assign/unassign mutation hooks (SWO-416)

### DIFF
--- a/packages/core/src/graphql/gql.ts
+++ b/packages/core/src/graphql/gql.ts
@@ -37,6 +37,8 @@ type Documents = {
     "\n  mutation ReorderPlaylistAudios($updates: [playlist_audios_updates!]!) {\n    update_playlist_audios_many(updates: $updates) {\n      affected_rows\n      returning {\n        playlist_id\n      }\n    }\n  }\n": typeof types.ReorderPlaylistAudiosDocument,
     "\n  mutation UpdateAudio($id: uuid!, $set: audios_set_input!) {\n    update_audios_by_pk(pk_columns: { id: $id }, _set: $set) {\n      id\n    }\n  }\n": typeof types.UpdateAudioDocument,
     "\n  mutation DeleteAudio($id: uuid!) {\n    delete_audios_by_pk(id: $id) {\n      id\n    }\n  }\n": typeof types.DeleteAudioDocument,
+    "\n  mutation AssignFeeling($object: audio_tags_insert_input!) {\n    insert_audio_tags_one(object: $object) {\n      audio_id\n      tag_id\n    }\n  }\n": typeof types.AssignFeelingDocument,
+    "\n  mutation UnassignFeeling($audioId: uuid!, $tagId: uuid!) {\n    delete_audio_tags_by_pk(audio_id: $audioId, tag_id: $tagId) {\n      audio_id\n      tag_id\n    }\n  }\n": typeof types.UnassignFeelingDocument,
     "\n  fragment AudioFields on audios {\n    id\n    name\n    source\n    thumbnailUrl\n    artistName\n  }\n": typeof types.AudioFieldsFragmentDoc,
     "\n  fragment PlaylistAudioFields on playlist_audios {\n    position\n    audio {\n      ...AudioFields\n    }\n  }\n": typeof types.PlaylistAudioFieldsFragmentDoc,
     "\n  fragment ListenPlaylistFields on playlist {\n    id\n    title\n    thumbnailUrl\n    slug\n    createdAt\n    description\n    playlist_audios(order_by: { position: asc }) {\n      ...PlaylistAudioFields\n    }\n  }\n": typeof types.ListenPlaylistFieldsFragmentDoc,
@@ -94,6 +96,8 @@ const documents: Documents = {
     "\n  mutation ReorderPlaylistAudios($updates: [playlist_audios_updates!]!) {\n    update_playlist_audios_many(updates: $updates) {\n      affected_rows\n      returning {\n        playlist_id\n      }\n    }\n  }\n": types.ReorderPlaylistAudiosDocument,
     "\n  mutation UpdateAudio($id: uuid!, $set: audios_set_input!) {\n    update_audios_by_pk(pk_columns: { id: $id }, _set: $set) {\n      id\n    }\n  }\n": types.UpdateAudioDocument,
     "\n  mutation DeleteAudio($id: uuid!) {\n    delete_audios_by_pk(id: $id) {\n      id\n    }\n  }\n": types.DeleteAudioDocument,
+    "\n  mutation AssignFeeling($object: audio_tags_insert_input!) {\n    insert_audio_tags_one(object: $object) {\n      audio_id\n      tag_id\n    }\n  }\n": types.AssignFeelingDocument,
+    "\n  mutation UnassignFeeling($audioId: uuid!, $tagId: uuid!) {\n    delete_audio_tags_by_pk(audio_id: $audioId, tag_id: $tagId) {\n      audio_id\n      tag_id\n    }\n  }\n": types.UnassignFeelingDocument,
     "\n  fragment AudioFields on audios {\n    id\n    name\n    source\n    thumbnailUrl\n    artistName\n  }\n": types.AudioFieldsFragmentDoc,
     "\n  fragment PlaylistAudioFields on playlist_audios {\n    position\n    audio {\n      ...AudioFields\n    }\n  }\n": types.PlaylistAudioFieldsFragmentDoc,
     "\n  fragment ListenPlaylistFields on playlist {\n    id\n    title\n    thumbnailUrl\n    slug\n    createdAt\n    description\n    playlist_audios(order_by: { position: asc }) {\n      ...PlaylistAudioFields\n    }\n  }\n": types.ListenPlaylistFieldsFragmentDoc,
@@ -217,6 +221,14 @@ export function graphql(source: "\n  mutation UpdateAudio($id: uuid!, $set: audi
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(source: "\n  mutation DeleteAudio($id: uuid!) {\n    delete_audios_by_pk(id: $id) {\n      id\n    }\n  }\n"): typeof import('./graphql').DeleteAudioDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n  mutation AssignFeeling($object: audio_tags_insert_input!) {\n    insert_audio_tags_one(object: $object) {\n      audio_id\n      tag_id\n    }\n  }\n"): typeof import('./graphql').AssignFeelingDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n  mutation UnassignFeeling($audioId: uuid!, $tagId: uuid!) {\n    delete_audio_tags_by_pk(audio_id: $audioId, tag_id: $tagId) {\n      audio_id\n      tag_id\n    }\n  }\n"): typeof import('./graphql').UnassignFeelingDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/packages/core/src/graphql/gql.ts
+++ b/packages/core/src/graphql/gql.ts
@@ -37,7 +37,7 @@ type Documents = {
     "\n  mutation ReorderPlaylistAudios($updates: [playlist_audios_updates!]!) {\n    update_playlist_audios_many(updates: $updates) {\n      affected_rows\n      returning {\n        playlist_id\n      }\n    }\n  }\n": typeof types.ReorderPlaylistAudiosDocument,
     "\n  mutation UpdateAudio($id: uuid!, $set: audios_set_input!) {\n    update_audios_by_pk(pk_columns: { id: $id }, _set: $set) {\n      id\n    }\n  }\n": typeof types.UpdateAudioDocument,
     "\n  mutation DeleteAudio($id: uuid!) {\n    delete_audios_by_pk(id: $id) {\n      id\n    }\n  }\n": typeof types.DeleteAudioDocument,
-    "\n  mutation AssignFeeling($object: audio_tags_insert_input!) {\n    insert_audio_tags_one(object: $object) {\n      audio_id\n      tag_id\n    }\n  }\n": typeof types.AssignFeelingDocument,
+    "\n  mutation AssignFeeling($object: audio_tags_insert_input!) {\n    insert_audio_tags_one(\n      object: $object\n      on_conflict: { constraint: audio_tags_pkey, update_columns: [] }\n    ) {\n      audio_id\n      tag_id\n    }\n  }\n": typeof types.AssignFeelingDocument,
     "\n  mutation UnassignFeeling($audioId: uuid!, $tagId: uuid!) {\n    delete_audio_tags_by_pk(audio_id: $audioId, tag_id: $tagId) {\n      audio_id\n      tag_id\n    }\n  }\n": typeof types.UnassignFeelingDocument,
     "\n  fragment AudioFields on audios {\n    id\n    name\n    source\n    thumbnailUrl\n    artistName\n  }\n": typeof types.AudioFieldsFragmentDoc,
     "\n  fragment PlaylistAudioFields on playlist_audios {\n    position\n    audio {\n      ...AudioFields\n    }\n  }\n": typeof types.PlaylistAudioFieldsFragmentDoc,
@@ -96,7 +96,7 @@ const documents: Documents = {
     "\n  mutation ReorderPlaylistAudios($updates: [playlist_audios_updates!]!) {\n    update_playlist_audios_many(updates: $updates) {\n      affected_rows\n      returning {\n        playlist_id\n      }\n    }\n  }\n": types.ReorderPlaylistAudiosDocument,
     "\n  mutation UpdateAudio($id: uuid!, $set: audios_set_input!) {\n    update_audios_by_pk(pk_columns: { id: $id }, _set: $set) {\n      id\n    }\n  }\n": types.UpdateAudioDocument,
     "\n  mutation DeleteAudio($id: uuid!) {\n    delete_audios_by_pk(id: $id) {\n      id\n    }\n  }\n": types.DeleteAudioDocument,
-    "\n  mutation AssignFeeling($object: audio_tags_insert_input!) {\n    insert_audio_tags_one(object: $object) {\n      audio_id\n      tag_id\n    }\n  }\n": types.AssignFeelingDocument,
+    "\n  mutation AssignFeeling($object: audio_tags_insert_input!) {\n    insert_audio_tags_one(\n      object: $object\n      on_conflict: { constraint: audio_tags_pkey, update_columns: [] }\n    ) {\n      audio_id\n      tag_id\n    }\n  }\n": types.AssignFeelingDocument,
     "\n  mutation UnassignFeeling($audioId: uuid!, $tagId: uuid!) {\n    delete_audio_tags_by_pk(audio_id: $audioId, tag_id: $tagId) {\n      audio_id\n      tag_id\n    }\n  }\n": types.UnassignFeelingDocument,
     "\n  fragment AudioFields on audios {\n    id\n    name\n    source\n    thumbnailUrl\n    artistName\n  }\n": types.AudioFieldsFragmentDoc,
     "\n  fragment PlaylistAudioFields on playlist_audios {\n    position\n    audio {\n      ...AudioFields\n    }\n  }\n": types.PlaylistAudioFieldsFragmentDoc,
@@ -224,7 +224,7 @@ export function graphql(source: "\n  mutation DeleteAudio($id: uuid!) {\n    del
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
-export function graphql(source: "\n  mutation AssignFeeling($object: audio_tags_insert_input!) {\n    insert_audio_tags_one(object: $object) {\n      audio_id\n      tag_id\n    }\n  }\n"): typeof import('./graphql').AssignFeelingDocument;
+export function graphql(source: "\n  mutation AssignFeeling($object: audio_tags_insert_input!) {\n    insert_audio_tags_one(\n      object: $object\n      on_conflict: { constraint: audio_tags_pkey, update_columns: [] }\n    ) {\n      audio_id\n      tag_id\n    }\n  }\n"): typeof import('./graphql').AssignFeelingDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/packages/core/src/graphql/graphql.ts
+++ b/packages/core/src/graphql/graphql.ts
@@ -14098,7 +14098,10 @@ export const DeleteAudioDocument = new TypedDocumentString(`
     `) as unknown as TypedDocumentString<DeleteAudioMutation, DeleteAudioMutationVariables>;
 export const AssignFeelingDocument = new TypedDocumentString(`
     mutation AssignFeeling($object: audio_tags_insert_input!) {
-  insert_audio_tags_one(object: $object) {
+  insert_audio_tags_one(
+    object: $object
+    on_conflict: {constraint: audio_tags_pkey, update_columns: []}
+  ) {
     audio_id
     tag_id
   }

--- a/packages/core/src/graphql/graphql.ts
+++ b/packages/core/src/graphql/graphql.ts
@@ -13305,6 +13305,21 @@ export type DeleteAudioMutationVariables = Exact<{
 
 export type DeleteAudioMutation = { __typename?: 'mutation_root', delete_audios_by_pk?: { __typename?: 'audios', id: any } | null };
 
+export type AssignFeelingMutationVariables = Exact<{
+  object: Audio_Tags_Insert_Input;
+}>;
+
+
+export type AssignFeelingMutation = { __typename?: 'mutation_root', insert_audio_tags_one?: { __typename?: 'audio_tags', audio_id: any, tag_id: any } | null };
+
+export type UnassignFeelingMutationVariables = Exact<{
+  audioId: Scalars['uuid']['input'];
+  tagId: Scalars['uuid']['input'];
+}>;
+
+
+export type UnassignFeelingMutation = { __typename?: 'mutation_root', delete_audio_tags_by_pk?: { __typename?: 'audio_tags', audio_id: any, tag_id: any } | null };
+
 export type AudioFieldsFragment = { __typename?: 'audios', id: any, name: string, source: string, thumbnailUrl?: string | null, artistName: string } & { ' $fragmentName'?: 'AudioFieldsFragment' };
 
 export type PlaylistAudioFieldsFragment = { __typename?: 'playlist_audios', position: number, audio: (
@@ -14081,6 +14096,22 @@ export const DeleteAudioDocument = new TypedDocumentString(`
   }
 }
     `) as unknown as TypedDocumentString<DeleteAudioMutation, DeleteAudioMutationVariables>;
+export const AssignFeelingDocument = new TypedDocumentString(`
+    mutation AssignFeeling($object: audio_tags_insert_input!) {
+  insert_audio_tags_one(object: $object) {
+    audio_id
+    tag_id
+  }
+}
+    `) as unknown as TypedDocumentString<AssignFeelingMutation, AssignFeelingMutationVariables>;
+export const UnassignFeelingDocument = new TypedDocumentString(`
+    mutation UnassignFeeling($audioId: uuid!, $tagId: uuid!) {
+  delete_audio_tags_by_pk(audio_id: $audioId, tag_id: $tagId) {
+    audio_id
+    tag_id
+  }
+}
+    `) as unknown as TypedDocumentString<UnassignFeelingMutation, UnassignFeelingMutationVariables>;
 export const ListenHomeDocument = new TypedDocumentString(`
     query ListenHome @cached {
   audios {

--- a/packages/core/src/listen/mutation-hooks/index.test.ts
+++ b/packages/core/src/listen/mutation-hooks/index.test.ts
@@ -5,10 +5,12 @@ import { useQueryContext } from '../../providers/query';
 import { useMutationRequest } from '../../universal/hooks/useMutation';
 import {
   useAddAudioToPlaylist,
+  useAssignFeeling,
   useCreatePlaylist,
   useDeleteAudio,
   useRemoveAudioFromPlaylist,
   useReorderPlaylistAudios,
+  useUnassignFeeling,
   useUpdateAudio,
 } from './index';
 
@@ -233,6 +235,60 @@ describe('Listen playlist mutation hooks', () => {
       renderHook(() => useDeleteAudio());
 
       getOnSuccess()?.({ delete_audios_by_pk: null });
+
+      expect(mockInvalidateQuery).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('useAssignFeeling', () => {
+    it('builds the audio_tags insert object', () => {
+      const { result } = renderHook(() => useAssignFeeling());
+
+      result.current({ audioId: 'a1', tagId: 't1' });
+
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        object: { audio_id: 'a1', tag_id: 't1' },
+      });
+    });
+
+    it('invalidates the manage list on success', () => {
+      const onSuccess = vi.fn();
+      renderHook(() => useAssignFeeling({ onSuccess }));
+
+      const data = { insert_audio_tags_one: { audio_id: 'a1', tag_id: 't1' } };
+      getOnSuccess()?.(data);
+
+      expect(mockInvalidateQuery).toHaveBeenCalledWith(['listen-manage']);
+      expect(onSuccess).toHaveBeenCalledWith(data);
+    });
+  });
+
+  describe('useUnassignFeeling', () => {
+    it('builds the by-pk delete variables', () => {
+      const { result } = renderHook(() => useUnassignFeeling());
+
+      result.current({ audioId: 'a1', tagId: 't1' });
+
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        audioId: 'a1',
+        tagId: 't1',
+      });
+    });
+
+    it('invalidates the manage list on success', () => {
+      renderHook(() => useUnassignFeeling());
+
+      getOnSuccess()?.({
+        delete_audio_tags_by_pk: { audio_id: 'a1', tag_id: 't1' },
+      });
+
+      expect(mockInvalidateQuery).toHaveBeenCalledWith(['listen-manage']);
+    });
+
+    it('does not invalidate when no row was deleted', () => {
+      renderHook(() => useUnassignFeeling());
+
+      getOnSuccess()?.({ delete_audio_tags_by_pk: null });
 
       expect(mockInvalidateQuery).not.toHaveBeenCalled();
     });

--- a/packages/core/src/listen/mutation-hooks/index.test.ts
+++ b/packages/core/src/listen/mutation-hooks/index.test.ts
@@ -251,7 +251,7 @@ describe('Listen playlist mutation hooks', () => {
       });
     });
 
-    it('invalidates the manage list on success', () => {
+    it('invalidates the manage and home lists on success', () => {
       const onSuccess = vi.fn();
       renderHook(() => useAssignFeeling({ onSuccess }));
 
@@ -259,7 +259,16 @@ describe('Listen playlist mutation hooks', () => {
       getOnSuccess()?.(data);
 
       expect(mockInvalidateQuery).toHaveBeenCalledWith(['listen-manage']);
+      expect(mockInvalidateQuery).toHaveBeenCalledWith(['listen-home', true]);
       expect(onSuccess).toHaveBeenCalledWith(data);
+    });
+
+    it('does not invalidate on a no-op re-assign (on_conflict returns null)', () => {
+      renderHook(() => useAssignFeeling());
+
+      getOnSuccess()?.({ insert_audio_tags_one: null });
+
+      expect(mockInvalidateQuery).not.toHaveBeenCalled();
     });
   });
 
@@ -275,7 +284,7 @@ describe('Listen playlist mutation hooks', () => {
       });
     });
 
-    it('invalidates the manage list on success', () => {
+    it('invalidates the manage and home lists on success', () => {
       renderHook(() => useUnassignFeeling());
 
       getOnSuccess()?.({
@@ -283,6 +292,7 @@ describe('Listen playlist mutation hooks', () => {
       });
 
       expect(mockInvalidateQuery).toHaveBeenCalledWith(['listen-manage']);
+      expect(mockInvalidateQuery).toHaveBeenCalledWith(['listen-home', true]);
     });
 
     it('does not invalidate when no row was deleted', () => {

--- a/packages/core/src/listen/mutation-hooks/index.ts
+++ b/packages/core/src/listen/mutation-hooks/index.ts
@@ -60,6 +60,24 @@ const deleteAudioMutation = graphql(/* GraphQL */ `
   }
 `);
 
+const assignFeelingMutation = graphql(/* GraphQL */ `
+  mutation AssignFeeling($object: audio_tags_insert_input!) {
+    insert_audio_tags_one(object: $object) {
+      audio_id
+      tag_id
+    }
+  }
+`);
+
+const unassignFeelingMutation = graphql(/* GraphQL */ `
+  mutation UnassignFeeling($audioId: uuid!, $tagId: uuid!) {
+    delete_audio_tags_by_pk(audio_id: $audioId, tag_id: $tagId) {
+      audio_id
+      tag_id
+    }
+  }
+`);
+
 interface MutationProps {
   onSuccess?: (data: any) => void;
   onError?: (error: unknown) => void;
@@ -85,6 +103,12 @@ interface UpdateAudioInput {
   name?: string;
   artistName?: string;
   thumbnailUrl?: string;
+}
+
+// A feeling assignment is one row in the audio_tags join (audio <-> listen tag).
+interface FeelingRef {
+  audioId: string;
+  tagId: string;
 }
 
 // The management dashboard (SWO-411) is a signed-in, user-only screen, so its
@@ -290,16 +314,75 @@ const useDeleteAudio = (props: MutationProps = {}) => {
   return deleteAudio;
 };
 
+const useAssignFeeling = (props: MutationProps = {}) => {
+  const { getAccessToken } = useAuthContext();
+  const { invalidateQuery } = useQueryContext();
+  const { onSuccess, onError } = props;
+
+  const { mutateAsync } = useMutationRequest({
+    document: assignFeelingMutation,
+    getAccessToken,
+    options: {
+      onSuccess: (data) => {
+        if (data.insert_audio_tags_one) {
+          invalidateQuery(MANAGE_QUERY_KEY);
+        }
+        onSuccess?.(data);
+      },
+      onError: (error) => {
+        console.error('Assign feeling failed:', error);
+        onError?.(error);
+      },
+    },
+  });
+
+  const assignFeeling = (input: FeelingRef) =>
+    mutateAsync({ object: { audio_id: input.audioId, tag_id: input.tagId } });
+
+  return assignFeeling;
+};
+
+const useUnassignFeeling = (props: MutationProps = {}) => {
+  const { getAccessToken } = useAuthContext();
+  const { invalidateQuery } = useQueryContext();
+  const { onSuccess, onError } = props;
+
+  const { mutateAsync } = useMutationRequest({
+    document: unassignFeelingMutation,
+    getAccessToken,
+    options: {
+      onSuccess: (data) => {
+        if (data.delete_audio_tags_by_pk) {
+          invalidateQuery(MANAGE_QUERY_KEY);
+        }
+        onSuccess?.(data);
+      },
+      onError: (error) => {
+        console.error('Unassign feeling failed:', error);
+        onError?.(error);
+      },
+    },
+  });
+
+  const unassignFeeling = (input: FeelingRef) =>
+    mutateAsync({ audioId: input.audioId, tagId: input.tagId });
+
+  return unassignFeeling;
+};
+
 export {
   type AddAudioInput,
   type CreateListenPlaylistInput,
+  type FeelingRef,
   type PlaylistAudioRef,
   type ReorderUpdate,
   type UpdateAudioInput,
   useAddAudioToPlaylist,
+  useAssignFeeling,
   useCreatePlaylist,
   useDeleteAudio,
   useRemoveAudioFromPlaylist,
   useReorderPlaylistAudios,
+  useUnassignFeeling,
   useUpdateAudio,
 };

--- a/packages/core/src/listen/mutation-hooks/index.ts
+++ b/packages/core/src/listen/mutation-hooks/index.ts
@@ -62,7 +62,10 @@ const deleteAudioMutation = graphql(/* GraphQL */ `
 
 const assignFeelingMutation = graphql(/* GraphQL */ `
   mutation AssignFeeling($object: audio_tags_insert_input!) {
-    insert_audio_tags_one(object: $object) {
+    insert_audio_tags_one(
+      object: $object
+      on_conflict: { constraint: audio_tags_pkey, update_columns: [] }
+    ) {
       audio_id
       tag_id
     }
@@ -315,7 +318,7 @@ const useDeleteAudio = (props: MutationProps = {}) => {
 };
 
 const useAssignFeeling = (props: MutationProps = {}) => {
-  const { getAccessToken } = useAuthContext();
+  const { getAccessToken, isSignedIn } = useAuthContext();
   const { invalidateQuery } = useQueryContext();
   const { onSuccess, onError } = props;
 
@@ -324,8 +327,12 @@ const useAssignFeeling = (props: MutationProps = {}) => {
     getAccessToken,
     options: {
       onSuccess: (data) => {
+        // on_conflict makes a re-assign a no-op: insert_audio_tags_one is null
+        // and nothing changed, so leave the caches alone. The home screen also
+        // reads each audio's feelings, so refresh it alongside the manage list.
         if (data.insert_audio_tags_one) {
           invalidateQuery(MANAGE_QUERY_KEY);
+          invalidateQuery([HOME_QUERY_KEY, isSignedIn]);
         }
         onSuccess?.(data);
       },
@@ -343,7 +350,7 @@ const useAssignFeeling = (props: MutationProps = {}) => {
 };
 
 const useUnassignFeeling = (props: MutationProps = {}) => {
-  const { getAccessToken } = useAuthContext();
+  const { getAccessToken, isSignedIn } = useAuthContext();
   const { invalidateQuery } = useQueryContext();
   const { onSuccess, onError } = props;
 
@@ -354,6 +361,7 @@ const useUnassignFeeling = (props: MutationProps = {}) => {
       onSuccess: (data) => {
         if (data.delete_audio_tags_by_pk) {
           invalidateQuery(MANAGE_QUERY_KEY);
+          invalidateQuery([HOME_QUERY_KEY, isSignedIn]);
         }
         onSuccess?.(data);
       },


### PR DESCRIPTION
## Summary

`useAssignFeeling` and `useUnassignFeeling` attach/detach a listen tag to/from an owned audio for the management dashboard (SWO-411), using the `audio_tags` user permissions from SWO-412.

- **Idempotent assign:** `insert_audio_tags_one` uses `on_conflict (audio_tags_pkey, update_columns: [])` so re-assigning an already-present feeling is a no-op returning `null` (toggle/double-tap safe), not a PK-violation error.
- Both hooks invalidate the manage list **and** the home query (`[listen-home, isSignedIn]`), which reads each audio's `audio_tags` for its feeling chips/filter — matching the sibling audio hooks. Invalidation is guarded on a returned row.

## Test plan

- 20 unit tests (incl. the no-op re-assign and no-op unassign paths, manage+home invalidation)
- `on_conflict` idempotency + both mutations verified live against local Hasura as the `user` role
- Generated types cover only the two new operations; `schema.graphql` untouched

SWO-416