### PR TITLE
[WIP] feat(extension): add AuthManager for OAuth device flow

### DIFF
--- a/apps/extension/config.ts
+++ b/apps/extension/config.ts
@@ -1,5 +1,6 @@
 const config = {
   allowedOrigin: import.meta.env.VITE_ALLOWED_ORIGIN,
+  backendUrl: import.meta.env.VITE_BACKEND_URL,
 };
 
 export { config };

--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -1,5 +1,6 @@
 import { removeItems, setItem } from 'core/universal/extension/storage';
 import { config } from '../config';
+import { isAuthenticated, getToken, startPairing, pollForDeviceToken, logout } from './background/auth';
 
 console.log('Background script starting...');
 
@@ -29,6 +30,59 @@ chrome.runtime.onMessageExternal.addListener(
       await removeItems(['auth0Token']);
       sendResponse({ success: true });
       return;
+    }
+  },
+);
+
+chrome.runtime.onMessage.addListener(
+  async (message, _sender, sendResponse) => {
+    const { type, data } = message;
+
+    switch (type) {
+      case 'GET_AUTH_STATUS': {
+        const authenticated = await isAuthenticated();
+        sendResponse({ authenticated });
+        return;
+      }
+
+      case 'GET_TOKEN': {
+        const token = await getToken();
+        sendResponse({ token });
+        return;
+      }
+
+      case 'START_PAIRING': {
+        try {
+          const result = await startPairing();
+          sendResponse({ success: true, ...result });
+        } catch (error) {
+          sendResponse({
+            success: false,
+            error: error instanceof Error ? error.message : 'Unknown error',
+          });
+        }
+        return;
+      }
+
+      case 'POLL_FOR_TOKEN': {
+        const { deviceCode, interval, expiresIn } = data;
+        try {
+          await pollForDeviceToken(deviceCode, interval, expiresIn);
+          sendResponse({ success: true });
+        } catch (error) {
+          sendResponse({
+            success: false,
+            error: error instanceof Error ? error.message : 'Unknown error',
+          });
+        }
+        return;
+      }
+
+      case 'LOGOUT': {
+        await logout();
+        sendResponse({ success: true });
+        return;
+      }
     }
   },
 );

--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -1,6 +1,12 @@
 import { removeItems, setItem } from 'core/universal/extension/storage';
 import { config } from '../config';
-import { isAuthenticated, getToken, startPairing, pollForDeviceToken, logout } from './background/auth';
+import {
+  isAuthenticated,
+  getToken,
+  startPairing,
+  pollForDeviceToken,
+  logout,
+} from './background/auth';
 
 console.log('Background script starting...');
 
@@ -34,55 +40,53 @@ chrome.runtime.onMessageExternal.addListener(
   },
 );
 
-chrome.runtime.onMessage.addListener(
-  async (message, _sender, sendResponse) => {
-    const { type, data } = message;
+chrome.runtime.onMessage.addListener(async (message, _sender, sendResponse) => {
+  const { type, data } = message;
 
-    switch (type) {
-      case 'GET_AUTH_STATUS': {
-        const authenticated = await isAuthenticated();
-        sendResponse({ authenticated });
-        return;
-      }
-
-      case 'GET_TOKEN': {
-        const token = await getToken();
-        sendResponse({ token });
-        return;
-      }
-
-      case 'START_PAIRING': {
-        try {
-          const result = await startPairing();
-          sendResponse({ success: true, ...result });
-        } catch (error) {
-          sendResponse({
-            success: false,
-            error: error instanceof Error ? error.message : 'Unknown error',
-          });
-        }
-        return;
-      }
-
-      case 'POLL_FOR_TOKEN': {
-        const { deviceCode, interval, expiresIn } = data;
-        try {
-          await pollForDeviceToken(deviceCode, interval, expiresIn);
-          sendResponse({ success: true });
-        } catch (error) {
-          sendResponse({
-            success: false,
-            error: error instanceof Error ? error.message : 'Unknown error',
-          });
-        }
-        return;
-      }
-
-      case 'LOGOUT': {
-        await logout();
-        sendResponse({ success: true });
-        return;
-      }
+  switch (type) {
+    case 'GET_AUTH_STATUS': {
+      const authenticated = await isAuthenticated();
+      sendResponse({ authenticated });
+      return;
     }
-  },
-);
+
+    case 'GET_TOKEN': {
+      const token = await getToken();
+      sendResponse({ token });
+      return;
+    }
+
+    case 'START_PAIRING': {
+      try {
+        const result = await startPairing();
+        sendResponse({ success: true, ...result });
+      } catch (error) {
+        sendResponse({
+          success: false,
+          error: error instanceof Error ? error.message : 'Unknown error',
+        });
+      }
+      return;
+    }
+
+    case 'POLL_FOR_TOKEN': {
+      const { deviceCode, interval, expiresIn } = data;
+      try {
+        await pollForDeviceToken(deviceCode, interval, expiresIn);
+        sendResponse({ success: true });
+      } catch (error) {
+        sendResponse({
+          success: false,
+          error: error instanceof Error ? error.message : 'Unknown error',
+        });
+      }
+      return;
+    }
+
+    case 'LOGOUT': {
+      await logout();
+      sendResponse({ success: true });
+      return;
+    }
+  }
+});

--- a/apps/extension/src/background/auth.ts
+++ b/apps/extension/src/background/auth.ts
@@ -1,4 +1,8 @@
-import { getItems, removeItems, setItem } from 'core/universal/extension/storage';
+import {
+  getItems,
+  removeItems,
+  setItem,
+} from 'core/universal/extension/storage';
 import { hasuraConfig } from '../../envConfig';
 import { config } from '../../config';
 
@@ -37,7 +41,10 @@ const isAuthenticated = async (): Promise<boolean> => {
   return !isTokenExpired(token);
 };
 
-const startPairing = async (): Promise<{ userCode: string; verificationUri: string }> => {
+const startPairing = async (): Promise<{
+  userCode: string;
+  verificationUri: string;
+}> => {
   const extensionId = chrome.runtime.id;
 
   const response = await fetch(hasuraConfig.url, {
@@ -66,13 +73,17 @@ const startPairing = async (): Promise<{ userCode: string; verificationUri: stri
   const json = await response.json();
 
   if (json.errors) {
-    throw new Error(json.errors[0]?.message ?? 'Failed to create device request');
+    throw new Error(
+      json.errors[0]?.message ?? 'Failed to create device request',
+    );
   }
 
   const result = json.data?.createDeviceRequest;
 
   if (!result?.success || !result?.data) {
-    throw new Error(result?.error?.message ?? 'Failed to create device request');
+    throw new Error(
+      result?.error?.message ?? 'Failed to create device request',
+    );
   }
 
   return {
@@ -126,10 +137,4 @@ const logout = async (): Promise<void> => {
   await removeItems([AUTH_TOKEN_KEY]);
 };
 
-export {
-  getToken,
-  isAuthenticated,
-  startPairing,
-  pollForDeviceToken,
-  logout,
-};
+export { getToken, isAuthenticated, startPairing, pollForDeviceToken, logout };

--- a/apps/extension/src/background/auth.ts
+++ b/apps/extension/src/background/auth.ts
@@ -1,0 +1,135 @@
+import { getItems, removeItems, setItem } from 'core/universal/extension/storage';
+import { hasuraConfig } from '../../envConfig';
+import { config } from '../../config';
+
+const AUTH_TOKEN_KEY = 'auth0Token';
+
+const decodeJwtPayload = (token: string): Record<string, unknown> | null => {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) {
+      return null;
+    }
+    return JSON.parse(atob(parts[1]));
+  } catch {
+    return null;
+  }
+};
+
+const isTokenExpired = (token: string): boolean => {
+  const payload = decodeJwtPayload(token);
+  if (!payload || typeof payload.exp !== 'number') {
+    return true;
+  }
+  return Date.now() >= payload.exp * 1000;
+};
+
+const getToken = async (): Promise<string | null> => {
+  const result = await getItems([AUTH_TOKEN_KEY]);
+  return result[AUTH_TOKEN_KEY] ?? null;
+};
+
+const isAuthenticated = async (): Promise<boolean> => {
+  const token = await getToken();
+  if (!token) {
+    return false;
+  }
+  return !isTokenExpired(token);
+};
+
+const startPairing = async (): Promise<{ userCode: string; verificationUri: string }> => {
+  const extensionId = chrome.runtime.id;
+
+  const response = await fetch(hasuraConfig.url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      query: `
+        mutation CreateDeviceRequest($input: CreateDeviceRequestInput!) {
+          createDeviceRequest(input: $input) {
+            success
+            data {
+              userCode
+              verificationUri
+            }
+          }
+        }
+      `,
+      variables: {
+        input: {
+          extensionId,
+        },
+      },
+    }),
+  });
+
+  const json = await response.json();
+
+  if (json.errors) {
+    throw new Error(json.errors[0]?.message ?? 'Failed to create device request');
+  }
+
+  const result = json.data?.createDeviceRequest;
+
+  if (!result?.success || !result?.data) {
+    throw new Error(result?.error?.message ?? 'Failed to create device request');
+  }
+
+  return {
+    userCode: result.data.userCode,
+    verificationUri: result.data.verificationUri,
+  };
+};
+
+const pollForDeviceToken = async (
+  deviceCode: string,
+  interval: number,
+  expiresIn: number,
+): Promise<void> => {
+  const startTime = Date.now();
+  const timeout = expiresIn * 1000;
+
+  while (Date.now() - startTime < timeout) {
+    const response = await fetch(`${config.backendUrl}/auth/device/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ deviceCode }),
+    });
+
+    const json = await response.json();
+
+    if (json.token) {
+      await setItem(AUTH_TOKEN_KEY, json.token);
+      return;
+    }
+
+    if (json.error === 'authorization_pending') {
+      await new Promise((resolve) => setTimeout(resolve, interval * 1000));
+      continue;
+    }
+
+    if (json.error === 'access_denied') {
+      throw new Error('access_denied');
+    }
+
+    if (json.error === 'expired_token') {
+      throw new Error('expired_token');
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, interval * 1000));
+  }
+
+  throw new Error('expired_token');
+};
+
+const logout = async (): Promise<void> => {
+  await removeItems([AUTH_TOKEN_KEY]);
+};
+
+export {
+  getToken,
+  isAuthenticated,
+  startPairing,
+  pollForDeviceToken,
+  logout,
+};


### PR DESCRIPTION
## Summary

Adds `AuthManager` to the extension background script — handles the OAuth Device Flow lifecycle: requesting device codes (`startPairing`), polling for tokens (`pollForDeviceToken`), token storage/retrieval (`getToken`/`isAuthenticated`), and logout. Wired into the background message handler for popup communication. SWO-176.

## Test plan

- [ ] Extension pairs successfully against local backend
- [ ] Token persists across service worker restarts
- [ ] CI green