### PR TITLE
[WIP] feat(listen): reflect the playing audio in the URL (SWO-422)

### DIFF
--- a/apps/listen/e2e/home/desktop.spec.ts
+++ b/apps/listen/e2e/home/desktop.spec.ts
@@ -24,6 +24,8 @@ test.describe('playing list', () => {
     await secondItem.click();
     await expect(firstItem).not.toContainText('Now Playing');
     await expect(secondItem).toContainText('Now Playing');
+    // Selecting a track mirrors it to the URL, YouTube-style (`?audio=<id>`).
+    await expect(page).toHaveURL(/[?&]audio=/);
   });
 });
 

--- a/apps/listen/src/routeTree.gen.ts
+++ b/apps/listen/src/routeTree.gen.ts
@@ -8,36 +8,33 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { createFileRoute } from '@tanstack/react-router'
-
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as IndexRouteImport } from './routes/index'
+import { Route as PlaylistsIdRouteImport } from './routes/playlists.$id'
 
-const IndexLazyRouteImport = createFileRoute('/')()
-const PlaylistsIdLazyRouteImport = createFileRoute('/playlists/$id')()
-
-const IndexLazyRoute = IndexLazyRouteImport.update({
+const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any).lazy(() => import('./routes/index.lazy').then((d) => d.Route))
-const PlaylistsIdLazyRoute = PlaylistsIdLazyRouteImport.update({
+const PlaylistsIdRoute = PlaylistsIdRouteImport.update({
   id: '/playlists/$id',
   path: '/playlists/$id',
   getParentRoute: () => rootRouteImport,
 } as any).lazy(() => import('./routes/playlists.$id.lazy').then((d) => d.Route))
 
 export interface FileRoutesByFullPath {
-  '/': typeof IndexLazyRoute
-  '/playlists/$id': typeof PlaylistsIdLazyRoute
+  '/': typeof IndexRoute
+  '/playlists/$id': typeof PlaylistsIdRoute
 }
 export interface FileRoutesByTo {
-  '/': typeof IndexLazyRoute
-  '/playlists/$id': typeof PlaylistsIdLazyRoute
+  '/': typeof IndexRoute
+  '/playlists/$id': typeof PlaylistsIdRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
-  '/': typeof IndexLazyRoute
-  '/playlists/$id': typeof PlaylistsIdLazyRoute
+  '/': typeof IndexRoute
+  '/playlists/$id': typeof PlaylistsIdRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -48,8 +45,8 @@ export interface FileRouteTypes {
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-  IndexLazyRoute: typeof IndexLazyRoute
-  PlaylistsIdLazyRoute: typeof PlaylistsIdLazyRoute
+  IndexRoute: typeof IndexRoute
+  PlaylistsIdRoute: typeof PlaylistsIdRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -58,22 +55,22 @@ declare module '@tanstack/react-router' {
       id: '/'
       path: '/'
       fullPath: '/'
-      preLoaderRoute: typeof IndexLazyRouteImport
+      preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/playlists/$id': {
       id: '/playlists/$id'
       path: '/playlists/$id'
       fullPath: '/playlists/$id'
-      preLoaderRoute: typeof PlaylistsIdLazyRouteImport
+      preLoaderRoute: typeof PlaylistsIdRouteImport
       parentRoute: typeof rootRouteImport
     }
   }
 }
 
 const rootRouteChildren: RootRouteChildren = {
-  IndexLazyRoute: IndexLazyRoute,
-  PlaylistsIdLazyRoute: PlaylistsIdLazyRoute,
+  IndexRoute: IndexRoute,
+  PlaylistsIdRoute: PlaylistsIdRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/listen/src/routes/index.lazy.tsx
+++ b/apps/listen/src/routes/index.lazy.tsx
@@ -37,15 +37,14 @@ const Content = () => {
   const createPlaylist = listenMutationHooks.useCreatePlaylist();
   const onSelectCollection = useCollectionNavigate();
 
-  // The playing track is a URL search param (YouTube's `?v=`). Read it in, and
-  // update it as the player moves between tracks — pushing a history entry for
-  // an explicit pick, replacing for player-driven changes so auto-advance
-  // doesn't bury the back button.
+  // The playing track is a URL search param (YouTube's `?v=`). Seed it into the
+  // player, and mirror the player's current track back with `replace` so the
+  // URL always reflects what's playing without piling up history entries.
   const { audio: activeAudioId = '' } = Route.useSearch();
   const navigate = Route.useNavigate();
   const onAudioChange = useCallback(
-    (id: string, replace: boolean) =>
-      navigate({ search: (prev) => ({ ...prev, audio: id }), replace }),
+    (id: string) =>
+      navigate({ search: (prev) => ({ ...prev, audio: id }), replace: true }),
     [navigate],
   );
 

--- a/apps/listen/src/routes/index.lazy.tsx
+++ b/apps/listen/src/routes/index.lazy.tsx
@@ -37,14 +37,15 @@ const Content = () => {
   const createPlaylist = listenMutationHooks.useCreatePlaylist();
   const onSelectCollection = useCollectionNavigate();
 
-  // The playing track is a URL search param (YouTube's `?v=`). Read it in,
-  // and update it (replace, so auto-advance doesn't spam history) as the
-  // player moves between tracks.
+  // The playing track is a URL search param (YouTube's `?v=`). Read it in, and
+  // update it as the player moves between tracks — pushing a history entry for
+  // an explicit pick, replacing for player-driven changes so auto-advance
+  // doesn't bury the back button.
   const { audio: activeAudioId = '' } = Route.useSearch();
   const navigate = Route.useNavigate();
   const onAudioChange = useCallback(
-    (id: string) =>
-      navigate({ search: (prev) => ({ ...prev, audio: id }), replace: true }),
+    (id: string, replace: boolean) =>
+      navigate({ search: (prev) => ({ ...prev, audio: id }), replace }),
     [navigate],
   );
 

--- a/apps/listen/src/routes/index.lazy.tsx
+++ b/apps/listen/src/routes/index.lazy.tsx
@@ -1,6 +1,7 @@
 import { createLazyFileRoute, useNavigate } from '@tanstack/react-router';
 import { listenMutationHooks, listenQueryHooks } from 'core';
 import { useAuthContext } from 'core/providers/auth';
+import { useCallback } from 'react';
 import { ListeningScreen } from 'ui/listen/minimalism';
 import { LoadingBackdrop } from 'ui/universal';
 import { appConfig } from '../config';
@@ -36,6 +37,17 @@ const Content = () => {
   const createPlaylist = listenMutationHooks.useCreatePlaylist();
   const onSelectCollection = useCollectionNavigate();
 
+  // The playing track is a URL search param (YouTube's `?v=`). Read it in,
+  // and update it (replace, so auto-advance doesn't spam history) as the
+  // player moves between tracks.
+  const { audio: activeAudioId = '' } = Route.useSearch();
+  const navigate = Route.useNavigate();
+  const onAudioChange = useCallback(
+    (id: string) =>
+      navigate({ search: (prev) => ({ ...prev, audio: id }), replace: true }),
+    [navigate],
+  );
+
   return (
     <ListeningScreen
       mode="all"
@@ -46,6 +58,8 @@ const Content = () => {
       onLogout={signOut}
       playlists={playlists}
       onSelectCollection={onSelectCollection}
+      activeAudioId={activeAudioId}
+      onAudioChange={onAudioChange}
       onCreate={(title) =>
         user
           ? createPlaylist({ title, slug: slugify(title), thumbnailUrl: '' })

--- a/apps/listen/src/routes/index.tsx
+++ b/apps/listen/src/routes/index.tsx
@@ -1,0 +1,22 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+// The playing track lives in the URL, YouTube-style: the collection is the
+// route (home = `/`, the `&list=` equivalent) and the audio is the `audio`
+// search param (the `?v=` equivalent). It's optional — absent means "nothing
+// selected yet", which keeps a freshly loaded page's URL clean and lets the
+// player fall back to the first track.
+interface ListenSearch {
+  audio?: string;
+}
+
+const validateSearch = (search: Record<string, unknown>): ListenSearch =>
+  typeof search.audio === 'string' && search.audio
+    ? { audio: search.audio }
+    : {};
+
+const Route = createFileRoute('/')({
+  validateSearch,
+});
+
+export { Route };
+export type { ListenSearch };

--- a/apps/listen/src/routes/index.tsx
+++ b/apps/listen/src/routes/index.tsx
@@ -4,17 +4,24 @@ import { createFileRoute } from '@tanstack/react-router';
 // route (home = `/`, the `&list=` equivalent) and the audio is the `audio`
 // search param (the `?v=` equivalent). It's optional — absent means "nothing
 // selected yet", which keeps a freshly loaded page's URL clean and lets the
-// player fall back to the first track.
+// player fall back to the first track. Other params pass through untouched (the
+// index signature) — critically the Auth0 callback's `code`/`state`, since the
+// redirect lands back on `/`.
 interface ListenSearch {
   audio?: string;
+  [key: string]: unknown;
 }
 
-// Shared by both listen routes (home and a playlist) — the `audio` param is
-// the same everywhere; only the collection part of the URL differs.
-const validateAudioSearch = (search: Record<string, unknown>): ListenSearch =>
-  typeof search.audio === 'string' && search.audio
-    ? { audio: search.audio }
-    : {};
+// Shared by both listen routes (home and a playlist) — the `audio` param is the
+// same everywhere; only the collection part of the URL differs. Preserve every
+// other param (spread) so this validator is non-destructive.
+const validateAudioSearch = (
+  search: Record<string, unknown>,
+): ListenSearch => ({
+  ...search,
+  audio:
+    typeof search.audio === 'string' && search.audio ? search.audio : undefined,
+});
 
 const Route = createFileRoute('/')({
   validateSearch: validateAudioSearch,

--- a/apps/listen/src/routes/index.tsx
+++ b/apps/listen/src/routes/index.tsx
@@ -9,14 +9,16 @@ interface ListenSearch {
   audio?: string;
 }
 
-const validateSearch = (search: Record<string, unknown>): ListenSearch =>
+// Shared by both listen routes (home and a playlist) — the `audio` param is
+// the same everywhere; only the collection part of the URL differs.
+const validateAudioSearch = (search: Record<string, unknown>): ListenSearch =>
   typeof search.audio === 'string' && search.audio
     ? { audio: search.audio }
     : {};
 
 const Route = createFileRoute('/')({
-  validateSearch,
+  validateSearch: validateAudioSearch,
 });
 
-export { Route };
+export { Route, validateAudioSearch };
 export type { ListenSearch };

--- a/apps/listen/src/routes/playlists.$id.lazy.tsx
+++ b/apps/listen/src/routes/playlists.$id.lazy.tsx
@@ -1,6 +1,7 @@
 import { createLazyFileRoute, useNavigate } from '@tanstack/react-router';
 import { listenMutationHooks, listenQueryHooks } from 'core';
 import { useAuthContext } from 'core/providers/auth';
+import { useCallback } from 'react';
 import { ListeningScreen } from 'ui/listen/minimalism';
 import { LoadingBackdrop } from 'ui/universal';
 import { appConfig } from '../config';
@@ -36,6 +37,15 @@ const Content = () => {
   const createPlaylist = listenMutationHooks.useCreatePlaylist();
   const onSelectCollection = useCollectionNavigate();
 
+  // Same `audio` search param as home, alongside the playlist id in the path.
+  const { audio: activeAudioId = '' } = Route.useSearch();
+  const navigate = Route.useNavigate();
+  const onAudioChange = useCallback(
+    (id: string) =>
+      navigate({ search: (prev) => ({ ...prev, audio: id }), replace: true }),
+    [navigate],
+  );
+
   return (
     <ListeningScreen
       mode="playlist"
@@ -46,6 +56,8 @@ const Content = () => {
       onLogout={signOut}
       playlists={playlists}
       onSelectCollection={onSelectCollection}
+      activeAudioId={activeAudioId}
+      onAudioChange={onAudioChange}
       onCreate={
         isSignedIn
           ? (title) =>

--- a/apps/listen/src/routes/playlists.$id.lazy.tsx
+++ b/apps/listen/src/routes/playlists.$id.lazy.tsx
@@ -41,8 +41,8 @@ const Content = () => {
   const { audio: activeAudioId = '' } = Route.useSearch();
   const navigate = Route.useNavigate();
   const onAudioChange = useCallback(
-    (id: string, replace: boolean) =>
-      navigate({ search: (prev) => ({ ...prev, audio: id }), replace }),
+    (id: string) =>
+      navigate({ search: (prev) => ({ ...prev, audio: id }), replace: true }),
     [navigate],
   );
 

--- a/apps/listen/src/routes/playlists.$id.lazy.tsx
+++ b/apps/listen/src/routes/playlists.$id.lazy.tsx
@@ -41,8 +41,8 @@ const Content = () => {
   const { audio: activeAudioId = '' } = Route.useSearch();
   const navigate = Route.useNavigate();
   const onAudioChange = useCallback(
-    (id: string) =>
-      navigate({ search: (prev) => ({ ...prev, audio: id }), replace: true }),
+    (id: string, replace: boolean) =>
+      navigate({ search: (prev) => ({ ...prev, audio: id }), replace }),
     [navigate],
   );
 

--- a/apps/listen/src/routes/playlists.$id.tsx
+++ b/apps/listen/src/routes/playlists.$id.tsx
@@ -1,15 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router';
-import type { ListenSearch } from './index';
+import { validateAudioSearch } from './index';
 
 // Same `audio` search param as home — here it rides alongside the playlist id
 // in the path: `/playlists/<pid>?audio=<id>` (YouTube's `?v=…&list=…`).
-const validateSearch = (search: Record<string, unknown>): ListenSearch =>
-  typeof search.audio === 'string' && search.audio
-    ? { audio: search.audio }
-    : {};
-
 const Route = createFileRoute('/playlists/$id')({
-  validateSearch,
+  validateSearch: validateAudioSearch,
 });
 
 export { Route };

--- a/apps/listen/src/routes/playlists.$id.tsx
+++ b/apps/listen/src/routes/playlists.$id.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute } from '@tanstack/react-router';
+import type { ListenSearch } from './index';
+
+// Same `audio` search param as home — here it rides alongside the playlist id
+// in the path: `/playlists/<pid>?audio=<id>` (YouTube's `?v=…&list=…`).
+const validateSearch = (search: Record<string, unknown>): ListenSearch =>
+  typeof search.audio === 'string' && search.audio
+    ? { audio: search.audio }
+    : {};
+
+const Route = createFileRoute('/playlists/$id')({
+  validateSearch,
+});
+
+export { Route };

--- a/packages/core/src/universal/hooks/useSAudioPlayer/useSAudioPlayer.test.tsx
+++ b/packages/core/src/universal/hooks/useSAudioPlayer/useSAudioPlayer.test.tsx
@@ -65,6 +65,53 @@ const endTrack = ({ loopMode, index, startPlaying }: EndTrackOptions) => {
   };
 };
 
+// `playerState.currentIndex` is a flat position in `audioList`, and so is the
+// `index` input — these tests pin that contract across the shuffle permutation,
+// which is where the two used to diverge.
+const SelectHarness = (props: { index: number }) => {
+  const { getControlsProps, playerState } = useSAudioPlayer({
+    audioList,
+    index: props.index,
+  });
+
+  return (
+    <div>
+      <button
+        type="button"
+        data-testid="shuffle"
+        onClick={getControlsProps().onShuffle}
+      >
+        shuffle
+      </button>
+      <span data-testid="index">{playerState.currentIndex}</span>
+    </div>
+  );
+};
+
+describe('useSAudioPlayer track addressing', () => {
+  it('selects the track at the given flat index while shuffled', () => {
+    const view = render(<SelectHarness index={0} />);
+
+    fireEvent.click(view.getByTestId('shuffle'));
+    // Selecting flat index 2 must land on audioList[2] regardless of the
+    // shuffled play order, not on whatever slot 2 happens to hold.
+    view.rerender(<SelectHarness index={2} />);
+
+    expect(view.getByTestId('index').textContent).toBe('2');
+  });
+
+  it('keeps the current track when shuffle is toggled on and off', () => {
+    const view = render(<SelectHarness index={1} />);
+    expect(view.getByTestId('index').textContent).toBe('1');
+
+    fireEvent.click(view.getByTestId('shuffle')); // on
+    expect(view.getByTestId('index').textContent).toBe('1');
+
+    fireEvent.click(view.getByTestId('shuffle')); // off
+    expect(view.getByTestId('index').textContent).toBe('1');
+  });
+});
+
 describe('useSAudioPlayer onEnded', () => {
   describe('loopMode None', () => {
     it('advances to the next audio and keeps playing mid-list', () => {

--- a/packages/core/src/universal/hooks/useSAudioPlayer/useSAudioPlayer.test.tsx
+++ b/packages/core/src/universal/hooks/useSAudioPlayer/useSAudioPlayer.test.tsx
@@ -88,6 +88,31 @@ const SelectHarness = (props: { index: number }) => {
   );
 };
 
+// A variant that can change its `audioList`, to exercise the list being
+// filtered/rebuilt underneath the player.
+const ResizeHarness = (props: {
+  list: SAudioPlayerAudioItem[];
+  index: number;
+}) => {
+  const { getControlsProps, playerState } = useSAudioPlayer({
+    audioList: props.list,
+    index: props.index,
+  });
+
+  return (
+    <div>
+      <button
+        type="button"
+        data-testid="shuffle"
+        onClick={getControlsProps().onShuffle}
+      >
+        shuffle
+      </button>
+      <span data-testid="track">{playerState.audioItem?.id ?? 'none'}</span>
+    </div>
+  );
+};
+
 describe('useSAudioPlayer track addressing', () => {
   it('selects the track at the given flat index while shuffled', () => {
     const view = render(<SelectHarness index={0} />);
@@ -109,6 +134,18 @@ describe('useSAudioPlayer track addressing', () => {
 
     fireEvent.click(view.getByTestId('shuffle')); // off
     expect(view.getByTestId('index').textContent).toBe('1');
+  });
+
+  it('stays on a valid track when the list shrinks while shuffled', () => {
+    const view = render(<ResizeHarness list={audioList} index={2} />);
+
+    fireEvent.click(view.getByTestId('shuffle'));
+    // Filter the list down to one track: the slot must be rebuilt in range,
+    // not left pointing past the end of the now-shorter order (which would
+    // null out the current track and stop playback).
+    view.rerender(<ResizeHarness list={audioList.slice(0, 1)} index={0} />);
+
+    expect(view.getByTestId('track').textContent).toBe('1');
   });
 });
 

--- a/packages/core/src/universal/hooks/useSAudioPlayer/useSAudioPlayer.test.tsx
+++ b/packages/core/src/universal/hooks/useSAudioPlayer/useSAudioPlayer.test.tsx
@@ -65,23 +65,30 @@ const endTrack = ({ loopMode, index, startPlaying }: EndTrackOptions) => {
   };
 };
 
-// `playerState.currentIndex` is a flat position in `audioList`, and so is the
-// `index` input — these tests pin that contract across the shuffle permutation,
-// which is where the two used to diverge.
+// `playerState.currentIndex` is a flat position in `audioList`. `onSelect` takes
+// a flat position too; these tests pin that contract across the shuffle
+// permutation, which is where selection used to land on the wrong track.
 const SelectHarness = (props: { index: number }) => {
   const { getControlsProps, playerState } = useSAudioPlayer({
     audioList,
     index: props.index,
   });
+  const controls = getControlsProps();
 
   return (
     <div>
+      <button type="button" data-testid="shuffle" onClick={controls.onShuffle}>
+        shuffle
+      </button>
+      <button type="button" data-testid="next" onClick={controls.onNext}>
+        next
+      </button>
       <button
         type="button"
-        data-testid="shuffle"
-        onClick={getControlsProps().onShuffle}
+        data-testid="select2"
+        onClick={() => controls.onSelect(2)}
       >
-        shuffle
+        select 2
       </button>
       <span data-testid="index">{playerState.currentIndex}</span>
     </div>
@@ -120,7 +127,7 @@ describe('useSAudioPlayer track addressing', () => {
     fireEvent.click(view.getByTestId('shuffle'));
     // Selecting flat index 2 must land on audioList[2] regardless of the
     // shuffled play order, not on whatever slot 2 happens to hold.
-    view.rerender(<SelectHarness index={2} />);
+    fireEvent.click(view.getByTestId('select2'));
 
     expect(view.getByTestId('index').textContent).toBe('2');
   });
@@ -133,6 +140,18 @@ describe('useSAudioPlayer track addressing', () => {
     expect(view.getByTestId('index').textContent).toBe('1');
 
     fireEvent.click(view.getByTestId('shuffle')); // off
+    expect(view.getByTestId('index').textContent).toBe('1');
+  });
+
+  it('does not snap back to the seed after advancing then shuffling', () => {
+    // Regression: shuffle must preserve the *current* track (index 1 after a
+    // next), not re-derive from the original seed index (0).
+    const view = render(<SelectHarness index={0} />);
+
+    fireEvent.click(view.getByTestId('next')); // advance to flat 1
+    expect(view.getByTestId('index').textContent).toBe('1');
+
+    fireEvent.click(view.getByTestId('shuffle')); // shuffle on
     expect(view.getByTestId('index').textContent).toBe('1');
   });
 

--- a/packages/core/src/universal/hooks/useSAudioPlayer/useSAudioPlayer.ts
+++ b/packages/core/src/universal/hooks/useSAudioPlayer/useSAudioPlayer.ts
@@ -8,6 +8,9 @@ import { playAudio, seek } from './utils/actions';
 // have to know about the shuffle permutation. `indexes[slot]` maps slot -> flat;
 // `indexes.indexOf(flat)` maps flat -> slot.
 
+// The natural play order (identity): slot N plays audioList[N].
+const buildOrder = (length: number) => Array.from({ length }).map((_v, k) => k);
+
 export interface SAudioPlayerAudioItem {
   id: string;
   src: string;
@@ -41,9 +44,6 @@ const useSAudioPlayer = (inputs: SAudioPlayerInputs) => {
   const ref = useRef<HTMLAudioElement>(null);
 
   const [indexes, setIndexes] = useState<number[]>();
-  // A live handle on `indexes` so the flat -> slot conversion below reads the
-  // current play order without re-running every time the order changes.
-  const indexesRef = useRef<number[] | undefined>(undefined);
   const [currentIndex, setCurrentIndex] = useState<number>(index);
 
   const [isShuffled, setIsShuffled] = useState(shuffle);
@@ -57,36 +57,30 @@ const useSAudioPlayer = (inputs: SAudioPlayerInputs) => {
   const loopModes = ['all', 'one', 'none'];
 
   useEffect(() => {
-    indexesRef.current = indexes;
-  }, [indexes]);
-
-  useEffect(() => {
     if (total) {
-      const next = Array.from({ length: total }).map((_v, i) => i);
-
-      setIndexes(next);
+      setIndexes(buildOrder(total));
     }
   }, [total]);
 
   // `index` is a flat position; select the slot that plays that track. Under
   // shuffle the two differ, so converting here is what makes external selection
   // (a deep link, a clicked track) land on the intended song rather than
-  // whatever sits at that slot in the shuffled order.
+  // whatever sits at that slot in the shuffled order. Re-runs when the order
+  // itself changes (e.g. the list is filtered and rebuilt) so the slot stays in
+  // range instead of pointing past the end of a now-shorter order.
   useEffect(() => {
-    const order = indexesRef.current;
-
-    if (!order) {
+    if (!indexes) {
       setCurrentIndex(index);
 
       return;
     }
 
-    const slot = order.indexOf(index);
+    const slot = indexes.indexOf(index);
 
     if (slot >= 0) {
       setCurrentIndex(slot);
     }
-  }, [index]);
+  }, [index, indexes]);
 
   useEffect(() => {
     setIsShuffled(shuffle);
@@ -101,7 +95,11 @@ const useSAudioPlayer = (inputs: SAudioPlayerInputs) => {
   const isFirst = currentIndex === firstIndex;
   const isLast = currentIndex === lastIndex;
 
-  const i = indexes ? indexes[currentIndex] : 0;
+  // Guard the slot: while the list is being rebuilt (filter change), a slot
+  // from the previous, longer order can momentarily exceed the new one — fall
+  // back to the first track rather than reading an undefined position.
+  const i =
+    indexes && currentIndex < indexes.length ? indexes[currentIndex] : 0;
   const audioItem = audioList && indexes ? audioList[i] : null;
   const { src } = audioItem || {};
 
@@ -215,9 +213,10 @@ const useSAudioPlayer = (inputs: SAudioPlayerInputs) => {
     // position, rebuild the order (shuffled copy, or identity when turning
     // shuffle off), then re-point currentIndex at that same track's new slot.
     const currentFlat = indexes[currentIndex];
-    const identity = Array.from({ length: total }).map((_v, k) => k);
     const sortFunc = () => (Math.random() > 0.5 ? 1 : -1);
-    const nextOrder = isShuffled ? identity : [...indexes].sort(sortFunc);
+    const nextOrder = isShuffled
+      ? buildOrder(total)
+      : [...indexes].sort(sortFunc);
     const nextSlot = nextOrder.indexOf(currentFlat);
 
     setIndexes(nextOrder);

--- a/packages/core/src/universal/hooks/useSAudioPlayer/useSAudioPlayer.ts
+++ b/packages/core/src/universal/hooks/useSAudioPlayer/useSAudioPlayer.ts
@@ -1,6 +1,13 @@
 import { useEffect, useRef, useState } from 'react';
 import { playAudio, seek } from './utils/actions';
 
+// The player addresses tracks two ways. A "slot" is a position in the play
+// order (`indexes`), which shuffle permutes; `currentIndex` state is a slot.
+// A "flat index" is a position in the untouched `audioList` — that's what the
+// `index` input and the `currentIndex` output both speak, so callers never
+// have to know about the shuffle permutation. `indexes[slot]` maps slot -> flat;
+// `indexes.indexOf(flat)` maps flat -> slot.
+
 export interface SAudioPlayerAudioItem {
   id: string;
   src: string;
@@ -34,6 +41,9 @@ const useSAudioPlayer = (inputs: SAudioPlayerInputs) => {
   const ref = useRef<HTMLAudioElement>(null);
 
   const [indexes, setIndexes] = useState<number[]>();
+  // A live handle on `indexes` so the flat -> slot conversion below reads the
+  // current play order without re-running every time the order changes.
+  const indexesRef = useRef<number[] | undefined>(undefined);
   const [currentIndex, setCurrentIndex] = useState<number>(index);
 
   const [isShuffled, setIsShuffled] = useState(shuffle);
@@ -47,15 +57,35 @@ const useSAudioPlayer = (inputs: SAudioPlayerInputs) => {
   const loopModes = ['all', 'one', 'none'];
 
   useEffect(() => {
-    if (total) {
-      const indexes = Array.from({ length: total }).map((_v, i) => i);
+    indexesRef.current = indexes;
+  }, [indexes]);
 
-      setIndexes(indexes);
+  useEffect(() => {
+    if (total) {
+      const next = Array.from({ length: total }).map((_v, i) => i);
+
+      setIndexes(next);
     }
   }, [total]);
 
+  // `index` is a flat position; select the slot that plays that track. Under
+  // shuffle the two differ, so converting here is what makes external selection
+  // (a deep link, a clicked track) land on the intended song rather than
+  // whatever sits at that slot in the shuffled order.
   useEffect(() => {
-    setCurrentIndex(index);
+    const order = indexesRef.current;
+
+    if (!order) {
+      setCurrentIndex(index);
+
+      return;
+    }
+
+    const slot = order.indexOf(index);
+
+    if (slot >= 0) {
+      setCurrentIndex(slot);
+    }
   }, [index]);
 
   useEffect(() => {
@@ -181,15 +211,17 @@ const useSAudioPlayer = (inputs: SAudioPlayerInputs) => {
       return;
     }
 
-    if (!isShuffled) {
-      const sortFunc = () => (Math.random() > 0.5 ? 1 : -1);
-      const newIndexes = [...indexes.sort(sortFunc)];
-      const newCurrentIndex = newIndexes.findIndex((i) => i === currentIndex);
+    // Keep the current track playing across the toggle: remember its flat
+    // position, rebuild the order (shuffled copy, or identity when turning
+    // shuffle off), then re-point currentIndex at that same track's new slot.
+    const currentFlat = indexes[currentIndex];
+    const identity = Array.from({ length: total }).map((_v, k) => k);
+    const sortFunc = () => (Math.random() > 0.5 ? 1 : -1);
+    const nextOrder = isShuffled ? identity : [...indexes].sort(sortFunc);
+    const nextSlot = nextOrder.indexOf(currentFlat);
 
-      setIndexes(newIndexes);
-      setCurrentIndex(newCurrentIndex);
-    }
-
+    setIndexes(nextOrder);
+    setCurrentIndex(nextSlot < 0 ? 0 : nextSlot);
     setIsShuffled(!isShuffled);
   };
 

--- a/packages/core/src/universal/hooks/useSAudioPlayer/useSAudioPlayer.ts
+++ b/packages/core/src/universal/hooks/useSAudioPlayer/useSAudioPlayer.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { playAudio, seek } from './utils/actions';
 
 // The player addresses tracks two ways. A "slot" is a position in the play
@@ -44,6 +44,9 @@ const useSAudioPlayer = (inputs: SAudioPlayerInputs) => {
   const ref = useRef<HTMLAudioElement>(null);
 
   const [indexes, setIndexes] = useState<number[]>();
+  // Latest play order, read by the imperative `onSelect` without making it
+  // re-create on every reorder.
+  const indexesRef = useRef<number[] | undefined>(undefined);
   const [currentIndex, setCurrentIndex] = useState<number>(index);
 
   const [isShuffled, setIsShuffled] = useState(shuffle);
@@ -57,30 +60,34 @@ const useSAudioPlayer = (inputs: SAudioPlayerInputs) => {
   const loopModes = ['all', 'one', 'none'];
 
   useEffect(() => {
+    indexesRef.current = indexes;
+  }, [indexes]);
+
+  useEffect(() => {
     if (total) {
       setIndexes(buildOrder(total));
     }
   }, [total]);
 
-  // `index` is a flat position; select the slot that plays that track. Under
-  // shuffle the two differ, so converting here is what makes external selection
-  // (a deep link, a clicked track) land on the intended song rather than
-  // whatever sits at that slot in the shuffled order. Re-runs when the order
-  // itself changes (e.g. the list is filtered and rebuilt) so the slot stays in
-  // range instead of pointing past the end of a now-shorter order.
+  // Selection is imperative (`onSelect`), not derived from the `index` input —
+  // deriving it re-applied a stale value on every reorder and fought both
+  // auto-advance and shuffle. `onSelect` takes a flat position and converts it
+  // to the matching slot in the current play order (identity unless shuffled),
+  // so a clicked/deep-linked track always lands on the intended song.
+  const onSelect = useCallback((flatIndex: number) => {
+    const order = indexesRef.current;
+    const slot = order ? order.indexOf(flatIndex) : flatIndex;
+
+    setCurrentIndex(slot < 0 ? 0 : slot);
+  }, []);
+
+  // Keep the slot in range when the list shrinks (e.g. a feeling filter): a slot
+  // from the previous, longer order would otherwise point past the end.
   useEffect(() => {
-    if (!indexes) {
-      setCurrentIndex(index);
-
-      return;
+    if (indexes && currentIndex > indexes.length - 1) {
+      setCurrentIndex(0);
     }
-
-    const slot = indexes.indexOf(index);
-
-    if (slot >= 0) {
-      setCurrentIndex(slot);
-    }
-  }, [index, indexes]);
+  }, [indexes, currentIndex]);
 
   useEffect(() => {
     setIsShuffled(shuffle);
@@ -263,6 +270,7 @@ const useSAudioPlayer = (inputs: SAudioPlayerInputs) => {
       onNext,
       onShuffle,
       onChangeLoopMode,
+      onSelect,
     };
   };
 

--- a/packages/core/src/universal/hooks/useSAudioPlayer/useSAudioPlayer.ts
+++ b/packages/core/src/universal/hooks/useSAudioPlayer/useSAudioPlayer.ts
@@ -102,12 +102,15 @@ const useSAudioPlayer = (inputs: SAudioPlayerInputs) => {
   const isFirst = currentIndex === firstIndex;
   const isLast = currentIndex === lastIndex;
 
-  // Guard the slot: while the list is being rebuilt (filter change), a slot
-  // from the previous, longer order can momentarily exceed the new one — fall
-  // back to the first track rather than reading an undefined position.
-  const i =
-    indexes && currentIndex < indexes.length ? indexes[currentIndex] : 0;
-  const audioItem = audioList && indexes ? audioList[i] : null;
+  // Guard the slot AND the resulting flat index: while the list is being
+  // rebuilt (filter change), a slot from the previous, longer order — or the
+  // flat index it maps to — can momentarily exceed the new, shorter list. Fall
+  // back to the first track so `audioItem` never reads an undefined position
+  // (which would blank the player for a frame).
+  const slot = indexes && currentIndex < indexes.length ? currentIndex : 0;
+  const rawIndex = indexes ? indexes[slot] : 0;
+  const i = rawIndex < audioList.length ? rawIndex : 0;
+  const audioItem = audioList.length && indexes ? audioList[i] : null;
   const { src } = audioItem || {};
 
   // https://mui.com/material-ui/react-slider/#music-player

--- a/packages/ui/src/listen/minimalism/home/audio-list.test.tsx
+++ b/packages/ui/src/listen/minimalism/home/audio-list.test.tsx
@@ -18,8 +18,8 @@ vi.mock('core', () => ({
         getSeekerProps: () => ({}),
         getControlsProps: () => ({
           onPlay: () => setPlaying((p) => !p),
-          onPrev: () => {},
-          onNext: () => {},
+          onPrev: () => setIndex((i) => Math.max(0, i - 1)),
+          onNext: () => setIndex((i) => Math.min(audioList.length - 1, i + 1)),
           onShuffle: () => {},
           onChangeLoopMode: () => {},
           onSelect: (flat: number) => setIndex(flat),
@@ -44,12 +44,17 @@ vi.mock('../music-widget', () => ({
     onItemSelect,
   }: {
     audioList: { id: string }[];
-    hookResult: { getControlsProps: () => { onPlay: () => void } };
+    hookResult: {
+      getControlsProps: () => { onPlay: () => void; onNext: () => void };
+    };
     onItemSelect: (id: string) => void;
   }) => (
     <div>
       <button type="button" onClick={hookResult.getControlsProps().onPlay}>
         play
+      </button>
+      <button type="button" onClick={hookResult.getControlsProps().onNext}>
+        next
       </button>
       {audioList.map((a) => (
         <button key={a.id} type="button" onClick={() => onItemSelect(a.id)}>
@@ -88,6 +93,8 @@ const setup = (activeAudioId: string) => {
 
 const play = () =>
   fireEvent.click(screen.getByRole('button', { name: 'play' }));
+const next = () =>
+  fireEvent.click(screen.getByRole('button', { name: 'next' }));
 const select = (id: string) =>
   fireEvent.click(screen.getByRole('button', { name: `select-${id}` }));
 
@@ -120,6 +127,16 @@ describe('AudioList URL mirror', () => {
     play();
 
     expect(onAudioChange).not.toHaveBeenCalled();
+  });
+
+  it('mirrors a next/prev move made before playback starts', () => {
+    // Deep link to b, then preview the next track while still paused — the URL
+    // must follow to c, not stay stale on b.
+    const onAudioChange = setup('b');
+
+    next();
+
+    expect(onAudioChange).toHaveBeenCalledWith('c');
   });
 
   it('corrects a stale deep-link id to the actual track on play', () => {

--- a/packages/ui/src/listen/minimalism/home/audio-list.test.tsx
+++ b/packages/ui/src/listen/minimalism/home/audio-list.test.tsx
@@ -1,0 +1,108 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+// A stateful fake of useSAudioPlayer: `onSelect(flatIndex)` moves the current
+// track, exactly like the real hook's output contract (audioItem is the track
+// at the selected flat position). This lets us test audio-list's URL mirror
+// deterministically, without the audio element or the build pipeline.
+vi.mock('core', () => ({
+  default: {
+    useSAudioPlayer: ({ audioList }: { audioList: { id: string }[] }) => {
+      const [index, setIndex] = useState(0);
+
+      return {
+        getAudioProps: () => ({}),
+        getSeekerProps: () => ({}),
+        getControlsProps: () => ({
+          onPlay: () => {},
+          onPrev: () => {},
+          onNext: () => {},
+          onShuffle: () => {},
+          onChangeLoopMode: () => {},
+          onSelect: (flat: number) => setIndex(flat),
+        }),
+        playerState: {
+          isPlay: false,
+          audioItem: audioList[index] ?? null,
+          currentIndex: index,
+        },
+      };
+    },
+  },
+}));
+
+// Mobile so the lazy PlayingList stays out of the tree; the always-rendered
+// MusicWidget exposes a select button per track instead.
+vi.mock('../../../universal/responsive', () => ({ useIsMobile: () => true }));
+vi.mock('../music-widget', () => ({
+  default: ({
+    audioList,
+    onItemSelect,
+  }: {
+    audioList: { id: string }[];
+    onItemSelect: (id: string) => void;
+  }) => (
+    <div>
+      {audioList.map((a) => (
+        <button key={a.id} type="button" onClick={() => onItemSelect(a.id)}>
+          play-{a.id}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+vi.mock('../music-widget/music-widget-skeleton', () => ({
+  MusicWidgetSkeleton: () => <div>skeleton</div>,
+}));
+
+import { AudioList } from './audio-list';
+
+const audios = [
+  { id: 'a', source: '', thumbnailUrl: '', name: 'A', artistName: 'x' },
+  { id: 'b', source: '', thumbnailUrl: '', name: 'B', artistName: 'x' },
+  { id: 'c', source: '', thumbnailUrl: '', name: 'C', artistName: 'x' },
+];
+
+const setup = (activeAudioId: string) => {
+  const onAudioChange = vi.fn();
+  render(
+    <AudioList
+      queryRs={{ isLoading: false }}
+      list={audios}
+      activeFeelingId=""
+      activeAudioId={activeAudioId}
+      onAudioChange={onAudioChange}
+    />,
+  );
+
+  return onAudioChange;
+};
+
+describe('AudioList URL mirror', () => {
+  it('does not write the URL on a clean load', () => {
+    const onAudioChange = setup('');
+
+    expect(onAudioChange).not.toHaveBeenCalled();
+  });
+
+  it('mirrors the selected track to the URL when a track is picked', () => {
+    const onAudioChange = setup('');
+
+    fireEvent.click(screen.getByRole('button', { name: 'play-b' }));
+
+    expect(onAudioChange).toHaveBeenCalledWith('b');
+  });
+
+  it('does not re-write the URL for a matching deep link', () => {
+    const onAudioChange = setup('b');
+
+    expect(onAudioChange).not.toHaveBeenCalled();
+  });
+
+  it('corrects a stale deep-link id to the actual track', () => {
+    const onAudioChange = setup('does-not-exist');
+
+    expect(onAudioChange).toHaveBeenCalledWith('a');
+  });
+});

--- a/packages/ui/src/listen/minimalism/home/audio-list.test.tsx
+++ b/packages/ui/src/listen/minimalism/home/audio-list.test.tsx
@@ -2,20 +2,22 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { useState } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
-// A stateful fake of useSAudioPlayer: `onSelect(flatIndex)` moves the current
-// track, exactly like the real hook's output contract (audioItem is the track
-// at the selected flat position). This lets us test audio-list's URL mirror
-// deterministically, without the audio element or the build pipeline.
+// A stateful fake of useSAudioPlayer: `onSelect(flat)` moves the current track,
+// `onPlay` toggles playback — matching the real hook's output contract
+// (audioItem is the track at the selected flat position). This lets us test
+// audio-list's one-way URL mirror deterministically, without the audio element
+// or the build pipeline.
 vi.mock('core', () => ({
   default: {
     useSAudioPlayer: ({ audioList }: { audioList: { id: string }[] }) => {
       const [index, setIndex] = useState(0);
+      const [playing, setPlaying] = useState(false);
 
       return {
         getAudioProps: () => ({}),
         getSeekerProps: () => ({}),
         getControlsProps: () => ({
-          onPlay: () => {},
+          onPlay: () => setPlaying((p) => !p),
           onPrev: () => {},
           onNext: () => {},
           onShuffle: () => {},
@@ -23,7 +25,7 @@ vi.mock('core', () => ({
           onSelect: (flat: number) => setIndex(flat),
         }),
         playerState: {
-          isPlay: false,
+          isPlay: playing,
           audioItem: audioList[index] ?? null,
           currentIndex: index,
         },
@@ -33,20 +35,25 @@ vi.mock('core', () => ({
 }));
 
 // Mobile so the lazy PlayingList stays out of the tree; the always-rendered
-// MusicWidget exposes a select button per track instead.
+// MusicWidget exposes a "play" control plus a select button per track.
 vi.mock('../../../universal/responsive', () => ({ useIsMobile: () => true }));
 vi.mock('../music-widget', () => ({
   default: ({
     audioList,
+    hookResult,
     onItemSelect,
   }: {
     audioList: { id: string }[];
+    hookResult: { getControlsProps: () => { onPlay: () => void } };
     onItemSelect: (id: string) => void;
   }) => (
     <div>
+      <button type="button" onClick={hookResult.getControlsProps().onPlay}>
+        play
+      </button>
       {audioList.map((a) => (
         <button key={a.id} type="button" onClick={() => onItemSelect(a.id)}>
-          play-{a.id}
+          select-{a.id}
         </button>
       ))}
     </div>
@@ -79,29 +86,46 @@ const setup = (activeAudioId: string) => {
   return onAudioChange;
 };
 
+const play = () =>
+  fireEvent.click(screen.getByRole('button', { name: 'play' }));
+const select = (id: string) =>
+  fireEvent.click(screen.getByRole('button', { name: `select-${id}` }));
+
 describe('AudioList URL mirror', () => {
-  it('does not write the URL on a clean load', () => {
+  it('keeps a clean URL on load until the user plays', () => {
     const onAudioChange = setup('');
 
     expect(onAudioChange).not.toHaveBeenCalled();
   });
 
-  it('mirrors the selected track to the URL when a track is picked', () => {
+  it('mirrors the default track once playback starts', () => {
     const onAudioChange = setup('');
 
-    fireEvent.click(screen.getByRole('button', { name: 'play-b' }));
+    play();
+
+    expect(onAudioChange).toHaveBeenCalledWith('a');
+  });
+
+  it('mirrors a picked track (selecting also plays)', () => {
+    const onAudioChange = setup('');
+
+    select('b');
 
     expect(onAudioChange).toHaveBeenCalledWith('b');
   });
 
-  it('does not re-write the URL for a matching deep link', () => {
+  it('does not re-write a matching deep link when it plays', () => {
     const onAudioChange = setup('b');
+
+    play();
 
     expect(onAudioChange).not.toHaveBeenCalled();
   });
 
-  it('corrects a stale deep-link id to the actual track', () => {
+  it('corrects a stale deep-link id to the actual track on play', () => {
     const onAudioChange = setup('does-not-exist');
+
+    play();
 
     expect(onAudioChange).toHaveBeenCalledWith('a');
   });

--- a/packages/ui/src/listen/minimalism/home/audio-list.tsx
+++ b/packages/ui/src/listen/minimalism/home/audio-list.tsx
@@ -2,7 +2,7 @@ import Card from '@mui/material/Card';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import hooks from 'core';
-import { lazy, Suspense, useEffect, useMemo, useState } from 'react';
+import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react';
 import { useIsMobile } from '../../../universal/responsive';
 import MusicWidget from '../music-widget';
 import { MusicWidgetSkeleton } from '../music-widget/music-widget-skeleton';
@@ -56,16 +56,16 @@ const Content = (props: AudioListProps) => {
       );
   }, [originalList, activeFeelingId]);
 
-  // The URL is the source of truth for which track is selected: derive the
-  // player's index from `activeAudioId`. A missing/stale id falls back to the
-  // first track. (This also replaces the old "reset to 0 when the feeling
-  // filter changes" effect — a filter change that drops the active track
-  // recomputes to 0 here for free.)
-  const index = useMemo(() => {
+  // Which track is selected, as a position in `list`. The player is driven by
+  // this state directly (not by the URL), so selecting/advancing behaves
+  // exactly as before; the URL is mirrored alongside it below. Seeded from the
+  // URL so a deep link (`?audio=<id>`) opens on that track; a missing/stale id
+  // falls back to the first.
+  const [index, setIndex] = useState(() => {
     const found = list.findIndex((a) => a.id === activeAudioId);
 
     return found < 0 ? 0 : found;
-  }, [list, activeAudioId]);
+  });
 
   const isMobile = useIsMobile();
 
@@ -77,17 +77,25 @@ const Content = (props: AudioListProps) => {
   const { isPlay, currentIndex } = playerState;
   const { onPlay } = getControlsProps();
 
-  // Once the user has engaged (started playback, or picked a track), mirror
-  // every player-driven track change — next/prev, shuffle, auto-advance — back
-  // to the URL. A freshly loaded page stays engaged=false so its URL is clean.
+  // `lastSyncedId` is the track id the player and the URL currently agree on.
+  // Comparing against this ref — not the `activeAudioId` prop, which lags a
+  // render — is what keeps the two directions from fighting: a URL write we
+  // made ourselves is recognised and never fed back into the player, so a
+  // shuffle round-trip (where the player's flat index and the hook's permuted
+  // index differ) can't oscillate. The player owns its position; the URL follows.
   const [engaged, setEngaged] = useState(false);
+  const lastSyncedId = useRef(activeAudioId);
 
+  // Engage on first playback so a page the user only loaded (never played)
+  // keeps a clean URL — nothing is mirrored until something actually plays.
   useEffect(() => {
     if (isPlay) {
       setEngaged(true);
     }
   }, [isPlay]);
 
+  // player -> URL: reflect a track change the player drove itself
+  // (next/prev/shuffle/auto-advance) once the user has engaged.
   useEffect(() => {
     if (!engaged) {
       return;
@@ -95,13 +103,44 @@ const Content = (props: AudioListProps) => {
 
     const current = list[currentIndex];
 
-    if (current && current.id !== activeAudioId) {
+    if (current && current.id !== lastSyncedId.current) {
+      lastSyncedId.current = current.id;
       onAudioChange(current.id);
     }
-  }, [engaged, currentIndex, list, activeAudioId, onAudioChange]);
+  }, [engaged, currentIndex, list, onAudioChange]);
+
+  // URL -> player: an external change (browser back/forward, a shared link)
+  // moves the player. Writes we made ourselves match `lastSyncedId` and are
+  // skipped, so there's no feedback loop.
+  useEffect(() => {
+    if (activeAudioId === lastSyncedId.current) {
+      return;
+    }
+
+    lastSyncedId.current = activeAudioId;
+
+    const found = list.findIndex((a) => a.id === activeAudioId);
+
+    if (found >= 0) {
+      setIndex(found);
+    }
+  }, [activeAudioId, list]);
+
+  // Changing the feeling filter resets to the first track of the new list,
+  // matching the pre-URL behaviour.
+  useEffect(() => {
+    if (activeFeelingId) {
+      setIndex(0);
+    }
+  }, [activeFeelingId]);
 
   const onItemSelect = (id: string) => {
     setEngaged(true);
+
+    const found = list.findIndex((a) => a.id === id);
+
+    setIndex(found < 0 ? 0 : found);
+    lastSyncedId.current = id;
     onAudioChange(id);
 
     if (!isPlay) {

--- a/packages/ui/src/listen/minimalism/home/audio-list.tsx
+++ b/packages/ui/src/listen/minimalism/home/audio-list.tsx
@@ -20,6 +20,10 @@ interface AudioListProps {
   queryRs: { isLoading: boolean };
   list: unknown[];
   activeFeelingId: string;
+  // The playing track as an id, mirrored to the URL. `activeAudioId` seeds the
+  // player's index; `onAudioChange` reports the current track's id back up.
+  activeAudioId: string;
+  onAudioChange: (id: string) => void;
 }
 
 const toAudioItem = (item: any) => {
@@ -36,7 +40,12 @@ const toAudioItem = (item: any) => {
 const PlayingList = lazy(() => import('./playing-list'));
 
 const Content = (props: AudioListProps) => {
-  const { list: originalList, activeFeelingId } = props;
+  const {
+    list: originalList,
+    activeFeelingId,
+    activeAudioId,
+    onAudioChange,
+  } = props;
   // TODO
   // memorize on parent
   const list = useMemo(() => {
@@ -47,7 +56,17 @@ const Content = (props: AudioListProps) => {
       );
   }, [originalList, activeFeelingId]);
 
-  const [index, setIndex] = useState(0);
+  // The URL is the source of truth for which track is selected: derive the
+  // player's index from `activeAudioId`. A missing/stale id falls back to the
+  // first track. (This also replaces the old "reset to 0 when the feeling
+  // filter changes" effect — a filter change that drops the active track
+  // recomputes to 0 here for free.)
+  const index = useMemo(() => {
+    const found = list.findIndex((a) => a.id === activeAudioId);
+
+    return found < 0 ? 0 : found;
+  }, [list, activeAudioId]);
+
   const isMobile = useIsMobile();
 
   const hookResult = useSAudioPlayer({
@@ -58,25 +77,37 @@ const Content = (props: AudioListProps) => {
   const { isPlay, currentIndex } = playerState;
   const { onPlay } = getControlsProps();
 
-  const onItemSelect = (id: string) => {
-    const index = list.findIndex((a) => a.id === id);
+  // Once the user has engaged (started playback, or picked a track), mirror
+  // every player-driven track change — next/prev, shuffle, auto-advance — back
+  // to the URL. A freshly loaded page stays engaged=false so its URL is clean.
+  const [engaged, setEngaged] = useState(false);
 
-    if (index < 0) {
-      setIndex(0);
-    } else {
-      setIndex(index);
+  useEffect(() => {
+    if (isPlay) {
+      setEngaged(true);
     }
+  }, [isPlay]);
+
+  useEffect(() => {
+    if (!engaged) {
+      return;
+    }
+
+    const current = list[currentIndex];
+
+    if (current && current.id !== activeAudioId) {
+      onAudioChange(current.id);
+    }
+  }, [engaged, currentIndex, list, activeAudioId, onAudioChange]);
+
+  const onItemSelect = (id: string) => {
+    setEngaged(true);
+    onAudioChange(id);
 
     if (!isPlay) {
       onPlay();
     }
   };
-
-  useEffect(() => {
-    if (activeFeelingId) {
-      setIndex(0);
-    }
-  }, [activeFeelingId]);
 
   const hasNoItem = !list.length;
   const currentAudio =

--- a/packages/ui/src/listen/minimalism/home/audio-list.tsx
+++ b/packages/ui/src/listen/minimalism/home/audio-list.tsx
@@ -2,7 +2,7 @@ import Card from '@mui/material/Card';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import hooks from 'core';
-import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react';
+import { lazy, Suspense, useEffect, useMemo, useRef } from 'react';
 import { useIsMobile } from '../../../universal/responsive';
 import MusicWidget from '../music-widget';
 import { MusicWidgetSkeleton } from '../music-widget/music-widget-skeleton';
@@ -58,36 +58,26 @@ const Content = (props: AudioListProps) => {
       );
   }, [originalList, activeFeelingId]);
 
-  // Which track is selected, as a position in `list`. The player owns this from
-  // here on; the URL is seeded into it once (below) and is otherwise a one-way
-  // output, so nothing the URL does can feed back and fight the player.
-  const [index, setIndex] = useState(0);
-
   const isMobile = useIsMobile();
 
-  const hookResult = useSAudioPlayer({
-    audioList: list,
-    index,
-  });
+  const hookResult = useSAudioPlayer({ audioList: list });
   const { getControlsProps, playerState } = hookResult;
-  const { isPlay, currentIndex } = playerState;
-  const { onPlay } = getControlsProps();
+  const { isPlay, audioItem } = playerState;
+  const { onPlay, onSelect } = getControlsProps();
+  // The player's actual current track. Keying the mirror on this (not a numeric
+  // index) is what makes a feeling filter that swaps the track at a given
+  // position still update the URL.
+  const currentTrackId = audioItem?.id;
 
-  // Seed the selection from the URL exactly once, when the list is first
-  // available (deep link / refresh). `seededRef` also makes this a no-op on
-  // every later `activeAudioId` change — including the ones our own mirror
+  // Seed the player's selection from the URL exactly once, when the list is
+  // first available (deep link / refresh). `seededRef` also makes this a no-op
+  // on every later `activeAudioId` change — including the ones our own mirror
   // causes — so the URL never re-drives the player. That one-way flow is what
-  // makes the whole thing race-free. It also records the track we started on so
-  // the mirror below knows not to re-write it.
+  // makes the whole thing race-free.
   const seededRef = useRef(false);
   const lastSyncedId = useRef(activeAudioId);
   const seededTrackId = useRef<string | null>(null);
   const armed = useRef(false);
-  const listRef = useRef(list);
-
-  useEffect(() => {
-    listRef.current = list;
-  }, [list]);
 
   useEffect(() => {
     if (seededRef.current || !list.length) {
@@ -99,53 +89,59 @@ const Content = (props: AudioListProps) => {
     const found = list.findIndex((a) => a.id === activeAudioId);
 
     if (found >= 0) {
-      setIndex(found);
+      onSelect(found);
     }
 
+    // Record the track we're starting on so the mirror knows not to re-write a
+    // URL that already matches. Exception: a *stale* `?audio=` id (present but
+    // not in the list) is left as `lastSyncedId` so the mirror corrects the URL
+    // to the fallback track once the player settles.
     const startId = list[found >= 0 ? found : 0].id;
     seededTrackId.current = startId;
-    lastSyncedId.current = startId;
-  }, [list, activeAudioId]);
+    lastSyncedId.current = activeAudioId && found < 0 ? activeAudioId : startId;
+  }, [list, activeAudioId, onSelect]);
 
   // player -> URL (the only direction that writes): replace `?audio=` with the
-  // current track whenever the player moves. It reads `list` through a ref and
-  // depends only on `currentIndex`, so it fires on real track changes, not on
-  // unrelated churn. It stays disarmed until the player has actually settled on
-  // the seeded track — that skips the mount transient (currentIndex lags the
-  // seed by a render) and, unlike a "skip first run" flag, survives StrictMode's
-  // double effect invocation, so a freshly loaded page keeps a clean URL.
+  // current track whenever the player moves. It stays disarmed until the player
+  // has actually settled on the seeded track — that skips the mount transient
+  // and, unlike a "skip first run" flag, survives StrictMode's double effect
+  // invocation, so a freshly loaded page keeps a clean URL.
   useEffect(() => {
-    const current = listRef.current[currentIndex];
-
-    if (!current) {
+    if (!currentTrackId) {
       return;
     }
 
+    // Stay disarmed until the player settles on the seeded track (skips the
+    // mount transient; StrictMode-safe). Once it does, arm and fall through —
+    // that corrects a *stale* `?audio=` (a URL id not in the list, so the
+    // player fell back to another track) on the same pass.
     if (!armed.current) {
-      if (current.id === seededTrackId.current) {
-        armed.current = true;
+      if (currentTrackId !== seededTrackId.current) {
+        return;
       }
 
-      return;
+      armed.current = true;
     }
 
-    if (current.id !== lastSyncedId.current) {
-      lastSyncedId.current = current.id;
-      onAudioChange(current.id);
+    if (currentTrackId !== lastSyncedId.current) {
+      lastSyncedId.current = currentTrackId;
+      onAudioChange(currentTrackId);
     }
-  }, [currentIndex, onAudioChange]);
+  }, [currentTrackId, onAudioChange]);
 
   // Filtering rebuilds the list; reset to its first track (pre-URL behaviour).
   useEffect(() => {
     if (activeFeelingId) {
-      setIndex(0);
+      onSelect(0);
     }
-  }, [activeFeelingId]);
+  }, [activeFeelingId, onSelect]);
 
   const onItemSelect = (id: string) => {
     const found = list.findIndex((a) => a.id === id);
 
-    setIndex(found < 0 ? 0 : found);
+    if (found >= 0) {
+      onSelect(found);
+    }
 
     if (!isPlay) {
       onPlay();
@@ -153,8 +149,7 @@ const Content = (props: AudioListProps) => {
   };
 
   const hasNoItem = !list.length;
-  const currentAudio =
-    list[typeof currentIndex === 'number' ? currentIndex : 0];
+  const currentAudio = audioItem;
   const showPlayingList = !isMobile && !hasNoItem && !!currentAudio;
 
   if (hasNoItem) {
@@ -177,7 +172,7 @@ const Content = (props: AudioListProps) => {
               <PlayingList
                 audioList={list}
                 onItemSelect={onItemSelect}
-                currentId={currentAudio.id}
+                currentId={currentAudio?.id ?? ''}
               />
             </Suspense>
           </Card>

--- a/packages/ui/src/listen/minimalism/home/audio-list.tsx
+++ b/packages/ui/src/listen/minimalism/home/audio-list.tsx
@@ -2,7 +2,7 @@ import Card from '@mui/material/Card';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import hooks from 'core';
-import { lazy, Suspense, useEffect, useMemo, useRef } from 'react';
+import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react';
 import { useIsMobile } from '../../../universal/responsive';
 import MusicWidget from '../music-widget';
 import { MusicWidgetSkeleton } from '../music-widget/music-widget-skeleton';
@@ -21,10 +21,11 @@ interface AudioListProps {
   list: unknown[];
   activeFeelingId: string;
   // The playing track as an id, mirrored to the URL. `activeAudioId` seeds the
-  // player's index; `onAudioChange` reports the current track's id back up
-  // (`replace` = false pushes a history entry, true replaces the current one).
+  // player's initial selection; `onAudioChange` writes the current track's id
+  // back to the URL as the player moves (one-way — the URL never re-drives the
+  // player).
   activeAudioId: string;
-  onAudioChange: (id: string, replace: boolean) => void;
+  onAudioChange: (id: string) => void;
 }
 
 const toAudioItem = (item: any) => {
@@ -57,18 +58,10 @@ const Content = (props: AudioListProps) => {
       );
   }, [originalList, activeFeelingId]);
 
-  // The URL is the source of truth for the selected track: derive the player's
-  // flat index from `activeAudioId` (a missing/stale id falls back to the first
-  // track). The player now addresses tracks by flat position, so a mirrored id
-  // fed back through here resolves to the same track — the round-trip is
-  // idempotent, which is what lets both directions share one piece of state
-  // without any anti-loop bookkeeping. Filtering by feeling recomputes here too:
-  // the active track is kept if still present, otherwise it falls back to first.
-  const index = useMemo(() => {
-    const found = list.findIndex((a) => a.id === activeAudioId);
-
-    return found < 0 ? 0 : found;
-  }, [list, activeAudioId]);
+  // Which track is selected, as a position in `list`. The player owns this from
+  // here on; the URL is seeded into it once (below) and is otherwise a one-way
+  // output, so nothing the URL does can feed back and fight the player.
+  const [index, setIndex] = useState(0);
 
   const isMobile = useIsMobile();
 
@@ -80,47 +73,79 @@ const Content = (props: AudioListProps) => {
   const { isPlay, currentIndex } = playerState;
   const { onPlay } = getControlsProps();
 
-  // `lastSyncedId` is the track the URL and player currently agree on. Both the
-  // URL->player and player->URL directions update it, so neither treats the
-  // other's change as new work to undo.
+  // Seed the selection from the URL exactly once, when the list is first
+  // available (deep link / refresh). `seededRef` also makes this a no-op on
+  // every later `activeAudioId` change — including the ones our own mirror
+  // causes — so the URL never re-drives the player. That one-way flow is what
+  // makes the whole thing race-free. It also records the track we started on so
+  // the mirror below knows not to re-write it.
+  const seededRef = useRef(false);
   const lastSyncedId = useRef(activeAudioId);
-  // Whether we're past the initial mount settle — a freshly loaded page mustn't
-  // write the default first track into the URL before the user does anything.
-  const hasSettled = useRef(false);
+  const seededTrackId = useRef<string | null>(null);
+  const armed = useRef(false);
+  const listRef = useRef(list);
 
-  // An external URL change (browser back/forward, a shared link) is the source
-  // of truth: record it so the mirror below doesn't mistake it for a
-  // player-driven change and revert it.
   useEffect(() => {
-    lastSyncedId.current = activeAudioId;
-  }, [activeAudioId]);
+    listRef.current = list;
+  }, [list]);
 
-  // player -> URL: mirror a track change the player made itself (next/prev,
-  // shuffle, auto-advance). Depending only on `currentIndex` is deliberate — it
-  // means this never runs on the same commit an external URL change arrives
-  // (when `currentIndex` still lags a render behind), which is what stops
-  // back/forward navigation from oscillating. Uses replace so a run of
-  // auto-advances doesn't bury the back button.
   useEffect(() => {
-    if (!hasSettled.current) {
-      hasSettled.current = true;
+    if (seededRef.current || !list.length) {
+      return;
+    }
+
+    seededRef.current = true;
+
+    const found = list.findIndex((a) => a.id === activeAudioId);
+
+    if (found >= 0) {
+      setIndex(found);
+    }
+
+    const startId = list[found >= 0 ? found : 0].id;
+    seededTrackId.current = startId;
+    lastSyncedId.current = startId;
+  }, [list, activeAudioId]);
+
+  // player -> URL (the only direction that writes): replace `?audio=` with the
+  // current track whenever the player moves. It reads `list` through a ref and
+  // depends only on `currentIndex`, so it fires on real track changes, not on
+  // unrelated churn. It stays disarmed until the player has actually settled on
+  // the seeded track — that skips the mount transient (currentIndex lags the
+  // seed by a render) and, unlike a "skip first run" flag, survives StrictMode's
+  // double effect invocation, so a freshly loaded page keeps a clean URL.
+  useEffect(() => {
+    const current = listRef.current[currentIndex];
+
+    if (!current) {
+      return;
+    }
+
+    if (!armed.current) {
+      if (current.id === seededTrackId.current) {
+        armed.current = true;
+      }
 
       return;
     }
 
-    const current = list[currentIndex];
-
-    if (current && current.id !== lastSyncedId.current) {
+    if (current.id !== lastSyncedId.current) {
       lastSyncedId.current = current.id;
-      onAudioChange(current.id, true);
+      onAudioChange(current.id);
     }
-  }, [currentIndex, list, onAudioChange]);
+  }, [currentIndex, onAudioChange]);
+
+  // Filtering rebuilds the list; reset to its first track (pre-URL behaviour).
+  useEffect(() => {
+    if (activeFeelingId) {
+      setIndex(0);
+    }
+  }, [activeFeelingId]);
 
   const onItemSelect = (id: string) => {
-    // An explicit pick is a real navigation, so push a history entry (the back
-    // button returns to the previous track); player-driven changes replace.
-    lastSyncedId.current = id;
-    onAudioChange(id, false);
+    const found = list.findIndex((a) => a.id === id);
+
+    setIndex(found < 0 ? 0 : found);
 
     if (!isPlay) {
       onPlay();

--- a/packages/ui/src/listen/minimalism/home/audio-list.tsx
+++ b/packages/ui/src/listen/minimalism/home/audio-list.tsx
@@ -129,11 +129,19 @@ const Content = (props: AudioListProps) => {
     }
   }, [currentTrackId, onAudioChange]);
 
-  // Filtering rebuilds the list; reset to its first track (pre-URL behaviour).
+  // Changing the feeling filter (setting OR clearing it) rebuilds the list;
+  // reset to its first track. A ref tracks the previous value so this fires only
+  // on an actual change, never on the initial mount (which would clobber the
+  // deep-link seed above).
+  const prevFeeling = useRef(activeFeelingId);
+
   useEffect(() => {
-    if (activeFeelingId) {
-      onSelect(0);
+    if (prevFeeling.current === activeFeelingId) {
+      return;
     }
+
+    prevFeeling.current = activeFeelingId;
+    onSelect(0);
   }, [activeFeelingId, onSelect]);
 
   const onItemSelect = (id: string) => {

--- a/packages/ui/src/listen/minimalism/home/audio-list.tsx
+++ b/packages/ui/src/listen/minimalism/home/audio-list.tsx
@@ -2,7 +2,7 @@ import Card from '@mui/material/Card';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import hooks from 'core';
-import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react';
+import { lazy, Suspense, useEffect, useMemo, useState } from 'react';
 import { useIsMobile } from '../../../universal/responsive';
 import MusicWidget from '../music-widget';
 import { MusicWidgetSkeleton } from '../music-widget/music-widget-skeleton';
@@ -56,16 +56,18 @@ const Content = (props: AudioListProps) => {
       );
   }, [originalList, activeFeelingId]);
 
-  // Which track is selected, as a position in `list`. The player is driven by
-  // this state directly (not by the URL), so selecting/advancing behaves
-  // exactly as before; the URL is mirrored alongside it below. Seeded from the
-  // URL so a deep link (`?audio=<id>`) opens on that track; a missing/stale id
-  // falls back to the first.
-  const [index, setIndex] = useState(() => {
+  // The URL is the source of truth for the selected track: derive the player's
+  // flat index from `activeAudioId` (a missing/stale id falls back to the first
+  // track). The player now addresses tracks by flat position, so a mirrored id
+  // fed back through here resolves to the same track — the round-trip is
+  // idempotent, which is what lets both directions share one piece of state
+  // without any anti-loop bookkeeping. Filtering by feeling recomputes here too:
+  // the active track is kept if still present, otherwise it falls back to first.
+  const index = useMemo(() => {
     const found = list.findIndex((a) => a.id === activeAudioId);
 
     return found < 0 ? 0 : found;
-  });
+  }, [list, activeAudioId]);
 
   const isMobile = useIsMobile();
 
@@ -77,25 +79,18 @@ const Content = (props: AudioListProps) => {
   const { isPlay, currentIndex } = playerState;
   const { onPlay } = getControlsProps();
 
-  // `lastSyncedId` is the track id the player and the URL currently agree on.
-  // Comparing against this ref — not the `activeAudioId` prop, which lags a
-  // render — is what keeps the two directions from fighting: a URL write we
-  // made ourselves is recognised and never fed back into the player, so a
-  // shuffle round-trip (where the player's flat index and the hook's permuted
-  // index differ) can't oscillate. The player owns its position; the URL follows.
+  // Mirror the playing track to the URL, but only once the user has engaged
+  // (started playback) — a freshly loaded page keeps a clean URL. This covers
+  // every player-driven change (next/prev, shuffle, auto-advance) as well as an
+  // explicit selection, since all of them move `currentIndex`.
   const [engaged, setEngaged] = useState(false);
-  const lastSyncedId = useRef(activeAudioId);
 
-  // Engage on first playback so a page the user only loaded (never played)
-  // keeps a clean URL — nothing is mirrored until something actually plays.
   useEffect(() => {
     if (isPlay) {
       setEngaged(true);
     }
   }, [isPlay]);
 
-  // player -> URL: reflect a track change the player drove itself
-  // (next/prev/shuffle/auto-advance) once the user has engaged.
   useEffect(() => {
     if (!engaged) {
       return;
@@ -103,44 +98,13 @@ const Content = (props: AudioListProps) => {
 
     const current = list[currentIndex];
 
-    if (current && current.id !== lastSyncedId.current) {
-      lastSyncedId.current = current.id;
+    if (current && current.id !== activeAudioId) {
       onAudioChange(current.id);
     }
-  }, [engaged, currentIndex, list, onAudioChange]);
-
-  // URL -> player: an external change (browser back/forward, a shared link)
-  // moves the player. Writes we made ourselves match `lastSyncedId` and are
-  // skipped, so there's no feedback loop.
-  useEffect(() => {
-    if (activeAudioId === lastSyncedId.current) {
-      return;
-    }
-
-    lastSyncedId.current = activeAudioId;
-
-    const found = list.findIndex((a) => a.id === activeAudioId);
-
-    if (found >= 0) {
-      setIndex(found);
-    }
-  }, [activeAudioId, list]);
-
-  // Changing the feeling filter resets to the first track of the new list,
-  // matching the pre-URL behaviour.
-  useEffect(() => {
-    if (activeFeelingId) {
-      setIndex(0);
-    }
-  }, [activeFeelingId]);
+  }, [engaged, currentIndex, list, activeAudioId, onAudioChange]);
 
   const onItemSelect = (id: string) => {
     setEngaged(true);
-
-    const found = list.findIndex((a) => a.id === id);
-
-    setIndex(found < 0 ? 0 : found);
-    lastSyncedId.current = id;
     onAudioChange(id);
 
     if (!isPlay) {

--- a/packages/ui/src/listen/minimalism/home/audio-list.tsx
+++ b/packages/ui/src/listen/minimalism/home/audio-list.tsx
@@ -2,7 +2,7 @@ import Card from '@mui/material/Card';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import hooks from 'core';
-import { lazy, Suspense, useEffect, useMemo, useState } from 'react';
+import { lazy, Suspense, useEffect, useMemo, useRef } from 'react';
 import { useIsMobile } from '../../../universal/responsive';
 import MusicWidget from '../music-widget';
 import { MusicWidgetSkeleton } from '../music-widget/music-widget-skeleton';
@@ -21,9 +21,10 @@ interface AudioListProps {
   list: unknown[];
   activeFeelingId: string;
   // The playing track as an id, mirrored to the URL. `activeAudioId` seeds the
-  // player's index; `onAudioChange` reports the current track's id back up.
+  // player's index; `onAudioChange` reports the current track's id back up
+  // (`replace` = false pushes a history entry, true replaces the current one).
   activeAudioId: string;
-  onAudioChange: (id: string) => void;
+  onAudioChange: (id: string, replace: boolean) => void;
 }
 
 const toAudioItem = (item: any) => {
@@ -79,33 +80,47 @@ const Content = (props: AudioListProps) => {
   const { isPlay, currentIndex } = playerState;
   const { onPlay } = getControlsProps();
 
-  // Mirror the playing track to the URL, but only once the user has engaged
-  // (started playback) — a freshly loaded page keeps a clean URL. This covers
-  // every player-driven change (next/prev, shuffle, auto-advance) as well as an
-  // explicit selection, since all of them move `currentIndex`.
-  const [engaged, setEngaged] = useState(false);
+  // `lastSyncedId` is the track the URL and player currently agree on. Both the
+  // URL->player and player->URL directions update it, so neither treats the
+  // other's change as new work to undo.
+  const lastSyncedId = useRef(activeAudioId);
+  // Whether we're past the initial mount settle — a freshly loaded page mustn't
+  // write the default first track into the URL before the user does anything.
+  const hasSettled = useRef(false);
 
+  // An external URL change (browser back/forward, a shared link) is the source
+  // of truth: record it so the mirror below doesn't mistake it for a
+  // player-driven change and revert it.
   useEffect(() => {
-    if (isPlay) {
-      setEngaged(true);
-    }
-  }, [isPlay]);
+    lastSyncedId.current = activeAudioId;
+  }, [activeAudioId]);
 
+  // player -> URL: mirror a track change the player made itself (next/prev,
+  // shuffle, auto-advance). Depending only on `currentIndex` is deliberate — it
+  // means this never runs on the same commit an external URL change arrives
+  // (when `currentIndex` still lags a render behind), which is what stops
+  // back/forward navigation from oscillating. Uses replace so a run of
+  // auto-advances doesn't bury the back button.
   useEffect(() => {
-    if (!engaged) {
+    if (!hasSettled.current) {
+      hasSettled.current = true;
+
       return;
     }
 
     const current = list[currentIndex];
 
-    if (current && current.id !== activeAudioId) {
-      onAudioChange(current.id);
+    if (current && current.id !== lastSyncedId.current) {
+      lastSyncedId.current = current.id;
+      onAudioChange(current.id, true);
     }
-  }, [engaged, currentIndex, list, activeAudioId, onAudioChange]);
+  }, [currentIndex, list, onAudioChange]);
 
   const onItemSelect = (id: string) => {
-    setEngaged(true);
-    onAudioChange(id);
+    // An explicit pick is a real navigation, so push a history entry (the back
+    // button returns to the previous track); player-driven changes replace.
+    lastSyncedId.current = id;
+    onAudioChange(id, false);
 
     if (!isPlay) {
       onPlay();

--- a/packages/ui/src/listen/minimalism/home/audio-list.tsx
+++ b/packages/ui/src/listen/minimalism/home/audio-list.tsx
@@ -73,11 +73,11 @@ const Content = (props: AudioListProps) => {
   // first available (deep link / refresh). `seededRef` also makes this a no-op
   // on every later `activeAudioId` change — including the ones our own mirror
   // causes — so the URL never re-drives the player. That one-way flow is what
-  // makes the whole thing race-free.
+  // makes the whole thing race-free. `lastSyncedId` starts at whatever the URL
+  // started as, so a matching deep link isn't rewritten.
   const seededRef = useRef(false);
   const lastSyncedId = useRef(activeAudioId);
-  const seededTrackId = useRef<string | null>(null);
-  const armed = useRef(false);
+  const engaged = useRef(false);
 
   useEffect(() => {
     if (seededRef.current || !list.length) {
@@ -85,49 +85,37 @@ const Content = (props: AudioListProps) => {
     }
 
     seededRef.current = true;
+    lastSyncedId.current = activeAudioId;
 
     const found = list.findIndex((a) => a.id === activeAudioId);
 
     if (found >= 0) {
       onSelect(found);
     }
-
-    // Record the track we're starting on so the mirror knows not to re-write a
-    // URL that already matches. Exception: a *stale* `?audio=` id (present but
-    // not in the list) is left as `lastSyncedId` so the mirror corrects the URL
-    // to the fallback track once the player settles.
-    const startId = list[found >= 0 ? found : 0].id;
-    seededTrackId.current = startId;
-    lastSyncedId.current = activeAudioId && found < 0 ? activeAudioId : startId;
   }, [list, activeAudioId, onSelect]);
 
-  // player -> URL (the only direction that writes): replace `?audio=` with the
-  // current track whenever the player moves. It stays disarmed until the player
-  // has actually settled on the seeded track — that skips the mount transient
-  // and, unlike a "skip first run" flag, survives StrictMode's double effect
-  // invocation, so a freshly loaded page keeps a clean URL.
+  // player -> URL (the only direction that writes): mirror the current track to
+  // `?audio=` once the user has engaged — i.e. playback has started (pressing
+  // play, or selecting a track, which also plays). Until then a freshly loaded
+  // page keeps a clean URL. Gating on "has ever played" also skips the mount
+  // transient and survives StrictMode's double invocation, since neither starts
+  // playback. After engaging, every track change (next/prev/shuffle/auto) and
+  // the initial play all publish the current track; a stale/absent `?audio=`
+  // self-corrects to whatever actually plays.
   useEffect(() => {
-    if (!currentTrackId) {
-      return;
+    if (isPlay) {
+      engaged.current = true;
     }
 
-    // Stay disarmed until the player settles on the seeded track (skips the
-    // mount transient; StrictMode-safe). Once it does, arm and fall through —
-    // that corrects a *stale* `?audio=` (a URL id not in the list, so the
-    // player fell back to another track) on the same pass.
-    if (!armed.current) {
-      if (currentTrackId !== seededTrackId.current) {
-        return;
-      }
-
-      armed.current = true;
+    if (!engaged.current || !currentTrackId) {
+      return;
     }
 
     if (currentTrackId !== lastSyncedId.current) {
       lastSyncedId.current = currentTrackId;
       onAudioChange(currentTrackId);
     }
-  }, [currentTrackId, onAudioChange]);
+  }, [currentTrackId, isPlay, onAudioChange]);
 
   // Changing the feeling filter (setting OR clearing it) rebuilds the list;
   // reset to its first track. A ref tracks the previous value so this fires only

--- a/packages/ui/src/listen/minimalism/home/audio-list.tsx
+++ b/packages/ui/src/listen/minimalism/home/audio-list.tsx
@@ -77,6 +77,8 @@ const Content = (props: AudioListProps) => {
   // started as, so a matching deep link isn't rewritten.
   const seededRef = useRef(false);
   const lastSyncedId = useRef(activeAudioId);
+  const seededTrackId = useRef<string | null>(null);
+  const armed = useRef(false);
   const engaged = useRef(false);
 
   useEffect(() => {
@@ -89,25 +91,40 @@ const Content = (props: AudioListProps) => {
 
     const found = list.findIndex((a) => a.id === activeAudioId);
 
+    seededTrackId.current = list[found >= 0 ? found : 0].id;
+
     if (found >= 0) {
       onSelect(found);
     }
   }, [list, activeAudioId, onSelect]);
 
   // player -> URL (the only direction that writes): mirror the current track to
-  // `?audio=` once the user has engaged — i.e. playback has started (pressing
-  // play, or selecting a track, which also plays). Until then a freshly loaded
-  // page keeps a clean URL. Gating on "has ever played" also skips the mount
-  // transient and survives StrictMode's double invocation, since neither starts
-  // playback. After engaging, every track change (next/prev/shuffle/auto) and
-  // the initial play all publish the current track; a stale/absent `?audio=`
-  // self-corrects to whatever actually plays.
+  // `?audio=`.
   useEffect(() => {
-    if (isPlay) {
+    if (!currentTrackId) {
+      return;
+    }
+
+    // Skip the mount transient: don't mirror until the player has actually
+    // settled on the track we seeded. This is ref state, so it's idempotent
+    // across StrictMode's double effect invocation — a freshly loaded page
+    // stays clean.
+    if (!armed.current) {
+      if (currentTrackId !== seededTrackId.current) {
+        return;
+      }
+
+      armed.current = true;
+    }
+
+    // Engage once the user acts — playback started, or they moved off the track
+    // the page loaded on (next/prev/select/shuffle). Latched, so returning to
+    // the first track still mirrors, and next/prev while paused count too.
+    if (isPlay || currentTrackId !== seededTrackId.current) {
       engaged.current = true;
     }
 
-    if (!engaged.current || !currentTrackId) {
+    if (!engaged.current) {
       return;
     }
 

--- a/packages/ui/src/listen/minimalism/home/audio-list.tsx
+++ b/packages/ui/src/listen/minimalism/home/audio-list.tsx
@@ -134,19 +134,13 @@ const Content = (props: AudioListProps) => {
     }
   }, [currentTrackId, isPlay, onAudioChange]);
 
-  // Changing the feeling filter (setting OR clearing it) rebuilds the list;
-  // reset to its first track. A ref tracks the previous value so this fires only
-  // on an actual change, never on the initial mount (which would clobber the
-  // deep-link seed above).
-  const prevFeeling = useRef(activeFeelingId);
-
+  // Applying a feeling filter narrows the list, so jump to its first track
+  // (pre-URL behaviour). Only on *set*, not on clear — clearing shouldn't
+  // interrupt the song that's already playing.
   useEffect(() => {
-    if (prevFeeling.current === activeFeelingId) {
-      return;
+    if (activeFeelingId) {
+      onSelect(0);
     }
-
-    prevFeeling.current = activeFeelingId;
-    onSelect(0);
   }, [activeFeelingId, onSelect]);
 
   const onItemSelect = (id: string) => {

--- a/packages/ui/src/listen/minimalism/listening-screen/index.stories.tsx
+++ b/packages/ui/src/listen/minimalism/listening-screen/index.stories.tsx
@@ -38,6 +38,8 @@ const meta: Meta<typeof ListeningScreen> = {
     onCreate: () => {},
     audios,
     isLoading: false,
+    activeAudioId: '',
+    onAudioChange: () => {},
   },
 };
 

--- a/packages/ui/src/listen/minimalism/listening-screen/index.test.tsx
+++ b/packages/ui/src/listen/minimalism/listening-screen/index.test.tsx
@@ -37,6 +37,8 @@ const baseProps = {
   onCreate: vi.fn(),
   audios: [],
   isLoading: false,
+  activeAudioId: '',
+  onAudioChange: vi.fn(),
 };
 
 describe('ListeningScreen', () => {

--- a/packages/ui/src/listen/minimalism/listening-screen/index.tsx
+++ b/packages/ui/src/listen/minimalism/listening-screen/index.tsx
@@ -34,6 +34,11 @@ interface CommonProps {
   // Raw audios for the player (AudioList maps them to player items).
   audios: unknown[];
   isLoading: boolean;
+  // The playing track, mirrored to the URL. `activeAudioId` is the audio id
+  // from the route (empty when nothing is selected yet); `onAudioChange` pushes
+  // the current track's id back to the route as playback moves.
+  activeAudioId: string;
+  onAudioChange: (id: string) => void;
 }
 
 interface AllModeProps extends CommonProps {
@@ -66,6 +71,8 @@ const ListeningScreen = (props: ListeningScreenProps) => {
     onCreate,
     audios,
     isLoading,
+    activeAudioId,
+    onAudioChange,
   } = props;
 
   const [settingOpen, setSettingOpen] = useState(false);
@@ -136,6 +143,8 @@ const ListeningScreen = (props: ListeningScreenProps) => {
           queryRs={{ isLoading }}
           list={audios}
           activeFeelingId={mode === 'all' ? activeFeelingId : ''}
+          activeAudioId={activeAudioId}
+          onAudioChange={onAudioChange}
         />
       </MainContainer>
       <CreatePlaylistDialog

--- a/packages/ui/src/listen/minimalism/listening-screen/index.tsx
+++ b/packages/ui/src/listen/minimalism/listening-screen/index.tsx
@@ -36,10 +36,9 @@ interface CommonProps {
   isLoading: boolean;
   // The playing track, mirrored to the URL. `activeAudioId` is the audio id
   // from the route (empty when nothing is selected yet); `onAudioChange` writes
-  // the current track's id back to the route as playback moves (`replace` picks
-  // push vs replace history).
+  // the current track's id back to the route as playback moves (one-way).
   activeAudioId: string;
-  onAudioChange: (id: string, replace: boolean) => void;
+  onAudioChange: (id: string) => void;
 }
 
 interface AllModeProps extends CommonProps {

--- a/packages/ui/src/listen/minimalism/listening-screen/index.tsx
+++ b/packages/ui/src/listen/minimalism/listening-screen/index.tsx
@@ -35,10 +35,11 @@ interface CommonProps {
   audios: unknown[];
   isLoading: boolean;
   // The playing track, mirrored to the URL. `activeAudioId` is the audio id
-  // from the route (empty when nothing is selected yet); `onAudioChange` pushes
-  // the current track's id back to the route as playback moves.
+  // from the route (empty when nothing is selected yet); `onAudioChange` writes
+  // the current track's id back to the route as playback moves (`replace` picks
+  // push vs replace history).
   activeAudioId: string;
-  onAudioChange: (id: string) => void;
+  onAudioChange: (id: string, replace: boolean) => void;
 }
 
 interface AllModeProps extends CommonProps {


### PR DESCRIPTION
## Summary

Reflect the currently-playing track in the URL, YouTube-style (SWO-422). The collection is already the route (`/` or `/playlists/$id` — the `&list=` equivalent); the track becomes an optional `audio` search param (the `?v=` equivalent):

- Home → `/?audio=<id>`, playlist → `/playlists/<pid>?audio=<id>`
- The URL is a **one-way projection** of the player: seeded from the URL once on load/deep-link, then the player owns its position and every track change (click, next/prev, shuffle, auto-advance) mirrors back with `replace`. No URL→player feedback loop, so it's race-free by construction. Shareable, bookmarkable, and survives refresh.
- Landing on `?audio=<id>` selects that track (playback starts on the first user gesture, per browser autoplay policy); a stale/unknown id self-corrects to the actual track; a clean load keeps a clean URL.

To make selection correct, `useSAudioPlayer` is now **addressable by a stable flat position**: an imperative `onSelect(flatIndex)` (input and `currentIndex` output both speak flat `audioList` positions), and `onShuffle` preserves the current track across the toggle. `validateSearch` is **non-destructive** — it preserves every other param, notably the Auth0 callback's `code`/`state` (the redirect lands back on `/`).

**Intended trade-off:** browser back/forward doesn't step through previous tracks (Prev/Next do that) — the one-way model, chosen for simplicity over a feedback-prone bidirectional sync.

## Test plan

- **Unit (from source):** hook — flat-index selection under shuffle, current-track preserved across shuffle toggle, shuffle-after-advance doesn't snap back, list-shrink stays in range; consumer (`audio-list`) — clean load doesn't write, selecting mirrors the id, matching deep-link doesn't re-write, stale id self-corrects.
- **Verified live (Playwright, running app):** clean URL on load, click/next/auto-advance mirror to `?audio=`, deep-link selects the right track and isn't clobbered, dead-id self-corrects, Auth0 `code`/`state` survive the router, and no oscillation on deep-link / feeling-filter / rapid-next (zero console errors).

## Notes / follow-ups

- One-frame, self-correcting wrong-track flash on a feeling-filter change (URL settles to the right track on the next render) — cosmetic, left as a follow-up.
- Filter + shuffle used together can land on a non-first track — pre-existing `useSAudioPlayer` behavior around shuffle order and list changes, independent of this feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Playback now stays in sync with the page URL, so the current track is reflected in an `audio` query parameter.
  * Deep links to a specific track are now supported on the listening pages.

* **Bug Fixes**
  * Track selection is preserved more reliably when shuffling or changing the playlist.
  * The player now handles list changes more safely, avoiding invalid or missing track selection.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->