### PR TITLE
[WIP] feat(listen): add playlist update and delete mutation hooks (SWO-417)

### DIFF
--- a/packages/core/src/graphql/gql.ts
+++ b/packages/core/src/graphql/gql.ts
@@ -32,6 +32,8 @@ type Documents = {
     "\n  query GetCurrentReading {\n    reading_progresses(where: { percentage: { _gt: 0, _lt: 100 } }, order_by: { lastReadAt: desc }, limit: 1) {\n      id\n      currentPage\n      totalPages\n      percentage\n      lastReadAt\n      book {\n        id\n        title\n        author\n        totalPages\n        thumbnailUrl\n      }\n    }\n  }\n": typeof types.GetCurrentReadingDocument,
     "\n  query GetReadingStats($monthStart: timestamptz!) {\n    books_aggregate {\n      aggregate {\n        count\n      }\n    }\n    completed_books: books_aggregate(where: { reading_progresses: { percentage: { _gte: 100 } } }) {\n      aggregate {\n        count\n      }\n    }\n    currently_reading: books_aggregate(where: { reading_progresses: { percentage: { _gt: 0, _lt: 100 } } }) {\n      aggregate {\n        count\n      }\n    }\n    reading_time_this_month: reading_progresses_aggregate(where: { lastReadAt: { _gte: $monthStart } }) {\n      aggregate {\n        sum {\n          readingTimeMinutes\n        }\n      }\n    }\n  }\n": typeof types.GetReadingStatsDocument,
     "\n  mutation CreateListenPlaylist($object: playlist_insert_input!) {\n    insert_playlist_one(object: $object) {\n      id\n      slug\n    }\n  }\n": typeof types.CreateListenPlaylistDocument,
+    "\n  mutation UpdatePlaylist($id: uuid!, $set: playlist_set_input!) {\n    update_playlist_by_pk(pk_columns: { id: $id }, _set: $set) {\n      id\n    }\n  }\n": typeof types.UpdatePlaylistDocument,
+    "\n  mutation DeletePlaylist($id: uuid!) {\n    delete_playlist_by_pk(id: $id) {\n      id\n    }\n  }\n": typeof types.DeletePlaylistDocument,
     "\n  mutation AddAudioToPlaylist($object: playlist_audios_insert_input!) {\n    insert_playlist_audios_one(object: $object) {\n      playlist_id\n      audio_id\n      position\n    }\n  }\n": typeof types.AddAudioToPlaylistDocument,
     "\n  mutation RemoveAudioFromPlaylist($playlistId: uuid!, $audioId: uuid!) {\n    delete_playlist_audios_by_pk(playlist_id: $playlistId, audio_id: $audioId) {\n      playlist_id\n      audio_id\n    }\n  }\n": typeof types.RemoveAudioFromPlaylistDocument,
     "\n  mutation ReorderPlaylistAudios($updates: [playlist_audios_updates!]!) {\n    update_playlist_audios_many(updates: $updates) {\n      affected_rows\n      returning {\n        playlist_id\n      }\n    }\n  }\n": typeof types.ReorderPlaylistAudiosDocument,
@@ -92,6 +94,8 @@ const documents: Documents = {
     "\n  query GetCurrentReading {\n    reading_progresses(where: { percentage: { _gt: 0, _lt: 100 } }, order_by: { lastReadAt: desc }, limit: 1) {\n      id\n      currentPage\n      totalPages\n      percentage\n      lastReadAt\n      book {\n        id\n        title\n        author\n        totalPages\n        thumbnailUrl\n      }\n    }\n  }\n": types.GetCurrentReadingDocument,
     "\n  query GetReadingStats($monthStart: timestamptz!) {\n    books_aggregate {\n      aggregate {\n        count\n      }\n    }\n    completed_books: books_aggregate(where: { reading_progresses: { percentage: { _gte: 100 } } }) {\n      aggregate {\n        count\n      }\n    }\n    currently_reading: books_aggregate(where: { reading_progresses: { percentage: { _gt: 0, _lt: 100 } } }) {\n      aggregate {\n        count\n      }\n    }\n    reading_time_this_month: reading_progresses_aggregate(where: { lastReadAt: { _gte: $monthStart } }) {\n      aggregate {\n        sum {\n          readingTimeMinutes\n        }\n      }\n    }\n  }\n": types.GetReadingStatsDocument,
     "\n  mutation CreateListenPlaylist($object: playlist_insert_input!) {\n    insert_playlist_one(object: $object) {\n      id\n      slug\n    }\n  }\n": types.CreateListenPlaylistDocument,
+    "\n  mutation UpdatePlaylist($id: uuid!, $set: playlist_set_input!) {\n    update_playlist_by_pk(pk_columns: { id: $id }, _set: $set) {\n      id\n    }\n  }\n": types.UpdatePlaylistDocument,
+    "\n  mutation DeletePlaylist($id: uuid!) {\n    delete_playlist_by_pk(id: $id) {\n      id\n    }\n  }\n": types.DeletePlaylistDocument,
     "\n  mutation AddAudioToPlaylist($object: playlist_audios_insert_input!) {\n    insert_playlist_audios_one(object: $object) {\n      playlist_id\n      audio_id\n      position\n    }\n  }\n": types.AddAudioToPlaylistDocument,
     "\n  mutation RemoveAudioFromPlaylist($playlistId: uuid!, $audioId: uuid!) {\n    delete_playlist_audios_by_pk(playlist_id: $playlistId, audio_id: $audioId) {\n      playlist_id\n      audio_id\n    }\n  }\n": types.RemoveAudioFromPlaylistDocument,
     "\n  mutation ReorderPlaylistAudios($updates: [playlist_audios_updates!]!) {\n    update_playlist_audios_many(updates: $updates) {\n      affected_rows\n      returning {\n        playlist_id\n      }\n    }\n  }\n": types.ReorderPlaylistAudiosDocument,
@@ -203,6 +207,14 @@ export function graphql(source: "\n  query GetReadingStats($monthStart: timestam
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(source: "\n  mutation CreateListenPlaylist($object: playlist_insert_input!) {\n    insert_playlist_one(object: $object) {\n      id\n      slug\n    }\n  }\n"): typeof import('./graphql').CreateListenPlaylistDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n  mutation UpdatePlaylist($id: uuid!, $set: playlist_set_input!) {\n    update_playlist_by_pk(pk_columns: { id: $id }, _set: $set) {\n      id\n    }\n  }\n"): typeof import('./graphql').UpdatePlaylistDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n  mutation DeletePlaylist($id: uuid!) {\n    delete_playlist_by_pk(id: $id) {\n      id\n    }\n  }\n"): typeof import('./graphql').DeletePlaylistDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/packages/core/src/graphql/graphql.ts
+++ b/packages/core/src/graphql/graphql.ts
@@ -13268,6 +13268,21 @@ export type CreateListenPlaylistMutationVariables = Exact<{
 
 export type CreateListenPlaylistMutation = { __typename?: 'mutation_root', insert_playlist_one?: { __typename?: 'playlist', id: any, slug: string } | null };
 
+export type UpdatePlaylistMutationVariables = Exact<{
+  id: Scalars['uuid']['input'];
+  set: Playlist_Set_Input;
+}>;
+
+
+export type UpdatePlaylistMutation = { __typename?: 'mutation_root', update_playlist_by_pk?: { __typename?: 'playlist', id: any } | null };
+
+export type DeletePlaylistMutationVariables = Exact<{
+  id: Scalars['uuid']['input'];
+}>;
+
+
+export type DeletePlaylistMutation = { __typename?: 'mutation_root', delete_playlist_by_pk?: { __typename?: 'playlist', id: any } | null };
+
 export type AddAudioToPlaylistMutationVariables = Exact<{
   object: Playlist_Audios_Insert_Input;
 }>;
@@ -14062,6 +14077,20 @@ export const CreateListenPlaylistDocument = new TypedDocumentString(`
   }
 }
     `) as unknown as TypedDocumentString<CreateListenPlaylistMutation, CreateListenPlaylistMutationVariables>;
+export const UpdatePlaylistDocument = new TypedDocumentString(`
+    mutation UpdatePlaylist($id: uuid!, $set: playlist_set_input!) {
+  update_playlist_by_pk(pk_columns: {id: $id}, _set: $set) {
+    id
+  }
+}
+    `) as unknown as TypedDocumentString<UpdatePlaylistMutation, UpdatePlaylistMutationVariables>;
+export const DeletePlaylistDocument = new TypedDocumentString(`
+    mutation DeletePlaylist($id: uuid!) {
+  delete_playlist_by_pk(id: $id) {
+    id
+  }
+}
+    `) as unknown as TypedDocumentString<DeletePlaylistMutation, DeletePlaylistMutationVariables>;
 export const AddAudioToPlaylistDocument = new TypedDocumentString(`
     mutation AddAudioToPlaylist($object: playlist_audios_insert_input!) {
   insert_playlist_audios_one(object: $object) {

--- a/packages/core/src/listen/mutation-hooks/index.test.ts
+++ b/packages/core/src/listen/mutation-hooks/index.test.ts
@@ -8,10 +8,12 @@ import {
   useAssignFeeling,
   useCreatePlaylist,
   useDeleteAudio,
+  useDeletePlaylist,
   useRemoveAudioFromPlaylist,
   useReorderPlaylistAudios,
   useUnassignFeeling,
   useUpdateAudio,
+  useUpdatePlaylist,
 } from './index';
 
 vi.mock('../../providers/auth');
@@ -299,6 +301,66 @@ describe('Listen playlist mutation hooks', () => {
       renderHook(() => useUnassignFeeling());
 
       getOnSuccess()?.({ delete_audio_tags_by_pk: null });
+
+      expect(mockInvalidateQuery).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('useUpdatePlaylist', () => {
+    it('sends id plus only the provided fields as _set', () => {
+      const { result } = renderHook(() => useUpdatePlaylist());
+
+      result.current({ id: 'p1', title: 'New title', description: 'New desc' });
+
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        id: 'p1',
+        set: { title: 'New title', description: 'New desc' },
+      });
+    });
+
+    it('invalidates the playlists and manage lists on success', () => {
+      const onSuccess = vi.fn();
+      renderHook(() => useUpdatePlaylist({ onSuccess }));
+
+      const data = { update_playlist_by_pk: { id: 'p1' } };
+      getOnSuccess()?.(data);
+
+      expect(mockInvalidateQuery).toHaveBeenCalledWith(['listen-playlists']);
+      expect(mockInvalidateQuery).toHaveBeenCalledWith(['listen-manage']);
+      expect(onSuccess).toHaveBeenCalledWith(data);
+    });
+
+    it('does not invalidate when no row was updated', () => {
+      renderHook(() => useUpdatePlaylist());
+
+      getOnSuccess()?.({ update_playlist_by_pk: null });
+
+      expect(mockInvalidateQuery).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('useDeletePlaylist', () => {
+    it('passes the id as the delete variable', () => {
+      const { result } = renderHook(() => useDeletePlaylist());
+
+      result.current('p1');
+
+      expect(mockMutateAsync).toHaveBeenCalledWith({ id: 'p1' });
+    });
+
+    it('invalidates the playlists and manage lists on success', () => {
+      renderHook(() => useDeletePlaylist());
+
+      getOnSuccess()?.({ delete_playlist_by_pk: { id: 'p1' } });
+
+      expect(mockInvalidateQuery).toHaveBeenCalledWith(['listen-playlists']);
+      expect(mockInvalidateQuery).toHaveBeenCalledWith(['listen-manage']);
+    });
+
+    it('does not invalidate when no row was deleted', () => {
+      renderHook(() => useDeletePlaylist());
+
+      getOnSuccess()?.({ delete_playlist_by_pk: null });
 
       expect(mockInvalidateQuery).not.toHaveBeenCalled();
     });

--- a/packages/core/src/listen/mutation-hooks/index.test.ts
+++ b/packages/core/src/listen/mutation-hooks/index.test.ts
@@ -318,15 +318,23 @@ describe('Listen playlist mutation hooks', () => {
       });
     });
 
-    it('invalidates the playlists and manage lists on success', () => {
+    it('invalidates the playlists, manage and detail queries on success', () => {
       const onSuccess = vi.fn();
       renderHook(() => useUpdatePlaylist({ onSuccess }));
 
       const data = { update_playlist_by_pk: { id: 'p1' } };
       getOnSuccess()?.(data);
 
-      expect(mockInvalidateQuery).toHaveBeenCalledWith(['listen-playlists']);
+      expect(mockInvalidateQuery).toHaveBeenCalledWith([
+        'listen-playlists',
+        true,
+      ]);
       expect(mockInvalidateQuery).toHaveBeenCalledWith(['listen-manage']);
+      expect(mockInvalidateQuery).toHaveBeenCalledWith([
+        'listen-playlist-detail',
+        true,
+        'p1',
+      ]);
       expect(onSuccess).toHaveBeenCalledWith(data);
     });
 
@@ -348,13 +356,21 @@ describe('Listen playlist mutation hooks', () => {
       expect(mockMutateAsync).toHaveBeenCalledWith({ id: 'p1' });
     });
 
-    it('invalidates the playlists and manage lists on success', () => {
+    it('invalidates the playlists, manage and detail queries on success', () => {
       renderHook(() => useDeletePlaylist());
 
       getOnSuccess()?.({ delete_playlist_by_pk: { id: 'p1' } });
 
-      expect(mockInvalidateQuery).toHaveBeenCalledWith(['listen-playlists']);
+      expect(mockInvalidateQuery).toHaveBeenCalledWith([
+        'listen-playlists',
+        true,
+      ]);
       expect(mockInvalidateQuery).toHaveBeenCalledWith(['listen-manage']);
+      expect(mockInvalidateQuery).toHaveBeenCalledWith([
+        'listen-playlist-detail',
+        true,
+        'p1',
+      ]);
     });
 
     it('does not invalidate when no row was deleted', () => {

--- a/packages/core/src/listen/mutation-hooks/index.ts
+++ b/packages/core/src/listen/mutation-hooks/index.ts
@@ -173,7 +173,7 @@ const useCreatePlaylist = (props: MutationProps = {}) => {
 };
 
 const useUpdatePlaylist = (props: MutationProps = {}) => {
-  const { getAccessToken } = useAuthContext();
+  const { getAccessToken, isSignedIn } = useAuthContext();
   const { invalidateQuery } = useQueryContext();
   const { onSuccess, onError } = props;
 
@@ -182,9 +182,14 @@ const useUpdatePlaylist = (props: MutationProps = {}) => {
     getAccessToken,
     options: {
       onSuccess: (data) => {
-        if (data.update_playlist_by_pk) {
-          invalidateQuery(['listen-playlists']);
+        // The playlists list and detail queries key on isSignedIn (detail also
+        // on the id); invalidateQuery matches exactly, so the full keys are
+        // rebuilt here or the refetch silently no-ops.
+        const playlist = data.update_playlist_by_pk;
+        if (playlist) {
+          invalidateQuery(['listen-playlists', isSignedIn]);
           invalidateQuery(MANAGE_QUERY_KEY);
+          invalidateQuery(['listen-playlist-detail', isSignedIn, playlist.id]);
         }
         onSuccess?.(data);
       },
@@ -204,7 +209,7 @@ const useUpdatePlaylist = (props: MutationProps = {}) => {
 };
 
 const useDeletePlaylist = (props: MutationProps = {}) => {
-  const { getAccessToken } = useAuthContext();
+  const { getAccessToken, isSignedIn } = useAuthContext();
   const { invalidateQuery } = useQueryContext();
   const { onSuccess, onError } = props;
 
@@ -213,9 +218,11 @@ const useDeletePlaylist = (props: MutationProps = {}) => {
     getAccessToken,
     options: {
       onSuccess: (data) => {
-        if (data.delete_playlist_by_pk) {
-          invalidateQuery(['listen-playlists']);
+        const playlist = data.delete_playlist_by_pk;
+        if (playlist) {
+          invalidateQuery(['listen-playlists', isSignedIn]);
           invalidateQuery(MANAGE_QUERY_KEY);
+          invalidateQuery(['listen-playlist-detail', isSignedIn, playlist.id]);
         }
         onSuccess?.(data);
       },

--- a/packages/core/src/listen/mutation-hooks/index.ts
+++ b/packages/core/src/listen/mutation-hooks/index.ts
@@ -14,6 +14,22 @@ const createPlaylistMutation = graphql(/* GraphQL */ `
   }
 `);
 
+const updatePlaylistMutation = graphql(/* GraphQL */ `
+  mutation UpdatePlaylist($id: uuid!, $set: playlist_set_input!) {
+    update_playlist_by_pk(pk_columns: { id: $id }, _set: $set) {
+      id
+    }
+  }
+`);
+
+const deletePlaylistMutation = graphql(/* GraphQL */ `
+  mutation DeletePlaylist($id: uuid!) {
+    delete_playlist_by_pk(id: $id) {
+      id
+    }
+  }
+`);
+
 const addAudioMutation = graphql(/* GraphQL */ `
   mutation AddAudioToPlaylist($object: playlist_audios_insert_input!) {
     insert_playlist_audios_one(object: $object) {
@@ -93,6 +109,14 @@ interface CreateListenPlaylistInput {
   description?: string;
 }
 
+// The user role may only update a playlist's title and description
+// (thumbnail/public are not user-writable — see the Hasura playlist perms).
+interface UpdatePlaylistInput {
+  id: string;
+  title?: string;
+  description?: string;
+}
+
 interface PlaylistAudioRef {
   playlistId: string;
   audioId: string;
@@ -146,6 +170,65 @@ const useCreatePlaylist = (props: MutationProps = {}) => {
     mutateAsync({ object: { ...input, site: LISTEN_SITE } });
 
   return createPlaylist;
+};
+
+const useUpdatePlaylist = (props: MutationProps = {}) => {
+  const { getAccessToken } = useAuthContext();
+  const { invalidateQuery } = useQueryContext();
+  const { onSuccess, onError } = props;
+
+  const { mutateAsync } = useMutationRequest({
+    document: updatePlaylistMutation,
+    getAccessToken,
+    options: {
+      onSuccess: (data) => {
+        if (data.update_playlist_by_pk) {
+          invalidateQuery(['listen-playlists']);
+          invalidateQuery(MANAGE_QUERY_KEY);
+        }
+        onSuccess?.(data);
+      },
+      onError: (error) => {
+        console.error('Update playlist failed:', error);
+        onError?.(error);
+      },
+    },
+  });
+
+  const updatePlaylist = (input: UpdatePlaylistInput) => {
+    const { id, ...fields } = input;
+    return mutateAsync({ id, set: fields });
+  };
+
+  return updatePlaylist;
+};
+
+const useDeletePlaylist = (props: MutationProps = {}) => {
+  const { getAccessToken } = useAuthContext();
+  const { invalidateQuery } = useQueryContext();
+  const { onSuccess, onError } = props;
+
+  const { mutateAsync } = useMutationRequest({
+    document: deletePlaylistMutation,
+    getAccessToken,
+    options: {
+      onSuccess: (data) => {
+        if (data.delete_playlist_by_pk) {
+          invalidateQuery(['listen-playlists']);
+          invalidateQuery(MANAGE_QUERY_KEY);
+        }
+        onSuccess?.(data);
+      },
+      onError: (error) => {
+        console.error('Delete playlist failed:', error);
+        onError?.(error);
+      },
+    },
+  });
+
+  const deletePlaylist = (id: string) => mutateAsync({ id });
+
+  return deletePlaylist;
 };
 
 const useAddAudioToPlaylist = (props: MutationProps = {}) => {
@@ -385,12 +468,15 @@ export {
   type PlaylistAudioRef,
   type ReorderUpdate,
   type UpdateAudioInput,
+  type UpdatePlaylistInput,
   useAddAudioToPlaylist,
   useAssignFeeling,
   useCreatePlaylist,
   useDeleteAudio,
+  useDeletePlaylist,
   useRemoveAudioFromPlaylist,
   useReorderPlaylistAudios,
   useUnassignFeeling,
   useUpdateAudio,
+  useUpdatePlaylist,
 };


### PR DESCRIPTION
## Summary

`useUpdatePlaylist` (title/description — the only user-writable columns per the Hasura playlist perms) and `useDeletePlaylist` for the management dashboard (SWO-411), using the playlist delete perm from SWO-413.

- Both invalidate the **full** query keys the provider matches exactly: `['listen-playlists', isSignedIn]`, `['listen-manage']`, and `['listen-playlist-detail', isSignedIn, id]` (id from the returned row) — otherwise the exact-match `invalidateQuery` silently no-ops. Guarded on a returned row.
- The same stale-key bug in the pre-existing create/add/remove/reorder hooks is tracked separately in **SWO-424**.

## Test plan

- 26 unit tests (incl. no-op-null paths and correct-key assertions)
- update (title+description), delete, and the empty-`_set` edge verified live against local Hasura as the `user` role
- Generated types cover only the two new operations; `schema.graphql` untouched

SWO-417