### PR TITLE
chore: gitignore local Linear CLI workspace config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ apps/listen/stats.html
 
 # Sentry Config File
 .env.sentry-build-plugin
+
+# Linear CLI local workspace config (may contain api_key)
+.linear.toml

--- a/apps/listen/vite.config.ts
+++ b/apps/listen/vite.config.ts
@@ -37,7 +37,10 @@ export default defineConfig({
              * of this group — a group only routes code, it doesn't set load
              * timing. Eager is required to catch load-time crashes.
              */
-            { name: 'tracker-vendor', test: /node_modules\/(rollbar|@rollbar)\// },
+            {
+              name: 'tracker-vendor',
+              test: /node_modules\/(rollbar|@rollbar)\//,
+            },
             /**
              * Remaining third-party code (Auth0, TanStack, popper, …) in its
              * own chunk so it stays cacheable across app-code changes instead


### PR DESCRIPTION
## Summary
- Ignore `.linear.toml`, a per-repo Linear CLI config that pins this workspace to the `sworld` Linear org (added so `linear` commands resolve to the right workspace without touching the global default). It's local machine config and can optionally hold a plaintext `api_key`, so it shouldn't be committed.
- Also includes a separate, unrelated commit: `apps/listen/vite.config.ts` picked up a pre-existing biome formatting fix via the repo's pre-push hook.

## Test plan
- [x] `git status` no longer shows `.linear.toml` as untracked after adding the ignore rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added local Linear CLI configuration files to the ignore list to help prevent accidental exposure of sensitive credentials.

* **Style**
  * Reformatted build configuration for improved readability without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->