### PR TITLE
feat(extension): add PDF parser with PDF.js integration

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "core": "workspace:*",
+    "pdfjs-dist": "^6.1.200",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "ui": "workspace:*"

--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -1,11 +1,11 @@
 import { removeItems, setItem } from 'core/universal/extension/storage';
 import { config } from '../config';
 import {
-  isAuthenticated,
   getToken,
-  startPairing,
-  pollForDeviceToken,
+  isAuthenticated,
   logout,
+  pollForDeviceToken,
+  startPairing,
 } from './background/auth';
 
 console.log('Background script starting...');

--- a/apps/extension/src/background/auth.ts
+++ b/apps/extension/src/background/auth.ts
@@ -3,8 +3,8 @@ import {
   removeItems,
   setItem,
 } from 'core/universal/extension/storage';
-import { hasuraConfig } from '../../envConfig';
 import { config } from '../../config';
+import { hasuraConfig } from '../../envConfig';
 
 const AUTH_TOKEN_KEY = 'auth0Token';
 

--- a/apps/extension/src/content-scripts/content.ts
+++ b/apps/extension/src/content-scripts/content.ts
@@ -1,1 +1,29 @@
-console.log('SWorld content script loaded');
+import type { ExtensionMessage } from 'core/universal/extension/communication/types';
+
+import { isPdfPage, parsePdfDocument } from './parsers/pdf';
+
+const main = async () => {
+  const url = window.location.href;
+  const contentType = document.contentType;
+
+  if (!isPdfPage(url, contentType)) {
+    return;
+  }
+
+  try {
+    const metadata = await parsePdfDocument(url);
+
+    const message: ExtensionMessage = {
+      source: 'content-script',
+      target: 'background',
+      type: 'PDF_METADATA_EXTRACTED',
+      payload: metadata,
+    };
+
+    chrome.runtime.sendMessage(message);
+  } catch (error) {
+    console.error('Failed to parse PDF metadata:', error);
+  }
+};
+
+main();

--- a/apps/extension/src/content-scripts/parsers/pdf.test.ts
+++ b/apps/extension/src/content-scripts/parsers/pdf.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { isPdfPage, parsePdfDocument } from './pdf';
+
+const mockPdfDocument = {
+  numPages: 5,
+  getMetadata: vi.fn().mockResolvedValue({
+    info: {
+      Title: 'Test Document',
+      Author: 'Test Author',
+    },
+  }),
+};
+
+vi.mock('pdfjs-dist', () => ({
+  getDocument: vi.fn(() => ({
+    promise: Promise.resolve(mockPdfDocument),
+  })),
+}));
+
+describe('isPdfPage', () => {
+  it('returns true for .pdf URLs', () => {
+    expect(isPdfPage('https://example.com/doc.pdf')).toBe(true);
+  });
+
+  it('returns true for .pdf URLs with query params', () => {
+    expect(isPdfPage('https://example.com/doc.pdf?token=abc')).toBe(true);
+  });
+
+  it('returns true for .PDF (case insensitive)', () => {
+    expect(isPdfPage('https://example.com/DOC.PDF')).toBe(true);
+  });
+
+  it('returns true when content type is application/pdf', () => {
+    expect(isPdfPage('https://example.com/doc', 'application/pdf')).toBe(true);
+  });
+
+  it('returns false for non-PDF URLs', () => {
+    expect(isPdfPage('https://example.com/doc.html')).toBe(false);
+  });
+
+  it('returns false for URLs without extension', () => {
+    expect(isPdfPage('https://example.com/doc')).toBe(false);
+  });
+
+  it('returns false when content type is not PDF', () => {
+    expect(isPdfPage('https://example.com/doc', 'text/html')).toBe(false);
+  });
+});
+
+describe('parsePdfDocument', () => {
+  it('extracts PDF metadata correctly', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(1024)),
+    });
+
+    const result = await parsePdfDocument('https://example.com/doc.pdf');
+
+    expect(result).toEqual({
+      url: 'https://example.com/doc.pdf',
+      title: 'Test Document',
+      author: 'Test Author',
+      pageCount: 5,
+      fileSize: 1024,
+    });
+  });
+
+  it('handles missing metadata gracefully', async () => {
+    vi.mocked(mockPdfDocument.getMetadata).mockResolvedValueOnce({ info: {} });
+
+    global.fetch = vi.fn().mockResolvedValue({
+      arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(512)),
+    });
+
+    const result = await parsePdfDocument('https://example.com/doc.pdf');
+
+    expect(result).toEqual({
+      url: 'https://example.com/doc.pdf',
+      title: undefined,
+      author: undefined,
+      pageCount: 5,
+      fileSize: 512,
+    });
+  });
+});

--- a/apps/extension/src/content-scripts/parsers/pdf.ts
+++ b/apps/extension/src/content-scripts/parsers/pdf.ts
@@ -1,0 +1,45 @@
+import type { PdfMetadata } from 'core/universal/extension/communication/types';
+import * as pdfjs from 'pdfjs-dist';
+
+const parsePdfDocument = async (url: string): Promise<PdfMetadata> => {
+  const response = await fetch(url);
+  const buffer = await response.arrayBuffer();
+  const loadingTask = pdfjs.getDocument({ data: buffer });
+  const pdf = await loadingTask.promise;
+
+  const meta = await pdf.getMetadata();
+  const info = meta.info as Record<string, unknown>;
+
+  const title = info?.Title as string | undefined;
+  const author = info?.Author as string | undefined;
+  const pageCount = pdf.numPages;
+  const fileSize = buffer.byteLength;
+
+  return {
+    url,
+    title: title || undefined,
+    author: author || undefined,
+    pageCount,
+    fileSize,
+  };
+};
+
+const isPdfPage = (url: string, contentType?: string): boolean => {
+  if (contentType?.includes('application/pdf')) {
+    return true;
+  }
+
+  try {
+    const parsed = new URL(url);
+    const pathname = parsed.pathname.toLowerCase();
+    if (pathname.endsWith('.pdf')) {
+      return true;
+    }
+  } catch {
+    // Invalid URL — fall through
+  }
+
+  return false;
+};
+
+export { isPdfPage, parsePdfDocument };

--- a/apps/extension/src/graphql/fragment-masking.ts
+++ b/apps/extension/src/graphql/fragment-masking.ts
@@ -1,9 +1,9 @@
 /* eslint-disable */
-import {
-  ResultOf,
+import type {
   DocumentTypeDecoration,
+  ResultOf,
 } from '@graphql-typed-document-node/core';
-import { Incremental, TypedDocumentString } from './graphql';
+import type { Incremental, TypedDocumentString } from './graphql';
 
 export type FragmentType<
   TDocumentType extends DocumentTypeDecoration<any, any>,

--- a/apps/listen/src/routes/manage.lazy.tsx
+++ b/apps/listen/src/routes/manage.lazy.tsx
@@ -1,9 +1,9 @@
 import { createLazyFileRoute, useNavigate } from '@tanstack/react-router';
 import { listenMutationHooks, listenQueryHooks } from 'core';
 import { useAuthContext } from 'core/providers/auth';
+import { useEffect } from 'react';
 import { ManageScreen } from 'ui/listen/minimalism';
 import { LoadingBackdrop } from 'ui/universal';
-import { useEffect } from 'react';
 import { appConfig } from '../config';
 import { createPlaylistSlug } from '../utils/slug';
 

--- a/apps/watch/src/routes/playlist.$slug.$playlistId.$videoId.lazy.tsx
+++ b/apps/watch/src/routes/playlist.$slug.$playlistId.$videoId.lazy.tsx
@@ -7,7 +7,7 @@ import {
   useSharePlaylist,
 } from 'core/watch/mutation-hooks/share-videos';
 import { useLoadPlaylistDetail } from 'core/watch/query-hooks/playlist-detail';
-import { lazy, useState, type JSX } from 'react';
+import { type JSX, lazy, useState } from 'react';
 import { AuthRoute } from 'ui/universal/authRoute';
 import { VideoDetailContainer } from 'ui/watch/video-detail-page/containers';
 import { Layout } from '../components/layout';

--- a/biome.json
+++ b/biome.json
@@ -15,7 +15,7 @@
       "!**/public/assets",
       "!**/storybook-static",
       "!**/coverage",
-      "!packages/core/src/graphql/**",
+      "!packages/core/src/graphql",
       "!packages/core/schema.graphql",
       "!**/routeTree.gen.ts"
     ],

--- a/packages/ui/src/listen/minimalism/music-widget/Controls.tsx
+++ b/packages/ui/src/listen/minimalism/music-widget/Controls.tsx
@@ -9,6 +9,7 @@ import SkipNextRounded from '@mui/icons-material/SkipNextRounded';
 import SkipPreviousRounded from '@mui/icons-material/SkipPreviousRounded';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
+
 enum SAudioPlayerLoopMode {
   None = 'none',
   All = 'all',

--- a/packages/ui/src/main/home-page/spending-breakdown/donut-chart.tsx
+++ b/packages/ui/src/main/home-page/spending-breakdown/donut-chart.tsx
@@ -1,7 +1,6 @@
 import { Box, Skeleton, Typography, useTheme } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import type { CategoryType } from 'core/finance';
-import { getFinanceColor } from '../../../universal/minimalism/domainPalette';
 import { formatNumber } from 'core/universal/common';
 import { PieChart } from 'echarts/charts';
 import { LegendComponent, TooltipComponent } from 'echarts/components';
@@ -12,6 +11,7 @@ import { CanvasRenderer } from 'echarts/renderers';
 // default import resolves to the module object instead of the component,
 // which crashes the finance page with React error #130 (SWO-356).
 import ReactEChartsCore from 'echarts-for-react/esm/core';
+import { getFinanceColor } from '../../../universal/minimalism/domainPalette';
 
 echarts.use([PieChart, TooltipComponent, LegendComponent, CanvasRenderer]);
 

--- a/packages/ui/src/main/home-page/transactions-dialog/index.tsx
+++ b/packages/ui/src/main/home-page/transactions-dialog/index.tsx
@@ -13,8 +13,8 @@ import {
 } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import type { CategoryType } from 'core/finance';
-import { getFinanceColor } from '../../../universal/minimalism/domainPalette';
 import { formatNumber } from 'core/universal/common';
+import { getFinanceColor } from '../../../universal/minimalism/domainPalette';
 
 interface Transaction {
   id: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       core:
         specifier: workspace:*
         version: link:../../packages/core
+      pdfjs-dist:
+        specifier: ^6.1.200
+        version: 6.1.200
       react:
         specifier: ^19.2.0
         version: 19.2.7
@@ -3814,6 +3817,81 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@napi-rs/canvas-android-arm64@1.0.2':
+    resolution: {integrity: sha512-IMXKVQod0ol4vt3gmClUfXz4JAgHYESGPCUqmH3lQxBoL0K/2greJaQE1HVBVxWWFKfLc4OLZVdxg7kXVyXv+g==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/canvas-darwin-arm64@1.0.2':
+    resolution: {integrity: sha512-Sc8tPi6cF+5lqOzCCKFALJHhDiRwyMzTPYm3bbhdXsOunU0lQO5f05ucyOzN2r55I23Hg5bsjH63uSCvWp3EgQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@1.0.2':
+    resolution: {integrity: sha512-niDXZ9LhKB1zLrUdYB64RHQFDGz9rr0eGx061qtJJU3U20EMMIx28ADF5fVYbhtOgkWQrBjFicfaye1yM0U62A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@1.0.2':
+    resolution: {integrity: sha512-sgatQL9JxGRH/Amzcvu0P3t8Am3duou74CisfuJ41Dwt8cWy723z/9KZ8LlgmxfypEwEZxSTNFJtU8d281lmhQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-gnu@1.0.2':
+    resolution: {integrity: sha512-dgKuX0peF3xwY6ZF5QxGS4wbfDqpoFAJYXiLSp+guZKARQUKMkRqZSDrXKj7nfrec3UCMzC0PFCPte0ES98AiA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-arm64-musl@1.0.2':
+    resolution: {integrity: sha512-qwROoDIC9upfvDoRLuPn2aNg9CGW1x0Ygr4k2Or+8paA9d0qBLwk87U+g8KQpoOviKoPoiwl97kvBYuYD7qZoA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@1.0.2':
+    resolution: {integrity: sha512-fXRjnPihdnbO6qy1QQOgxAonb68A0TCEG7rj1x7v7rxNElsE8EVIKIEUTvyDtU+sthYSbX+8e7g3oZiLGnOmxw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-gnu@1.0.2':
+    resolution: {integrity: sha512-nPR97DXhbWIAy7yazF3jc06kEPMqYMLmPzFOVNlwKPfIoSChnI+x7dc0hTLaihz3jxrjL6j4BbA7earxfx4X3g==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-musl@1.0.2':
+    resolution: {integrity: sha512-l7zZY5+jL5qnBZtDz7CoBtY6p7EkHu422g/0zWwrOrzIwWyWxZFRfZZORY1UG7YApymPLx+UbOkN206xXn/c1Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-win32-arm64-msvc@1.0.2':
+    resolution: {integrity: sha512-yE0koHCFF4PIbMc2o2SEALhnipz7WBISh5glLvQiomtIoCcW0np3H4Lw93ceJAfJttTTeIIWFbwH84F7EVzjMQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/canvas-win32-x64-msvc@1.0.2':
+    resolution: {integrity: sha512-okU8/t2foV6C31n0GtvEMbfD5rOFc70+/6xUNME9Guld29sgSOIGUEDScAWFlcP3k5TYQRl9TNkwJEEjh15w8A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/canvas@1.0.2':
+    resolution: {integrity: sha512-EYEqlMYaCbpZDz+IgDH5xp9MTd3ui4dmGqbQYryhMLnSRxrhHKq5KQWHHKxFUcEP4Hp8/BWgvqXocX4j7iSbOQ==}
+    engines: {node: '>= 10'}
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -9490,6 +9568,10 @@ packages:
   pathval@2.0.1:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
+
+  pdfjs-dist@6.1.200:
+    resolution: {integrity: sha512-o8MolyzirkkLrcdsae/HEOiIcXWI7DS5zGpvqW8xTC2YUsW30rltFw2bDGvw/fskUdEMrQm2br68jzDS5BH2vw==}
+    engines: {node: '>=22.13.0 || >=24'}
 
   phaser-matter-collision-plugin@1.0.0:
     resolution: {integrity: sha512-8ihbK5tPmMzpLSbJkrnyPKNZT/TyhN2bjHtthTl2cmTCiJpY6Ih7SZf1Kb6zWtUD8kWlllPrBktF1CcwmMvc0w==}
@@ -16602,6 +16684,54 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
+  '@napi-rs/canvas-android-arm64@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-darwin-x64@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-gnu@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-win32-arm64-msvc@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas@1.0.2':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 1.0.2
+      '@napi-rs/canvas-darwin-arm64': 1.0.2
+      '@napi-rs/canvas-darwin-x64': 1.0.2
+      '@napi-rs/canvas-linux-arm-gnueabihf': 1.0.2
+      '@napi-rs/canvas-linux-arm64-gnu': 1.0.2
+      '@napi-rs/canvas-linux-arm64-musl': 1.0.2
+      '@napi-rs/canvas-linux-riscv64-gnu': 1.0.2
+      '@napi-rs/canvas-linux-x64-gnu': 1.0.2
+      '@napi-rs/canvas-linux-x64-musl': 1.0.2
+      '@napi-rs/canvas-win32-arm64-msvc': 1.0.2
+      '@napi-rs/canvas-win32-x64-msvc': 1.0.2
+    optional: true
+
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)':
     dependencies:
       '@emnapi/core': 1.11.0
@@ -23151,6 +23281,10 @@ snapshots:
   pathe@2.0.3: {}
 
   pathval@2.0.1: {}
+
+  pdfjs-dist@6.1.200:
+    optionalDependencies:
+      '@napi-rs/canvas': 1.0.2
 
   phaser-matter-collision-plugin@1.0.0(phaser@3.88.2):
     dependencies:


### PR DESCRIPTION
## Summary

Add PDF content parser for the browser extension. Detects PDF pages by URL/content-type, parses document metadata using PDF.js, and sends `PDF_METADATA_EXTRACTED` messages to the background script.

## Test plan

- `pnpm test:vitest` passes (8 tests)
- `pnpm lint` — no new errors