### PR TITLE
[WIP] feat(main): add /pair page for extension OAuth device flow

### DIFF
--- a/apps/main/src/components/PairPage.tsx
+++ b/apps/main/src/components/PairPage.tsx
@@ -1,0 +1,162 @@
+import { TypedDocumentString } from 'core/graphql/graphql';
+import { useAuthContext } from 'core/providers/auth';
+import { useMutationRequest } from 'core/universal/hooks/useMutation';
+import type React from 'react';
+import { useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Container,
+  TextField,
+  Typography,
+} from 'ui/universal/containers/generic';
+
+interface AuthorizeDeviceResponse {
+  authorizeDevice: {
+    success: boolean;
+    data?: {
+      success: boolean;
+    } | null;
+    error?: {
+      code: string;
+      message: string;
+    } | null;
+  };
+}
+
+interface AuthorizeDeviceVariables {
+  input: {
+    userCode: string;
+  };
+}
+
+const authorizeDeviceMutation = new TypedDocumentString<
+  AuthorizeDeviceResponse,
+  AuthorizeDeviceVariables
+>(`
+  mutation AuthorizeDevice($input: AuthorizeDeviceInput!) {
+    authorizeDevice(input: $input) {
+      success
+      data {
+        success
+      }
+      error {
+        code
+        message
+      }
+    }
+  }
+`);
+
+type PageState = 'input' | 'loading' | 'success' | 'error';
+
+const PairPage: React.FC = () => {
+  const { getAccessToken } = useAuthContext();
+  const [userCode, setUserCode] = useState('');
+  const [pageState, setPageState] = useState<PageState>('input');
+
+  const { mutateAsync: authorizeDevice } = useMutationRequest({
+    document: authorizeDeviceMutation,
+    getAccessToken,
+  });
+
+  const handleAuthorize = async () => {
+    if (!userCode.trim()) return;
+
+    setPageState('loading');
+
+    try {
+      const result = await authorizeDevice({
+        input: { userCode: userCode.trim() },
+      });
+
+      if (result.authorizeDevice.success) {
+        setPageState('success');
+      } else {
+        setPageState('error');
+      }
+    } catch {
+      setPageState('error');
+    }
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setUserCode(e.target.value);
+  };
+
+  return (
+    <Container maxWidth="sm">
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          minHeight: '100vh',
+          gap: 3,
+        }}
+      >
+        {pageState === 'success' ? (
+          <Alert severity="success" sx={{ width: '100%' }}>
+            Extension paired! You can close this page.
+          </Alert>
+        ) : pageState === 'error' ? (
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 2,
+              width: '100%',
+            }}
+          >
+            <Alert severity="error">
+              Invalid code. Please check and try again.
+            </Alert>
+            <Button
+              variant="outlined"
+              onClick={() => setPageState('input')}
+              fullWidth
+            >
+              Try again
+            </Button>
+          </Box>
+        ) : (
+          <>
+            <Typography variant="h5" component="h1" gutterBottom>
+              Pair Extension
+            </Typography>
+            <Typography variant="body1" color="text.secondary" align="center">
+              Enter the code shown in your browser extension to authorize it.
+            </Typography>
+            <TextField
+              fullWidth
+              label="User code"
+              placeholder="e.g. BIRD-123"
+              value={userCode}
+              onChange={handleChange}
+              disabled={pageState === 'loading'}
+              autoFocus
+            />
+            <Button
+              variant="contained"
+              onClick={handleAuthorize}
+              disabled={!userCode.trim() || pageState === 'loading'}
+              fullWidth
+              sx={{ py: 1.5 }}
+            >
+              {pageState === 'loading' ? (
+                <CircularProgress size={24} color="inherit" />
+              ) : (
+                'Authorize'
+              )}
+            </Button>
+          </>
+        )}
+      </Box>
+    </Container>
+  );
+};
+
+export { PairPage };

--- a/apps/main/src/routeTree.gen.ts
+++ b/apps/main/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Route as rootRouteImport } from './routes/__root'
 
+const PairLazyRouteImport = createFileRoute('/pair')()
 const FinanceLazyRouteImport = createFileRoute('/finance')()
 const IndexLazyRouteImport = createFileRoute('/')()
 const LibraryIndexLazyRouteImport = createFileRoute('/library/')()
@@ -21,6 +22,11 @@ const LibraryBooksBookIdLazyRouteImport = createFileRoute(
   '/library/books/$bookId',
 )()
 
+const PairLazyRoute = PairLazyRouteImport.update({
+  id: '/pair',
+  path: '/pair',
+  getParentRoute: () => rootRouteImport,
+} as any).lazy(() => import('./routes/pair.lazy').then((d) => d.Route))
 const FinanceLazyRoute = FinanceLazyRouteImport.update({
   id: '/finance',
   path: '/finance',
@@ -57,6 +63,7 @@ const LibraryBooksBookIdLazyRoute = LibraryBooksBookIdLazyRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexLazyRoute
   '/finance': typeof FinanceLazyRoute
+  '/pair': typeof PairLazyRoute
   '/journal/$date': typeof JournalDateLazyRoute
   '/journal/': typeof JournalIndexLazyRoute
   '/library/': typeof LibraryIndexLazyRoute
@@ -65,6 +72,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexLazyRoute
   '/finance': typeof FinanceLazyRoute
+  '/pair': typeof PairLazyRoute
   '/journal/$date': typeof JournalDateLazyRoute
   '/journal': typeof JournalIndexLazyRoute
   '/library': typeof LibraryIndexLazyRoute
@@ -74,6 +82,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexLazyRoute
   '/finance': typeof FinanceLazyRoute
+  '/pair': typeof PairLazyRoute
   '/journal/$date': typeof JournalDateLazyRoute
   '/journal/': typeof JournalIndexLazyRoute
   '/library/': typeof LibraryIndexLazyRoute
@@ -84,6 +93,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/finance'
+    | '/pair'
     | '/journal/$date'
     | '/journal/'
     | '/library/'
@@ -92,6 +102,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/finance'
+    | '/pair'
     | '/journal/$date'
     | '/journal'
     | '/library'
@@ -100,6 +111,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/finance'
+    | '/pair'
     | '/journal/$date'
     | '/journal/'
     | '/library/'
@@ -109,6 +121,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexLazyRoute: typeof IndexLazyRoute
   FinanceLazyRoute: typeof FinanceLazyRoute
+  PairLazyRoute: typeof PairLazyRoute
   JournalDateLazyRoute: typeof JournalDateLazyRoute
   JournalIndexLazyRoute: typeof JournalIndexLazyRoute
   LibraryIndexLazyRoute: typeof LibraryIndexLazyRoute
@@ -117,6 +130,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/pair': {
+      id: '/pair'
+      path: '/pair'
+      fullPath: '/pair'
+      preLoaderRoute: typeof PairLazyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/finance': {
       id: '/finance'
       path: '/finance'
@@ -165,6 +185,7 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexLazyRoute: IndexLazyRoute,
   FinanceLazyRoute: FinanceLazyRoute,
+  PairLazyRoute: PairLazyRoute,
   JournalDateLazyRoute: JournalDateLazyRoute,
   JournalIndexLazyRoute: JournalIndexLazyRoute,
   LibraryIndexLazyRoute: LibraryIndexLazyRoute,

--- a/apps/main/src/routes/pair.lazy.tsx
+++ b/apps/main/src/routes/pair.lazy.tsx
@@ -1,0 +1,15 @@
+import { createLazyFileRoute } from '@tanstack/react-router';
+import { AuthRoute } from 'ui/universal/authRoute';
+import { PairPage } from '../components/PairPage';
+
+const PairRoute = () => {
+  return (
+    <AuthRoute>
+      <PairPage />
+    </AuthRoute>
+  );
+};
+
+export const Route = createLazyFileRoute('/pair')({
+  component: PairRoute,
+});

--- a/packages/ui/src/universal/containers/generic/index.tsx
+++ b/packages/ui/src/universal/containers/generic/index.tsx
@@ -1,6 +1,19 @@
+import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
 import Container from '@mui/material/Container';
 import Grid from '@mui/material/Grid';
+import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 
-export { Box, Grid, Typography, Container };
+export {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Container,
+  Grid,
+  TextField,
+  Typography,
+};


### PR DESCRIPTION
## Summary

Adds a `/pair` route where users enter their extension's user code and authorize it. Uses the `authorizeDevice` Hasura action. Shows loading, success, and error states. SWO-177.

## Test plan

- [ ] Navigate to `/pair`, enter a valid user code, click Authorize → success
- [ ] Enter an invalid code → error message with retry
- [ ] CI green