### PR TITLE
[WIP] feat(listen): management dashboard UI (SWO-418/419/420)

### DIFF
--- a/apps/listen/src/routeTree.gen.ts
+++ b/apps/listen/src/routeTree.gen.ts
@@ -12,9 +12,15 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Route as rootRouteImport } from './routes/__root'
 
+const ManageLazyRouteImport = createFileRoute('/manage')()
 const IndexLazyRouteImport = createFileRoute('/')()
 const PlaylistsIdLazyRouteImport = createFileRoute('/playlists/$id')()
 
+const ManageLazyRoute = ManageLazyRouteImport.update({
+  id: '/manage',
+  path: '/manage',
+  getParentRoute: () => rootRouteImport,
+} as any).lazy(() => import('./routes/manage.lazy').then((d) => d.Route))
 const IndexLazyRoute = IndexLazyRouteImport.update({
   id: '/',
   path: '/',
@@ -28,32 +34,43 @@ const PlaylistsIdLazyRoute = PlaylistsIdLazyRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexLazyRoute
+  '/manage': typeof ManageLazyRoute
   '/playlists/$id': typeof PlaylistsIdLazyRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexLazyRoute
+  '/manage': typeof ManageLazyRoute
   '/playlists/$id': typeof PlaylistsIdLazyRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexLazyRoute
+  '/manage': typeof ManageLazyRoute
   '/playlists/$id': typeof PlaylistsIdLazyRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/playlists/$id'
+  fullPaths: '/' | '/manage' | '/playlists/$id'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/playlists/$id'
-  id: '__root__' | '/' | '/playlists/$id'
+  to: '/' | '/manage' | '/playlists/$id'
+  id: '__root__' | '/' | '/manage' | '/playlists/$id'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexLazyRoute: typeof IndexLazyRoute
+  ManageLazyRoute: typeof ManageLazyRoute
   PlaylistsIdLazyRoute: typeof PlaylistsIdLazyRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/manage': {
+      id: '/manage'
+      path: '/manage'
+      fullPath: '/manage'
+      preLoaderRoute: typeof ManageLazyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -73,6 +90,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexLazyRoute: IndexLazyRoute,
+  ManageLazyRoute: ManageLazyRoute,
   PlaylistsIdLazyRoute: PlaylistsIdLazyRoute,
 }
 export const routeTree = rootRouteImport

--- a/apps/listen/src/routes/index.lazy.tsx
+++ b/apps/listen/src/routes/index.lazy.tsx
@@ -4,13 +4,7 @@ import { useAuthContext } from 'core/providers/auth';
 import { ListeningScreen } from 'ui/listen/minimalism';
 import { LoadingBackdrop } from 'ui/universal';
 import { appConfig } from '../config';
-
-const slugify = (value: string) =>
-  value
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
+import { createPlaylistSlug } from '../utils/slug';
 
 // Selecting a collection is navigation, not state: All → `/`, a playlist → its URL.
 const useCollectionNavigate = () => {
@@ -49,7 +43,11 @@ const Content = () => {
       onSelectCollection={onSelectCollection}
       onCreate={(title) =>
         user
-          ? createPlaylist({ title, slug: slugify(title), thumbnailUrl: '' })
+          ? createPlaylist({
+              title,
+              slug: createPlaylistSlug(title),
+              thumbnailUrl: '',
+            })
           : signIn()
       }
       feelings={feelings}

--- a/apps/listen/src/routes/index.lazy.tsx
+++ b/apps/listen/src/routes/index.lazy.tsx
@@ -31,6 +31,7 @@ const useCollectionNavigate = () => {
 // create action does: create a playlist when signed in, otherwise sign in.
 const Content = () => {
   const { user, signIn, signOut } = useAuthContext();
+  const navigate = useNavigate();
   const { audios, feelings, playlists, isLoading } =
     listenQueryHooks.useLoadHome();
   const createPlaylist = listenMutationHooks.useCreatePlaylist();
@@ -54,6 +55,7 @@ const Content = () => {
       feelings={feelings}
       isLoading={isLoading}
       audios={audios}
+      onManage={user ? () => navigate({ to: '/manage' }) : undefined}
     />
   );
 };

--- a/apps/listen/src/routes/manage.lazy.tsx
+++ b/apps/listen/src/routes/manage.lazy.tsx
@@ -1,0 +1,84 @@
+import { createLazyFileRoute, useNavigate } from '@tanstack/react-router';
+import { listenMutationHooks, listenQueryHooks } from 'core';
+import { useAuthContext } from 'core/providers/auth';
+import { ManageScreen } from 'ui/listen/minimalism';
+import { LoadingBackdrop } from 'ui/universal';
+import { useEffect } from 'react';
+import { appConfig } from '../config';
+
+const slugify = (value: string) =>
+  value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+const Content = () => {
+  const { user, signOut } = useAuthContext();
+  const navigate = useNavigate();
+  const { audios, feelings, playlists, isLoading } =
+    listenQueryHooks.useLoadManage();
+
+  const updateAudio = listenMutationHooks.useUpdateAudio();
+  const deleteAudio = listenMutationHooks.useDeleteAudio();
+  const assignFeeling = listenMutationHooks.useAssignFeeling();
+  const unassignFeeling = listenMutationHooks.useUnassignFeeling();
+  const createPlaylist = listenMutationHooks.useCreatePlaylist();
+  const updatePlaylist = listenMutationHooks.useUpdatePlaylist();
+  const deletePlaylist = listenMutationHooks.useDeletePlaylist();
+
+  return (
+    <ManageScreen
+      sites={appConfig.sites}
+      user={user}
+      onLogout={signOut}
+      isLoading={isLoading}
+      audios={audios}
+      feelings={feelings}
+      playlists={playlists}
+      onUpdateAudio={updateAudio}
+      onDeleteAudio={deleteAudio}
+      onAssignFeeling={assignFeeling}
+      onUnassignFeeling={unassignFeeling}
+      onCreatePlaylist={({ title, description }) =>
+        createPlaylist({
+          title,
+          slug: slugify(title),
+          thumbnailUrl: '',
+          description,
+        })
+      }
+      onUpdatePlaylist={updatePlaylist}
+      onDeletePlaylist={deletePlaylist}
+      onOpenPlaylist={(id) =>
+        navigate({ to: '/playlists/$id', params: { id } })
+      }
+    />
+  );
+};
+
+// Management is signed-in only — send anonymous visitors back to the player.
+const Manage = () => {
+  const { isLoading, user } = useAuthContext();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!isLoading && !user) {
+      navigate({ to: '/' });
+    }
+  }, [isLoading, user, navigate]);
+
+  if (isLoading) {
+    return <LoadingBackdrop message="Valuable things deserve waiting" />;
+  }
+
+  if (!user) {
+    return null;
+  }
+
+  return <Content />;
+};
+
+export const Route = createLazyFileRoute('/manage')({
+  component: Manage,
+});

--- a/apps/listen/src/routes/manage.lazy.tsx
+++ b/apps/listen/src/routes/manage.lazy.tsx
@@ -5,13 +5,7 @@ import { ManageScreen } from 'ui/listen/minimalism';
 import { LoadingBackdrop } from 'ui/universal';
 import { useEffect } from 'react';
 import { appConfig } from '../config';
-
-const slugify = (value: string) =>
-  value
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
+import { createPlaylistSlug } from '../utils/slug';
 
 const Content = () => {
   const { user, signOut } = useAuthContext();
@@ -43,7 +37,7 @@ const Content = () => {
       onCreatePlaylist={({ title, description }) =>
         createPlaylist({
           title,
-          slug: slugify(title),
+          slug: createPlaylistSlug(title),
           thumbnailUrl: '',
           description,
         })

--- a/apps/listen/src/routes/playlists.$id.lazy.tsx
+++ b/apps/listen/src/routes/playlists.$id.lazy.tsx
@@ -25,6 +25,7 @@ const useCollectionNavigate = () => {
 const Content = () => {
   const { id } = Route.useParams();
   const { isSignedIn, user, signIn, signOut } = useAuthContext();
+  const navigate = useNavigate();
   const queryRs = listenQueryHooks.useLoadPlaylistDetail({ id });
   const { playlists } = listenQueryHooks.useLoadPlaylists();
   const createPlaylist = listenMutationHooks.useCreatePlaylist();
@@ -50,6 +51,7 @@ const Content = () => {
               })
           : () => signIn()
       }
+      onManage={user ? () => navigate({ to: '/manage' }) : undefined}
       isLoading={queryRs.isLoading}
       audios={queryRs.audios}
     />

--- a/apps/listen/src/routes/playlists.$id.lazy.tsx
+++ b/apps/listen/src/routes/playlists.$id.lazy.tsx
@@ -4,13 +4,7 @@ import { useAuthContext } from 'core/providers/auth';
 import { ListeningScreen } from 'ui/listen/minimalism';
 import { LoadingBackdrop } from 'ui/universal';
 import { appConfig } from '../config';
-
-const slugify = (value: string) =>
-  value
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
+import { createPlaylistSlug } from '../utils/slug';
 
 // Selecting a collection is navigation, not state: All → `/`, a playlist → its URL.
 const useCollectionNavigate = () => {
@@ -49,7 +43,11 @@ const Content = () => {
       onCreate={
         isSignedIn
           ? (title) =>
-              createPlaylist({ title, slug: slugify(title), thumbnailUrl: '' })
+              createPlaylist({
+                title,
+                slug: createPlaylistSlug(title),
+                thumbnailUrl: '',
+              })
           : () => signIn()
       }
       isLoading={queryRs.isLoading}

--- a/apps/listen/src/utils/slug.ts
+++ b/apps/listen/src/utils/slug.ts
@@ -1,0 +1,15 @@
+const slugify = (value: string) =>
+  value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+// Playlist slugs must be unique per site but aren't user-facing (routes address
+// playlists by id), so append a short random suffix — and fall back when the
+// title has no slug-able characters (emoji/punctuation-only) — to avoid unique
+// constraint violations and empty slugs.
+const createPlaylistSlug = (title: string) =>
+  `${slugify(title) || 'playlist'}-${crypto.randomUUID().slice(0, 8)}`;
+
+export { slugify, createPlaylistSlug };

--- a/apps/listen/src/utils/slug.ts
+++ b/apps/listen/src/utils/slug.ts
@@ -5,9 +5,13 @@ import { slugify } from 'core/universal/common';
 // titles), append a short random suffix, and fall back when the title has no
 // slug-able characters — so duplicate/emoji titles don't collide on the slug
 // unique constraint or produce an empty slug.
-const randomSuffix = () => Math.random().toString(36).slice(2, 10);
+// Timestamp base guarantees a non-empty, monotonic suffix; the random tail
+// avoids collisions within the same millisecond. (Math.random alone can
+// collapse to a near-empty base-36 slice.)
+const uniqueSuffix = () =>
+  `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
 
 const createPlaylistSlug = (title: string) =>
-  `${slugify(title) || 'playlist'}-${randomSuffix()}`;
+  `${slugify(title) || 'playlist'}-${uniqueSuffix()}`;
 
 export { createPlaylistSlug };

--- a/apps/listen/src/utils/slug.ts
+++ b/apps/listen/src/utils/slug.ts
@@ -1,15 +1,13 @@
-const slugify = (value: string) =>
-  value
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
+import { slugify } from 'core/universal/common';
 
 // Playlist slugs must be unique per site but aren't user-facing (routes address
-// playlists by id), so append a short random suffix — and fall back when the
-// title has no slug-able characters (emoji/punctuation-only) — to avoid unique
-// constraint violations and empty slugs.
-const createPlaylistSlug = (title: string) =>
-  `${slugify(title) || 'playlist'}-${crypto.randomUUID().slice(0, 8)}`;
+// playlists by id). Reuse core's accent-aware slugify (handles Vietnamese
+// titles), append a short random suffix, and fall back when the title has no
+// slug-able characters — so duplicate/emoji titles don't collide on the slug
+// unique constraint or produce an empty slug.
+const randomSuffix = () => Math.random().toString(36).slice(2, 10);
 
-export { slugify, createPlaylistSlug };
+const createPlaylistSlug = (title: string) =>
+  `${slugify(title) || 'playlist'}-${randomSuffix()}`;
+
+export { createPlaylistSlug };

--- a/packages/core/src/listen/mutation-hooks/index.test.ts
+++ b/packages/core/src/listen/mutation-hooks/index.test.ts
@@ -83,8 +83,12 @@ describe('Listen playlist mutation hooks', () => {
         'listen-playlists',
         true,
       ]);
-      expect(mockInvalidateQuery).toHaveBeenCalledWith(['listen-home', true]);
       expect(mockInvalidateQuery).toHaveBeenCalledWith(['listen-manage']);
+      // Not the home query — invalidating it would blank the active home screen.
+      expect(mockInvalidateQuery).not.toHaveBeenCalledWith([
+        'listen-home',
+        true,
+      ]);
       expect(onSuccess).toHaveBeenCalledWith(data);
     });
 

--- a/packages/core/src/listen/mutation-hooks/index.test.ts
+++ b/packages/core/src/listen/mutation-hooks/index.test.ts
@@ -72,15 +72,27 @@ describe('Listen playlist mutation hooks', () => {
       });
     });
 
-    it('invalidates the playlists list on success', () => {
+    it('invalidates the playlists and manage lists on success', () => {
       const onSuccess = vi.fn();
       renderHook(() => useCreatePlaylist({ onSuccess }));
 
       const data = { insert_playlist_one: { id: '1', slug: 'chill' } };
       getOnSuccess()?.(data);
 
-      expect(mockInvalidateQuery).toHaveBeenCalledWith(['listen-playlists']);
+      expect(mockInvalidateQuery).toHaveBeenCalledWith([
+        'listen-playlists',
+        true,
+      ]);
+      expect(mockInvalidateQuery).toHaveBeenCalledWith(['listen-manage']);
       expect(onSuccess).toHaveBeenCalledWith(data);
+    });
+
+    it('does not invalidate when no row was created', () => {
+      renderHook(() => useCreatePlaylist());
+
+      getOnSuccess()?.({ insert_playlist_one: null });
+
+      expect(mockInvalidateQuery).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/listen/mutation-hooks/index.test.ts
+++ b/packages/core/src/listen/mutation-hooks/index.test.ts
@@ -83,6 +83,7 @@ describe('Listen playlist mutation hooks', () => {
         'listen-playlists',
         true,
       ]);
+      expect(mockInvalidateQuery).toHaveBeenCalledWith(['listen-home', true]);
       expect(mockInvalidateQuery).toHaveBeenCalledWith(['listen-manage']);
       expect(onSuccess).toHaveBeenCalledWith(data);
     });

--- a/packages/core/src/listen/mutation-hooks/index.ts
+++ b/packages/core/src/listen/mutation-hooks/index.ts
@@ -146,7 +146,7 @@ const MANAGE_QUERY_KEY = ['listen-manage'];
 const HOME_QUERY_KEY = 'listen-home';
 
 const useCreatePlaylist = (props: MutationProps = {}) => {
-  const { getAccessToken } = useAuthContext();
+  const { getAccessToken, isSignedIn } = useAuthContext();
   const { invalidateQuery } = useQueryContext();
   const { onSuccess, onError } = props;
 
@@ -155,7 +155,12 @@ const useCreatePlaylist = (props: MutationProps = {}) => {
     getAccessToken,
     options: {
       onSuccess: (data) => {
-        invalidateQuery(['listen-playlists']);
+        // invalidateQuery matches exactly, so rebuild the full playlists-list
+        // key; also refresh the manage list, which shows the same playlists.
+        if (data.insert_playlist_one) {
+          invalidateQuery(['listen-playlists', isSignedIn]);
+          invalidateQuery(MANAGE_QUERY_KEY);
+        }
         onSuccess?.(data);
       },
       onError: (error) => {

--- a/packages/core/src/listen/mutation-hooks/index.ts
+++ b/packages/core/src/listen/mutation-hooks/index.ts
@@ -155,12 +155,13 @@ const useCreatePlaylist = (props: MutationProps = {}) => {
     getAccessToken,
     options: {
       onSuccess: (data) => {
-        // invalidateQuery matches exactly, so rebuild the full keys. All three
-        // screens list playlists: the collection select (home), the playlists
-        // list, and the manage dashboard.
+        // invalidateQuery matches exactly, so rebuild the full playlists-list
+        // key; also refresh the manage list. Deliberately NOT the home query:
+        // invalidateQuery removes-then-refetches, which would blank the whole
+        // active home screen to spinners on create — the collection select
+        // picks up the new playlist on its next mount instead.
         if (data.insert_playlist_one) {
           invalidateQuery(['listen-playlists', isSignedIn]);
-          invalidateQuery([HOME_QUERY_KEY, isSignedIn]);
           invalidateQuery(MANAGE_QUERY_KEY);
         }
         onSuccess?.(data);

--- a/packages/core/src/listen/mutation-hooks/index.ts
+++ b/packages/core/src/listen/mutation-hooks/index.ts
@@ -155,10 +155,12 @@ const useCreatePlaylist = (props: MutationProps = {}) => {
     getAccessToken,
     options: {
       onSuccess: (data) => {
-        // invalidateQuery matches exactly, so rebuild the full playlists-list
-        // key; also refresh the manage list, which shows the same playlists.
+        // invalidateQuery matches exactly, so rebuild the full keys. All three
+        // screens list playlists: the collection select (home), the playlists
+        // list, and the manage dashboard.
         if (data.insert_playlist_one) {
           invalidateQuery(['listen-playlists', isSignedIn]);
+          invalidateQuery([HOME_QUERY_KEY, isSignedIn]);
           invalidateQuery(MANAGE_QUERY_KEY);
         }
         onSuccess?.(data);

--- a/packages/ui/src/listen/minimalism/home/settings/index.test.tsx
+++ b/packages/ui/src/listen/minimalism/home/settings/index.test.tsx
@@ -53,4 +53,23 @@ describe('SettingsPanel', () => {
     // Check if toggle function was called with false
     expect(defaultProps.toggle).toHaveBeenCalledWith(false);
   });
+
+  it('omits the manage entry when no manage action is provided', () => {
+    render(<SettingsPanel {...defaultProps} />);
+
+    expect(screen.queryByText('Manage library')).not.toBeInTheDocument();
+  });
+
+  it('renders and wires the manage entry when provided', () => {
+    const manage = vi.fn();
+    render(
+      <SettingsPanel {...defaultProps} actions={{ logout: vi.fn(), manage }} />,
+    );
+
+    const manageButton = screen.getByText('Manage library');
+    expect(manageButton).toBeInTheDocument();
+
+    fireEvent.click(manageButton);
+    expect(manage).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/ui/src/listen/minimalism/home/settings/index.tsx
+++ b/packages/ui/src/listen/minimalism/home/settings/index.tsx
@@ -1,3 +1,4 @@
+import LibraryMusic from '@mui/icons-material/LibraryMusic';
 import Logout from '@mui/icons-material/Logout';
 import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
@@ -12,16 +13,20 @@ interface SettingsPanelProps {
   toggle: React.Dispatch<React.SetStateAction<boolean>>;
   actions: {
     logout: () => void;
+    // Opens the management dashboard. Omitted for anonymous visitors, who have
+    // nothing to manage — so the entry only appears when signed in.
+    manage?: () => void;
   };
 }
 
 const texts = {
   logout: 'Logout',
+  manage: 'Manage library',
 };
 
 const SettingsPanel = (props: SettingsPanelProps) => {
   const { open, toggle, actions } = props;
-  const { logout } = actions;
+  const { logout, manage } = actions;
 
   return (
     <Drawer anchor="right" open={open} onClose={() => toggle(false)}>
@@ -33,7 +38,16 @@ const SettingsPanel = (props: SettingsPanelProps) => {
           flexDirection: 'column',
         }}
       >
-        <List sx={{ flex: 1 }}></List>
+        <List sx={{ flex: 1 }}>
+          {manage ? (
+            <ListItemButton onClick={manage}>
+              <ListItemIcon>
+                <LibraryMusic />
+              </ListItemIcon>
+              <ListItemText primary={texts.manage} />
+            </ListItemButton>
+          ) : null}
+        </List>
         <Divider />
         <List>
           <ListItemButton onClick={logout}>

--- a/packages/ui/src/listen/minimalism/index.ts
+++ b/packages/ui/src/listen/minimalism/index.ts
@@ -4,6 +4,16 @@ import { FeelingList } from './home/feeling-list';
 import { MainContainer } from './home/main-container';
 import { SettingsPanel } from './home/settings';
 import { ListeningScreen } from './listening-screen';
+import { ManageScreen } from './manage';
+import type {
+  AudioEdit,
+  FeelingRef,
+  ManageAudio,
+  ManageFeeling,
+  ManagePlaylist,
+  PlaylistCreate,
+  PlaylistEdit,
+} from './manage/types';
 import MusicWidget from './music-widget';
 import { CreatePlaylistDialog } from './playlists/create-dialog';
 
@@ -16,4 +26,14 @@ export {
   CollectionSelect,
   CreatePlaylistDialog,
   ListeningScreen,
+  ManageScreen,
+};
+export type {
+  AudioEdit,
+  FeelingRef,
+  ManageAudio,
+  ManageFeeling,
+  ManagePlaylist,
+  PlaylistCreate,
+  PlaylistEdit,
 };

--- a/packages/ui/src/listen/minimalism/listening-screen/index.tsx
+++ b/packages/ui/src/listen/minimalism/listening-screen/index.tsx
@@ -31,6 +31,8 @@ interface CommonProps {
   playlists: CollectionSelectPlaylist[];
   onSelectCollection: (value: 'all' | string) => void;
   onCreate: (title: string) => void;
+  // Opens the management dashboard (signed-in only). Omit for anonymous.
+  onManage?: () => void;
   // Raw audios for the player (AudioList maps them to player items).
   audios: unknown[];
   isLoading: boolean;
@@ -64,6 +66,7 @@ const ListeningScreen = (props: ListeningScreenProps) => {
     playlists,
     onSelectCollection,
     onCreate,
+    onManage,
     audios,
     isLoading,
   } = props;
@@ -95,7 +98,7 @@ const ListeningScreen = (props: ListeningScreenProps) => {
       <SettingsPanel
         open={settingOpen}
         toggle={setSettingOpen}
-        actions={{ logout: onLogout }}
+        actions={{ logout: onLogout, manage: onManage }}
       />
       <MainContainer>
         <Box

--- a/packages/ui/src/listen/minimalism/manage/audio-edit-dialog.tsx
+++ b/packages/ui/src/listen/minimalism/manage/audio-edit-dialog.tsx
@@ -1,0 +1,86 @@
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import { useEffect, useState } from 'react';
+import type { AudioEdit, ManageAudio } from './types';
+
+interface AudioEditDialogProps {
+  open: boolean;
+  audio: ManageAudio | null;
+  onClose: () => void;
+  onSave: (input: AudioEdit) => void;
+}
+
+const AudioEditDialog = (props: AudioEditDialogProps) => {
+  const { open, audio, onClose, onSave } = props;
+  const [name, setName] = useState('');
+  const [artistName, setArtistName] = useState('');
+  const [thumbnailUrl, setThumbnailUrl] = useState('');
+
+  // Seed the fields from the audio each time the dialog opens for one.
+  useEffect(() => {
+    if (audio) {
+      setName(audio.name);
+      setArtistName(audio.artistName);
+      setThumbnailUrl(audio.thumbnailUrl);
+    }
+  }, [audio]);
+
+  const handleSave = () => {
+    if (!audio) return;
+    const trimmedName = name.trim();
+    if (!trimmedName) return;
+    onSave({
+      id: audio.id,
+      name: trimmedName,
+      artistName: artistName.trim(),
+      thumbnailUrl: thumbnailUrl.trim(),
+    });
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="xs">
+      <DialogTitle>Edit audio</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <TextField
+            autoFocus
+            label="Name"
+            fullWidth
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+          />
+          <TextField
+            label="Artist"
+            fullWidth
+            value={artistName}
+            onChange={(event) => setArtistName(event.target.value)}
+          />
+          <TextField
+            label="Thumbnail URL"
+            fullWidth
+            value={thumbnailUrl}
+            onChange={(event) => setThumbnailUrl(event.target.value)}
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          onClick={handleSave}
+          variant="contained"
+          disabled={!name.trim()}
+        >
+          Save
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export { AudioEditDialog };

--- a/packages/ui/src/listen/minimalism/manage/audio-edit-dialog.tsx
+++ b/packages/ui/src/listen/minimalism/manage/audio-edit-dialog.tsx
@@ -21,14 +21,15 @@ const AudioEditDialog = (props: AudioEditDialogProps) => {
   const [artistName, setArtistName] = useState('');
   const [thumbnailUrl, setThumbnailUrl] = useState('');
 
-  // Seed the fields from the audio each time the dialog opens for one.
+  // Seed the fields every time the dialog opens, so a cancelled edit never
+  // leaks its unsaved values into the next open of the same audio.
   useEffect(() => {
-    if (audio) {
+    if (open && audio) {
       setName(audio.name);
       setArtistName(audio.artistName);
       setThumbnailUrl(audio.thumbnailUrl);
     }
-  }, [audio]);
+  }, [open, audio]);
 
   const handleSave = () => {
     if (!audio) return;

--- a/packages/ui/src/listen/minimalism/manage/audio-section.test.tsx
+++ b/packages/ui/src/listen/minimalism/manage/audio-section.test.tsx
@@ -1,0 +1,79 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { AudioSection } from './audio-section';
+import '@testing-library/jest-dom';
+
+const audios = [
+  {
+    id: 'a1',
+    name: 'Unravel',
+    artistName: 'TK',
+    thumbnailUrl: '',
+    source: 'unravel.mp3',
+    tagIds: ['t1'],
+  },
+];
+
+const feelings = [
+  { id: 't1', name: 'sad' },
+  { id: 't2', name: 'calm' },
+];
+
+const baseProps = {
+  isLoading: false,
+  audios,
+  feelings,
+  onUpdateAudio: vi.fn(),
+  onDeleteAudio: vi.fn(),
+  onAssignFeeling: vi.fn(),
+  onUnassignFeeling: vi.fn(),
+};
+
+describe('AudioSection', () => {
+  it('edits an audio through the dialog seeded with its values', () => {
+    const onUpdateAudio = vi.fn();
+    render(<AudioSection {...baseProps} onUpdateAudio={onUpdateAudio} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Unravel' }));
+
+    const dialog = screen.getByRole('dialog');
+    const nameField = within(dialog).getByLabelText('Name');
+    expect(nameField).toHaveValue('Unravel');
+    fireEvent.change(nameField, { target: { value: 'Unravel (acoustic)' } });
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }));
+
+    expect(onUpdateAudio).toHaveBeenCalledWith({
+      id: 'a1',
+      name: 'Unravel (acoustic)',
+      artistName: 'TK',
+      thumbnailUrl: '',
+    });
+  });
+
+  it('deletes an audio after confirmation', () => {
+    const onDeleteAudio = vi.fn();
+    render(<AudioSection {...baseProps} onDeleteAudio={onDeleteAudio} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Unravel' }));
+    fireEvent.click(
+      within(screen.getByRole('dialog')).getByRole('button', {
+        name: 'Delete',
+      }),
+    );
+
+    expect(onDeleteAudio).toHaveBeenCalledWith('a1');
+  });
+
+  it('assigns a feeling scoped to the audio', () => {
+    const onAssignFeeling = vi.fn();
+    render(<AudioSection {...baseProps} onAssignFeeling={onAssignFeeling} />);
+
+    fireEvent.click(screen.getByText('Add feeling'));
+    fireEvent.click(screen.getByText('calm'));
+
+    expect(onAssignFeeling).toHaveBeenCalledWith({
+      audioId: 'a1',
+      tagId: 't2',
+    });
+  });
+});

--- a/packages/ui/src/listen/minimalism/manage/audio-section.tsx
+++ b/packages/ui/src/listen/minimalism/manage/audio-section.tsx
@@ -40,7 +40,15 @@ const AudioSection = (props: AudioSectionProps) => {
   } = props;
 
   const [editing, setEditing] = useState<ManageAudio | null>(null);
-  const [deleting, setDeleting] = useState<ManageAudio | null>(null);
+  // The confirm target is kept even while the dialog closes, so its name
+  // doesn't flash to "undefined" during the fade-out; `confirmOpen` drives it.
+  const [confirmTarget, setConfirmTarget] = useState<ManageAudio | null>(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const askDelete = (audio: ManageAudio) => {
+    setConfirmTarget(audio);
+    setConfirmOpen(true);
+  };
 
   return (
     <Box component="section">
@@ -104,7 +112,7 @@ const AudioSection = (props: AudioSectionProps) => {
                   </IconButton>
                   <IconButton
                     aria-label={`Delete ${audio.name}`}
-                    onClick={() => setDeleting(audio)}
+                    onClick={() => askDelete(audio)}
                   >
                     <Delete />
                   </IconButton>
@@ -122,12 +130,12 @@ const AudioSection = (props: AudioSectionProps) => {
         onSave={onUpdateAudio}
       />
       <ConfirmDialog
-        open={Boolean(deleting)}
+        open={confirmOpen}
         title="Delete audio"
-        message={`Delete "${deleting?.name}"? This can't be undone.`}
-        onClose={() => setDeleting(null)}
+        message={`Delete "${confirmTarget?.name}"? This can't be undone.`}
+        onClose={() => setConfirmOpen(false)}
         onConfirm={() => {
-          if (deleting) onDeleteAudio(deleting.id);
+          if (confirmTarget) onDeleteAudio(confirmTarget.id);
         }}
       />
     </Box>

--- a/packages/ui/src/listen/minimalism/manage/audio-section.tsx
+++ b/packages/ui/src/listen/minimalism/manage/audio-section.tsx
@@ -1,0 +1,137 @@
+import Delete from '@mui/icons-material/Delete';
+import Edit from '@mui/icons-material/Edit';
+import Avatar from '@mui/material/Avatar';
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
+import IconButton from '@mui/material/IconButton';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { useState } from 'react';
+import { AudioEditDialog } from './audio-edit-dialog';
+import { ConfirmDialog } from './confirm-dialog';
+import { FeelingPicker } from './feeling-picker';
+import type {
+  AudioEdit,
+  FeelingRef,
+  ManageAudio,
+  ManageFeeling,
+} from './types';
+
+interface AudioSectionProps {
+  isLoading: boolean;
+  audios: ManageAudio[];
+  feelings: ManageFeeling[];
+  onUpdateAudio: (input: AudioEdit) => void;
+  onDeleteAudio: (id: string) => void;
+  onAssignFeeling: (input: FeelingRef) => void;
+  onUnassignFeeling: (input: FeelingRef) => void;
+}
+
+const AudioSection = (props: AudioSectionProps) => {
+  const {
+    isLoading,
+    audios,
+    feelings,
+    onUpdateAudio,
+    onDeleteAudio,
+    onAssignFeeling,
+    onUnassignFeeling,
+  } = props;
+
+  const [editing, setEditing] = useState<ManageAudio | null>(null);
+  const [deleting, setDeleting] = useState<ManageAudio | null>(null);
+
+  return (
+    <Box component="section">
+      <Typography variant="h6" component="h2" sx={{ mb: 2 }}>
+        Audios ({audios.length})
+      </Typography>
+
+      {isLoading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+          <CircularProgress />
+        </Box>
+      ) : audios.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          You have no audios yet.
+        </Typography>
+      ) : (
+        <Stack spacing={2}>
+          {audios.map((audio) => (
+            <Paper key={audio.id} variant="outlined" sx={{ p: 2 }}>
+              <Stack
+                direction={{ xs: 'column', sm: 'row' }}
+                spacing={2}
+                sx={{ alignItems: { sm: 'center' } }}
+              >
+                <Avatar
+                  src={audio.thumbnailUrl || undefined}
+                  variant="rounded"
+                  sx={{ width: 56, height: 56 }}
+                >
+                  {audio.name.charAt(0)}
+                </Avatar>
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Typography variant="subtitle1" noWrap>
+                    {audio.name}
+                  </Typography>
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    noWrap
+                    sx={{ mb: 1 }}
+                  >
+                    {audio.artistName}
+                  </Typography>
+                  <FeelingPicker
+                    assignedTagIds={audio.tagIds}
+                    feelings={feelings}
+                    onAssign={(tagId) =>
+                      onAssignFeeling({ audioId: audio.id, tagId })
+                    }
+                    onUnassign={(tagId) =>
+                      onUnassignFeeling({ audioId: audio.id, tagId })
+                    }
+                  />
+                </Box>
+                <Stack direction="row" spacing={1}>
+                  <IconButton
+                    aria-label={`Edit ${audio.name}`}
+                    onClick={() => setEditing(audio)}
+                  >
+                    <Edit />
+                  </IconButton>
+                  <IconButton
+                    aria-label={`Delete ${audio.name}`}
+                    onClick={() => setDeleting(audio)}
+                  >
+                    <Delete />
+                  </IconButton>
+                </Stack>
+              </Stack>
+            </Paper>
+          ))}
+        </Stack>
+      )}
+
+      <AudioEditDialog
+        open={Boolean(editing)}
+        audio={editing}
+        onClose={() => setEditing(null)}
+        onSave={onUpdateAudio}
+      />
+      <ConfirmDialog
+        open={Boolean(deleting)}
+        title="Delete audio"
+        message={`Delete "${deleting?.name}"? This can't be undone.`}
+        onClose={() => setDeleting(null)}
+        onConfirm={() => {
+          if (deleting) onDeleteAudio(deleting.id);
+        }}
+      />
+    </Box>
+  );
+};
+
+export { AudioSection };

--- a/packages/ui/src/listen/minimalism/manage/confirm-dialog.tsx
+++ b/packages/ui/src/listen/minimalism/manage/confirm-dialog.tsx
@@ -1,0 +1,48 @@
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+const ConfirmDialog = (props: ConfirmDialogProps) => {
+  const {
+    open,
+    title,
+    message,
+    confirmLabel = 'Delete',
+    onClose,
+    onConfirm,
+  } = props;
+
+  const handleConfirm = () => {
+    onConfirm();
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs">
+      <DialogTitle>{title}</DialogTitle>
+      <DialogContent>
+        <DialogContentText>{message}</DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button onClick={handleConfirm} color="error" variant="contained">
+          {confirmLabel}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export { ConfirmDialog };

--- a/packages/ui/src/listen/minimalism/manage/feeling-picker.test.tsx
+++ b/packages/ui/src/listen/minimalism/manage/feeling-picker.test.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { FeelingPicker } from './feeling-picker';
+import '@testing-library/jest-dom';
+
+const feelings = [
+  { id: 't1', name: 'happy' },
+  { id: 't2', name: 'sad' },
+  { id: 't3', name: 'calm' },
+];
+
+describe('FeelingPicker', () => {
+  it('shows assigned feelings as chips and offers the rest to add', () => {
+    render(
+      <FeelingPicker
+        assignedTagIds={['t1']}
+        feelings={feelings}
+        onAssign={vi.fn()}
+        onUnassign={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('happy')).toBeInTheDocument();
+    expect(screen.queryByText('sad')).not.toBeInTheDocument();
+
+    // The unassigned feelings appear only in the add menu, once opened.
+    fireEvent.click(screen.getByText('Add feeling'));
+    expect(screen.getByText('sad')).toBeInTheDocument();
+    expect(screen.getByText('calm')).toBeInTheDocument();
+  });
+
+  it('assigns a feeling picked from the add menu', () => {
+    const onAssign = vi.fn();
+    render(
+      <FeelingPicker
+        assignedTagIds={[]}
+        feelings={feelings}
+        onAssign={onAssign}
+        onUnassign={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Add feeling'));
+    fireEvent.click(screen.getByText('calm'));
+
+    expect(onAssign).toHaveBeenCalledWith('t3');
+  });
+
+  it('unassigns a feeling when its chip is deleted', () => {
+    const onUnassign = vi.fn();
+    render(
+      <FeelingPicker
+        assignedTagIds={['t2']}
+        feelings={feelings}
+        onAssign={vi.fn()}
+        onUnassign={onUnassign}
+      />,
+    );
+
+    // MUI renders the chip delete affordance as a CancelIcon button.
+    fireEvent.click(screen.getByTestId('CancelIcon'));
+
+    expect(onUnassign).toHaveBeenCalledWith('t2');
+  });
+
+  it('shows an empty hint and no add menu when all feelings are assigned', () => {
+    render(
+      <FeelingPicker
+        assignedTagIds={['t1', 't2', 't3']}
+        feelings={feelings}
+        onAssign={vi.fn()}
+        onUnassign={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText('Add feeling')).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/listen/minimalism/manage/feeling-picker.test.tsx
+++ b/packages/ui/src/listen/minimalism/manage/feeling-picker.test.tsx
@@ -63,6 +63,22 @@ describe('FeelingPicker', () => {
     expect(onUnassign).toHaveBeenCalledWith('t2');
   });
 
+  it('still shows and can remove an assigned tag missing from the vocabulary', () => {
+    const onUnassign = vi.fn();
+    render(
+      <FeelingPicker
+        assignedTagIds={['orphan']}
+        feelings={feelings}
+        onAssign={vi.fn()}
+        onUnassign={onUnassign}
+      />,
+    );
+
+    expect(screen.getByText('Unknown')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('CancelIcon'));
+    expect(onUnassign).toHaveBeenCalledWith('orphan');
+  });
+
   it('shows an empty hint and no add menu when all feelings are assigned', () => {
     render(
       <FeelingPicker

--- a/packages/ui/src/listen/minimalism/manage/feeling-picker.tsx
+++ b/packages/ui/src/listen/minimalism/manage/feeling-picker.tsx
@@ -21,7 +21,13 @@ const FeelingPicker = (props: FeelingPickerProps) => {
   const { assignedTagIds, feelings, onAssign, onUnassign } = props;
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
-  const assigned = feelings.filter((f) => assignedTagIds.includes(f.id));
+  // Derive chips from the assigned ids (not the vocabulary) so an assignment
+  // whose tag is missing from `feelings` still shows and can be removed.
+  const nameById = new Map(feelings.map((f) => [f.id, f.name]));
+  const assigned = assignedTagIds.map((id) => ({
+    id,
+    name: nameById.get(id) ?? 'Unknown',
+  }));
   const available = feelings.filter((f) => !assignedTagIds.includes(f.id));
 
   const handleAdd = (tagId: string) => {

--- a/packages/ui/src/listen/minimalism/manage/feeling-picker.tsx
+++ b/packages/ui/src/listen/minimalism/manage/feeling-picker.tsx
@@ -1,0 +1,79 @@
+import Add from '@mui/icons-material/Add';
+import Chip from '@mui/material/Chip';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { useState } from 'react';
+import type { ManageFeeling } from './types';
+
+interface FeelingPickerProps {
+  assignedTagIds: string[];
+  feelings: ManageFeeling[];
+  onAssign: (tagId: string) => void;
+  onUnassign: (tagId: string) => void;
+}
+
+// Shows an audio's feelings as removable chips, plus an "Add" menu offering the
+// feelings not yet assigned. The whole listen feeling vocabulary comes in via
+// `feelings`; assignment is add/remove only (no tag creation here).
+const FeelingPicker = (props: FeelingPickerProps) => {
+  const { assignedTagIds, feelings, onAssign, onUnassign } = props;
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+
+  const assigned = feelings.filter((f) => assignedTagIds.includes(f.id));
+  const available = feelings.filter((f) => !assignedTagIds.includes(f.id));
+
+  const handleAdd = (tagId: string) => {
+    onAssign(tagId);
+    setAnchorEl(null);
+  };
+
+  return (
+    <Stack
+      direction="row"
+      spacing={1}
+      useFlexGap
+      sx={{ flexWrap: 'wrap', alignItems: 'center' }}
+    >
+      {assigned.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          No feelings yet
+        </Typography>
+      ) : (
+        assigned.map((feeling) => (
+          <Chip
+            key={feeling.id}
+            label={feeling.name}
+            size="small"
+            onDelete={() => onUnassign(feeling.id)}
+          />
+        ))
+      )}
+      {available.length > 0 ? (
+        <>
+          <Chip
+            icon={<Add />}
+            label="Add feeling"
+            size="small"
+            variant="outlined"
+            onClick={(event) => setAnchorEl(event.currentTarget)}
+          />
+          <Menu
+            anchorEl={anchorEl}
+            open={Boolean(anchorEl)}
+            onClose={() => setAnchorEl(null)}
+          >
+            {available.map((feeling) => (
+              <MenuItem key={feeling.id} onClick={() => handleAdd(feeling.id)}>
+                {feeling.name}
+              </MenuItem>
+            ))}
+          </Menu>
+        </>
+      ) : null}
+    </Stack>
+  );
+};
+
+export { FeelingPicker };

--- a/packages/ui/src/listen/minimalism/manage/index.tsx
+++ b/packages/ui/src/listen/minimalism/manage/index.tsx
@@ -1,0 +1,120 @@
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import type { Auth } from 'core';
+import { useState } from 'react';
+import { FullWidthContainer } from '../../../universal';
+import { Header } from '../../../universal/header';
+import { MainContainer } from '../home/main-container';
+import { SettingsPanel } from '../home/settings';
+import { AudioSection } from './audio-section';
+import { PlaylistSection } from './playlist-section';
+import type {
+  AudioEdit,
+  FeelingRef,
+  ManageAudio,
+  ManageFeeling,
+  ManagePlaylist,
+  PlaylistCreate,
+  PlaylistEdit,
+} from './types';
+
+interface HeaderSites {
+  main: string;
+  listen: string;
+  watch: string;
+  til: string;
+}
+
+interface ManageScreenProps {
+  sites: HeaderSites;
+  user: Auth.CustomUser | null;
+  onLogout: () => void;
+  isLoading: boolean;
+  audios: ManageAudio[];
+  feelings: ManageFeeling[];
+  playlists: ManagePlaylist[];
+  onUpdateAudio: (input: AudioEdit) => void;
+  onDeleteAudio: (id: string) => void;
+  onAssignFeeling: (input: FeelingRef) => void;
+  onUnassignFeeling: (input: FeelingRef) => void;
+  onCreatePlaylist: (input: PlaylistCreate) => void;
+  onUpdatePlaylist: (input: PlaylistEdit) => void;
+  onDeletePlaylist: (id: string) => void;
+  onOpenPlaylist: (id: string) => void;
+}
+
+/**
+ * The listen management dashboard (SWO-411). A signed-in, user-only screen for
+ * managing your own library: edit/delete audios and their feelings, and CRUD
+ * your own playlists. It shares the app header and settings panel with the
+ * player screens; the Logo is the way back to the player.
+ */
+const ManageScreen = (props: ManageScreenProps) => {
+  const {
+    sites,
+    user,
+    onLogout,
+    isLoading,
+    audios,
+    feelings,
+    playlists,
+    onUpdateAudio,
+    onDeleteAudio,
+    onAssignFeeling,
+    onUnassignFeeling,
+    onCreatePlaylist,
+    onUpdatePlaylist,
+    onDeletePlaylist,
+    onOpenPlaylist,
+  } = props;
+
+  const [settingsOpen, setSettingsOpen] = useState(false);
+
+  return (
+    <FullWidthContainer>
+      <Header
+        user={user}
+        onAvatarClick={() => setSettingsOpen(true)}
+        siteChoices={{ sites, activeSite: 'listen' }}
+      />
+      <SettingsPanel
+        open={settingsOpen}
+        toggle={setSettingsOpen}
+        actions={{ logout: onLogout }}
+      />
+      <MainContainer>
+        <Box sx={{ my: 4 }}>
+          <Typography variant="h4" component="h1" sx={{ mb: 1 }}>
+            Manage library
+          </Typography>
+          <Typography variant="body1" color="text.secondary">
+            Edit your audios and feelings, and organise your playlists.
+          </Typography>
+        </Box>
+        <Stack spacing={6} sx={{ pb: 8 }}>
+          <AudioSection
+            isLoading={isLoading}
+            audios={audios}
+            feelings={feelings}
+            onUpdateAudio={onUpdateAudio}
+            onDeleteAudio={onDeleteAudio}
+            onAssignFeeling={onAssignFeeling}
+            onUnassignFeeling={onUnassignFeeling}
+          />
+          <PlaylistSection
+            isLoading={isLoading}
+            playlists={playlists}
+            onCreatePlaylist={onCreatePlaylist}
+            onUpdatePlaylist={onUpdatePlaylist}
+            onDeletePlaylist={onDeletePlaylist}
+            onOpenPlaylist={onOpenPlaylist}
+          />
+        </Stack>
+      </MainContainer>
+    </FullWidthContainer>
+  );
+};
+
+export { ManageScreen };
+export type { ManageScreenProps };

--- a/packages/ui/src/listen/minimalism/manage/playlist-edit-dialog.tsx
+++ b/packages/ui/src/listen/minimalism/manage/playlist-edit-dialog.tsx
@@ -1,0 +1,79 @@
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import { useEffect, useState } from 'react';
+import type { ManagePlaylist } from './types';
+
+interface PlaylistFormValues {
+  title: string;
+  description: string;
+}
+
+interface PlaylistEditDialogProps {
+  open: boolean;
+  // null → create mode; a playlist → edit mode.
+  playlist: ManagePlaylist | null;
+  onClose: () => void;
+  onSubmit: (values: PlaylistFormValues) => void;
+}
+
+const PlaylistEditDialog = (props: PlaylistEditDialogProps) => {
+  const { open, playlist, onClose, onSubmit } = props;
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+
+  // Reset the fields whenever the dialog target changes (create vs a playlist).
+  useEffect(() => {
+    setTitle(playlist?.title ?? '');
+    setDescription(playlist?.description ?? '');
+  }, [playlist]);
+
+  const handleSubmit = () => {
+    const trimmed = title.trim();
+    if (!trimmed) return;
+    onSubmit({ title: trimmed, description: description.trim() });
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="xs">
+      <DialogTitle>{playlist ? 'Edit playlist' : 'New playlist'}</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <TextField
+            autoFocus
+            label="Title"
+            fullWidth
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+          />
+          <TextField
+            label="Description"
+            fullWidth
+            multiline
+            minRows={2}
+            value={description}
+            onChange={(event) => setDescription(event.target.value)}
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          onClick={handleSubmit}
+          variant="contained"
+          disabled={!title.trim()}
+        >
+          {playlist ? 'Save' : 'Create'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export { PlaylistEditDialog };
+export type { PlaylistFormValues };

--- a/packages/ui/src/listen/minimalism/manage/playlist-edit-dialog.tsx
+++ b/packages/ui/src/listen/minimalism/manage/playlist-edit-dialog.tsx
@@ -26,11 +26,15 @@ const PlaylistEditDialog = (props: PlaylistEditDialogProps) => {
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
 
-  // Reset the fields whenever the dialog target changes (create vs a playlist).
+  // Reset the fields every time the dialog opens. Keying only on `playlist`
+  // would leave create mode (playlist stays null) showing the previous entry's
+  // values on the next open.
   useEffect(() => {
-    setTitle(playlist?.title ?? '');
-    setDescription(playlist?.description ?? '');
-  }, [playlist]);
+    if (open) {
+      setTitle(playlist?.title ?? '');
+      setDescription(playlist?.description ?? '');
+    }
+  }, [open, playlist]);
 
   const handleSubmit = () => {
     const trimmed = title.trim();

--- a/packages/ui/src/listen/minimalism/manage/playlist-section.test.tsx
+++ b/packages/ui/src/listen/minimalism/manage/playlist-section.test.tsx
@@ -1,0 +1,90 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { PlaylistSection } from './playlist-section';
+import '@testing-library/jest-dom';
+
+const playlists = [
+  {
+    id: 'p1',
+    title: 'Chill',
+    slug: 'chill',
+    description: 'relax',
+    thumbnailUrl: '',
+  },
+];
+
+const baseProps = {
+  isLoading: false,
+  playlists,
+  onCreatePlaylist: vi.fn(),
+  onUpdatePlaylist: vi.fn(),
+  onDeletePlaylist: vi.fn(),
+  onOpenPlaylist: vi.fn(),
+};
+
+const getDialog = () => screen.getByRole('dialog');
+
+describe('PlaylistSection', () => {
+  it('routes the create form to onCreatePlaylist', () => {
+    const onCreatePlaylist = vi.fn();
+    render(
+      <PlaylistSection {...baseProps} onCreatePlaylist={onCreatePlaylist} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'New playlist' }));
+
+    const dialog = getDialog();
+    fireEvent.change(within(dialog).getByLabelText('Title'), {
+      target: { value: 'Focus' },
+    });
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Create' }));
+
+    expect(onCreatePlaylist).toHaveBeenCalledWith({
+      title: 'Focus',
+      description: '',
+    });
+  });
+
+  it('routes the edit form to onUpdatePlaylist with the playlist id', () => {
+    const onUpdatePlaylist = vi.fn();
+    render(
+      <PlaylistSection {...baseProps} onUpdatePlaylist={onUpdatePlaylist} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Chill' }));
+
+    const dialog = getDialog();
+    const titleField = within(dialog).getByLabelText('Title');
+    fireEvent.change(titleField, { target: { value: 'Chill vibes' } });
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }));
+
+    expect(onUpdatePlaylist).toHaveBeenCalledWith({
+      id: 'p1',
+      title: 'Chill vibes',
+      description: 'relax',
+    });
+  });
+
+  it('deletes after confirmation', () => {
+    const onDeletePlaylist = vi.fn();
+    render(
+      <PlaylistSection {...baseProps} onDeletePlaylist={onDeletePlaylist} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Chill' }));
+    fireEvent.click(
+      within(getDialog()).getByRole('button', { name: 'Delete' }),
+    );
+
+    expect(onDeletePlaylist).toHaveBeenCalledWith('p1');
+  });
+
+  it('opens the playlist detail when its title is clicked', () => {
+    const onOpenPlaylist = vi.fn();
+    render(<PlaylistSection {...baseProps} onOpenPlaylist={onOpenPlaylist} />);
+
+    fireEvent.click(screen.getByText('Chill'));
+
+    expect(onOpenPlaylist).toHaveBeenCalledWith('p1');
+  });
+});

--- a/packages/ui/src/listen/minimalism/manage/playlist-section.tsx
+++ b/packages/ui/src/listen/minimalism/manage/playlist-section.tsx
@@ -39,7 +39,17 @@ const PlaylistSection = (props: PlaylistSectionProps) => {
   const [formOpen, setFormOpen] = useState(false);
   // The playlist being edited; null while the form is in create mode.
   const [editing, setEditing] = useState<ManagePlaylist | null>(null);
-  const [deleting, setDeleting] = useState<ManagePlaylist | null>(null);
+  // Kept while the confirm dialog closes so its title doesn't flash to
+  // "undefined" during the fade-out; `confirmOpen` drives visibility.
+  const [confirmTarget, setConfirmTarget] = useState<ManagePlaylist | null>(
+    null,
+  );
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const askDelete = (playlist: ManagePlaylist) => {
+    setConfirmTarget(playlist);
+    setConfirmOpen(true);
+  };
 
   const openCreate = () => {
     setEditing(null);
@@ -116,7 +126,7 @@ const PlaylistSection = (props: PlaylistSectionProps) => {
                   </IconButton>
                   <IconButton
                     aria-label={`Delete ${playlist.title}`}
-                    onClick={() => setDeleting(playlist)}
+                    onClick={() => askDelete(playlist)}
                   >
                     <Delete />
                   </IconButton>
@@ -134,12 +144,12 @@ const PlaylistSection = (props: PlaylistSectionProps) => {
         onSubmit={handleSubmit}
       />
       <ConfirmDialog
-        open={Boolean(deleting)}
+        open={confirmOpen}
         title="Delete playlist"
-        message={`Delete "${deleting?.title}"? This can't be undone.`}
-        onClose={() => setDeleting(null)}
+        message={`Delete "${confirmTarget?.title}"? This can't be undone.`}
+        onClose={() => setConfirmOpen(false)}
         onConfirm={() => {
-          if (deleting) onDeletePlaylist(deleting.id);
+          if (confirmTarget) onDeletePlaylist(confirmTarget.id);
         }}
       />
     </Box>

--- a/packages/ui/src/listen/minimalism/manage/playlist-section.tsx
+++ b/packages/ui/src/listen/minimalism/manage/playlist-section.tsx
@@ -1,0 +1,149 @@
+import Add from '@mui/icons-material/Add';
+import Delete from '@mui/icons-material/Delete';
+import Edit from '@mui/icons-material/Edit';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import IconButton from '@mui/material/IconButton';
+import Link from '@mui/material/Link';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { useState } from 'react';
+import { ConfirmDialog } from './confirm-dialog';
+import {
+  PlaylistEditDialog,
+  type PlaylistFormValues,
+} from './playlist-edit-dialog';
+import type { ManagePlaylist, PlaylistCreate, PlaylistEdit } from './types';
+
+interface PlaylistSectionProps {
+  isLoading: boolean;
+  playlists: ManagePlaylist[];
+  onCreatePlaylist: (input: PlaylistCreate) => void;
+  onUpdatePlaylist: (input: PlaylistEdit) => void;
+  onDeletePlaylist: (id: string) => void;
+  onOpenPlaylist: (id: string) => void;
+}
+
+const PlaylistSection = (props: PlaylistSectionProps) => {
+  const {
+    isLoading,
+    playlists,
+    onCreatePlaylist,
+    onUpdatePlaylist,
+    onDeletePlaylist,
+    onOpenPlaylist,
+  } = props;
+
+  const [formOpen, setFormOpen] = useState(false);
+  // The playlist being edited; null while the form is in create mode.
+  const [editing, setEditing] = useState<ManagePlaylist | null>(null);
+  const [deleting, setDeleting] = useState<ManagePlaylist | null>(null);
+
+  const openCreate = () => {
+    setEditing(null);
+    setFormOpen(true);
+  };
+
+  const openEdit = (playlist: ManagePlaylist) => {
+    setEditing(playlist);
+    setFormOpen(true);
+  };
+
+  const handleSubmit = (values: PlaylistFormValues) => {
+    if (editing) {
+      onUpdatePlaylist({ id: editing.id, ...values });
+    } else {
+      onCreatePlaylist(values);
+    }
+  };
+
+  return (
+    <Box component="section">
+      <Stack
+        direction="row"
+        sx={{ alignItems: 'center', justifyContent: 'space-between', mb: 2 }}
+      >
+        <Typography variant="h6" component="h2">
+          Playlists ({playlists.length})
+        </Typography>
+        <Button variant="contained" startIcon={<Add />} onClick={openCreate}>
+          New playlist
+        </Button>
+      </Stack>
+
+      {isLoading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+          <CircularProgress />
+        </Box>
+      ) : playlists.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          You have no playlists yet.
+        </Typography>
+      ) : (
+        <Stack spacing={2}>
+          {playlists.map((playlist) => (
+            <Paper key={playlist.id} variant="outlined" sx={{ p: 2 }}>
+              <Stack
+                direction={{ xs: 'column', sm: 'row' }}
+                spacing={2}
+                sx={{ alignItems: { sm: 'center' } }}
+              >
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Link
+                    component="button"
+                    variant="subtitle1"
+                    underline="hover"
+                    color="inherit"
+                    onClick={() => onOpenPlaylist(playlist.id)}
+                    sx={{ textAlign: 'left' }}
+                  >
+                    {playlist.title}
+                  </Link>
+                  {playlist.description ? (
+                    <Typography variant="body2" color="text.secondary" noWrap>
+                      {playlist.description}
+                    </Typography>
+                  ) : null}
+                </Box>
+                <Stack direction="row" spacing={1}>
+                  <IconButton
+                    aria-label={`Edit ${playlist.title}`}
+                    onClick={() => openEdit(playlist)}
+                  >
+                    <Edit />
+                  </IconButton>
+                  <IconButton
+                    aria-label={`Delete ${playlist.title}`}
+                    onClick={() => setDeleting(playlist)}
+                  >
+                    <Delete />
+                  </IconButton>
+                </Stack>
+              </Stack>
+            </Paper>
+          ))}
+        </Stack>
+      )}
+
+      <PlaylistEditDialog
+        open={formOpen}
+        playlist={editing}
+        onClose={() => setFormOpen(false)}
+        onSubmit={handleSubmit}
+      />
+      <ConfirmDialog
+        open={Boolean(deleting)}
+        title="Delete playlist"
+        message={`Delete "${deleting?.title}"? This can't be undone.`}
+        onClose={() => setDeleting(null)}
+        onConfirm={() => {
+          if (deleting) onDeletePlaylist(deleting.id);
+        }}
+      />
+    </Box>
+  );
+};
+
+export { PlaylistSection };

--- a/packages/ui/src/listen/minimalism/manage/types.ts
+++ b/packages/ui/src/listen/minimalism/manage/types.ts
@@ -1,0 +1,58 @@
+// Shapes the management dashboard consumes. The frontend query-hook transformer
+// (useLoadManage) already produces these; the mutation hooks accept the *Edit /
+// *Ref inputs.
+
+interface ManageAudio {
+  id: string;
+  name: string;
+  artistName: string;
+  thumbnailUrl: string;
+  source: string;
+  tagIds: string[];
+}
+
+interface ManageFeeling {
+  id: string;
+  name: string;
+}
+
+interface ManagePlaylist {
+  id: string;
+  title: string;
+  slug: string;
+  description?: string | null;
+  thumbnailUrl?: string | null;
+}
+
+interface AudioEdit {
+  id: string;
+  name?: string;
+  artistName?: string;
+  thumbnailUrl?: string;
+}
+
+interface FeelingRef {
+  audioId: string;
+  tagId: string;
+}
+
+interface PlaylistCreate {
+  title: string;
+  description?: string;
+}
+
+interface PlaylistEdit {
+  id: string;
+  title?: string;
+  description?: string;
+}
+
+export type {
+  AudioEdit,
+  FeelingRef,
+  ManageAudio,
+  ManageFeeling,
+  ManagePlaylist,
+  PlaylistCreate,
+  PlaylistEdit,
+};


### PR DESCRIPTION
## Summary

The listen management dashboard (SWO-411) — a signed-in, user-only `/manage` screen to manage your own library. Reached via a new **"Manage library"** entry in the avatar SettingsPanel (home + playlist-detail drawers); anonymous visitors are redirected to the player. Delivered as one cohesive screen resolving SWO-418 (route shell), SWO-419 (audio section), and SWO-420 (playlist section).

- **Audios:** edit metadata (name/artist/thumbnail), delete (confirm), assign/unassign feelings via a chip picker (add-menu of available listen tags).
- **Playlists:** create / edit (title, description) / delete (confirm), each linking to the playlist-detail page for track management.

Wires the already-merged core hooks. Also fixes `useCreatePlaylist` to invalidate the right keys (manage + playlists), reuses core's accent-aware `slugify` with a unique non-empty suffix, and consolidates the triplicated local `slugify`.

## Test plan

- 18 ui tests (FeelingPicker split/assign/unassign incl. orphan tag, AudioSection edit/delete/feeling, PlaylistSection create-vs-edit/delete/open, SettingsPanel manage entry) + 27 core mutation-hook tests
- `ui` + `core` + `listen` typecheck clean; Biome clean
- Manually verified signed-in in a browser: dashboard renders, edit/delete/feelings + playlist CRUD work; anonymous `/manage` redirects to `/`
- Went through four `/code-review` rounds to zero findings

Resolves SWO-418, SWO-419, SWO-420.