### PR TITLE
feat(extension): add video platform detectors and page type detector

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "lint": "biome lint --quit-on-problem .",
     "format": "biome format --write .",
+    "test": "vitest",
     "codegen": "dotenvx run -- graphql-codegen --config codegen.ts"
   },
   "dependencies": {
@@ -22,7 +23,9 @@
     "@graphql-codegen/cli": "^5.0.3",
     "@types/chrome": "^0.0.268",
     "@vitejs/plugin-react": "^6.0.3",
+    "jsdom": "^25.0.1",
     "typescript": "^5.6.2",
-    "vite": "^8.1.2"
+    "vite": "^8.1.2",
+    "vitest": "^4.1.9"
   }
 }

--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -1,11 +1,11 @@
 import { removeItems, setItem } from 'core/universal/extension/storage';
 import { config } from '../config';
 import {
-  isAuthenticated,
   getToken,
-  startPairing,
-  pollForDeviceToken,
+  isAuthenticated,
   logout,
+  pollForDeviceToken,
+  startPairing,
 } from './background/auth';
 
 console.log('Background script starting...');

--- a/apps/extension/src/background/auth.ts
+++ b/apps/extension/src/background/auth.ts
@@ -3,8 +3,8 @@ import {
   removeItems,
   setItem,
 } from 'core/universal/extension/storage';
-import { hasuraConfig } from '../../envConfig';
 import { config } from '../../config';
+import { hasuraConfig } from '../../envConfig';
 
 const AUTH_TOKEN_KEY = 'auth0Token';
 

--- a/apps/extension/src/content-scripts/parsers/detector.test.ts
+++ b/apps/extension/src/content-scripts/parsers/detector.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { detect, detectPageType, hasVideoElement } from './detector';
+
+describe('detectPageType', () => {
+  it('should detect youtube from /watch URL', () => {
+    expect(detectPageType('https://youtube.com/watch?v=abc')).toBe('youtube');
+  });
+
+  it('should detect youtube from youtu.be URL', () => {
+    expect(detectPageType('https://youtu.be/abc')).toBe('youtube');
+  });
+
+  it('should detect vimeo URL', () => {
+    expect(detectPageType('https://vimeo.com/12345')).toBe('vimeo');
+  });
+
+  it('should detect PDF URL', () => {
+    expect(detectPageType('https://example.com/doc.pdf')).toBe('pdf');
+  });
+
+  it('should default to webpage', () => {
+    expect(detectPageType('https://example.com')).toBe('webpage');
+  });
+
+  it('should return unknown for undefined URL', () => {
+    expect(detectPageType(undefined)).toBe('unknown');
+  });
+});
+
+describe('hasVideoElement', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('should return true when video element exists', () => {
+    const video = document.createElement('video');
+    document.body.appendChild(video);
+    expect(hasVideoElement()).toBe(true);
+  });
+
+  it('should return false when no video element', () => {
+    expect(hasVideoElement()).toBe(false);
+  });
+});
+
+describe('detect', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    document.head.innerHTML = '';
+  });
+
+  it('should return youtube type with metadata for youtube URL', () => {
+    const result = detect('https://youtube.com/watch?v=abc');
+    expect(result.pageType).toBe('youtube');
+    expect(result.content).not.toBeNull();
+    if (result.content && 'platform' in result.content) {
+      expect(result.content.platform).toBe('youtube');
+    }
+  });
+
+  it('should return vimeo type with metadata for vimeo URL', () => {
+    const result = detect('https://vimeo.com/12345');
+    expect(result.pageType).toBe('vimeo');
+    expect(result.content).not.toBeNull();
+    if (result.content && 'platform' in result.content) {
+      expect(result.content.platform).toBe('vimeo');
+    }
+  });
+
+  it('should return pdf type for PDF URL', () => {
+    const result = detect('https://example.com/doc.pdf');
+    expect(result.pageType).toBe('pdf');
+    expect(result.content).toBeNull();
+  });
+
+  it('should return video-generic when video element exists', () => {
+    const video = document.createElement('video');
+    document.body.appendChild(video);
+    const result = detect('https://example.com');
+    expect(result.pageType).toBe('video-generic');
+    expect(result.content).toBeNull();
+  });
+
+  it('should return webpage type for regular URL', () => {
+    const result = detect('https://example.com');
+    expect(result.pageType).toBe('webpage');
+    expect(result.content).toBeNull();
+  });
+});

--- a/apps/extension/src/content-scripts/parsers/detector.ts
+++ b/apps/extension/src/content-scripts/parsers/detector.ts
@@ -1,4 +1,8 @@
-import type { PageContent, PageType, VideoMetadata } from 'core/universal/extension/communication/types';
+import type {
+  PageContent,
+  PageType,
+  VideoMetadata,
+} from 'core/universal/extension/communication/types';
 import { extractYouTubeMetadata } from './youtube';
 import { extractVimeoMetadata } from './vimeo';
 

--- a/apps/extension/src/content-scripts/parsers/detector.ts
+++ b/apps/extension/src/content-scripts/parsers/detector.ts
@@ -3,8 +3,8 @@ import type {
   PageType,
   VideoMetadata,
 } from 'core/universal/extension/communication/types';
-import { extractYouTubeMetadata } from './youtube';
 import { extractVimeoMetadata } from './vimeo';
+import { extractYouTubeMetadata } from './youtube';
 
 const YOUTUBE_RE = /^(https?:\/\/)?(www\.)?(youtube\.com\/watch|youtu\.be\/)/;
 const VIMEO_RE = /^(https?:\/\/)?(www\.)?vimeo\.com\//;

--- a/apps/extension/src/content-scripts/parsers/detector.ts
+++ b/apps/extension/src/content-scripts/parsers/detector.ts
@@ -1,0 +1,48 @@
+import type { PageContent, PageType, VideoMetadata } from 'core/universal/extension/communication/types';
+import { extractYouTubeMetadata } from './youtube';
+import { extractVimeoMetadata } from './vimeo';
+
+const YOUTUBE_RE = /^(https?:\/\/)?(www\.)?(youtube\.com\/watch|youtu\.be\/)/;
+const VIMEO_RE = /^(https?:\/\/)?(www\.)?vimeo\.com\//;
+const PDF_URL_RE = /\.pdf$/i;
+
+const detectPageType = (url?: string): PageType => {
+  if (!url) return 'unknown';
+  if (YOUTUBE_RE.test(url)) return 'youtube';
+  if (VIMEO_RE.test(url)) return 'vimeo';
+  if (PDF_URL_RE.test(url)) return 'pdf';
+  return 'webpage';
+};
+
+const hasVideoElement = (): boolean => {
+  if (typeof document === 'undefined') return false;
+  return document.querySelector('video') !== null;
+};
+
+type DetectResult = {
+  pageType: PageType;
+  content: PageContent | VideoMetadata | null;
+};
+
+const detect = (url?: string): DetectResult => {
+  const pageType = detectPageType(url);
+
+  if (pageType === 'youtube') {
+    const metadata = extractYouTubeMetadata();
+    return { pageType, content: metadata };
+  }
+
+  if (pageType === 'vimeo') {
+    const metadata = extractVimeoMetadata();
+    return { pageType, content: metadata };
+  }
+
+  if (hasVideoElement()) {
+    return { pageType: 'video-generic', content: null };
+  }
+
+  return { pageType, content: null };
+};
+
+export type { DetectResult };
+export { detect, detectPageType, hasVideoElement };

--- a/apps/extension/src/content-scripts/parsers/vimeo.ts
+++ b/apps/extension/src/content-scripts/parsers/vimeo.ts
@@ -1,0 +1,42 @@
+import type { VideoMetadata } from 'core/universal/extension/communication/types';
+
+const VIMEO_VIDEO_RE = /^\/+(\d+)\/?/;
+
+const getMetaContent = (property: string): string | undefined => {
+  if (typeof document === 'undefined') return undefined;
+  const el =
+    document.querySelector(`meta[property="${property}"]`) ||
+    document.querySelector(`meta[name="${property}"]`);
+  return el?.getAttribute('content') ?? undefined;
+};
+
+const getVideoId = (): string | undefined => {
+  if (typeof document === 'undefined') return undefined;
+  const pathname = window.location.pathname;
+  const match = pathname.match(VIMEO_VIDEO_RE);
+  return match?.[1] ?? undefined;
+};
+
+const extractVimeoMetadata = (): VideoMetadata => {
+  if (typeof document === 'undefined') {
+    return { url: '', platform: 'vimeo' };
+  }
+
+  const videoId = getVideoId();
+  const ogTitle = getMetaContent('og:title');
+  const docTitle = document.title?.replace(/ - Vimeo$/, '');
+  const title = ogTitle || docTitle || undefined;
+  const ogImage = getMetaContent('og:image');
+  const thumbnailUrl = ogImage || undefined;
+  const videoUrl = window.location.href;
+
+  return {
+    url: videoUrl,
+    title,
+    platform: 'vimeo',
+    videoId,
+    thumbnailUrl,
+  };
+};
+
+export { extractVimeoMetadata, getVideoId };

--- a/apps/extension/src/content-scripts/parsers/youtube.test.ts
+++ b/apps/extension/src/content-scripts/parsers/youtube.test.ts
@@ -54,6 +54,14 @@ describe('getVideoId', () => {
     expect(getVideoId()).toBe('dQw4w9WgXcQ');
   });
 
+  it('should extract video id from youtu.be short URL', () => {
+    Object.defineProperty(window, 'location', {
+      value: new URL('https://youtu.be/dQw4w9WgXcQ'),
+      writable: true,
+    });
+    expect(getVideoId()).toBe('dQw4w9WgXcQ');
+  });
+
   it('should return undefined for non-video path', () => {
     Object.defineProperty(window, 'location', {
       value: new URL('https://youtube.com/feed'),

--- a/apps/extension/src/content-scripts/parsers/youtube.test.ts
+++ b/apps/extension/src/content-scripts/parsers/youtube.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractYouTubeMetadata,
+  getMetaContent,
+  getVideoId,
+  parseDuration,
+} from './youtube';
+
+describe('parseDuration', () => {
+  it('should parse full duration', () => {
+    expect(parseDuration('PT1H2M30S')).toBe(3750);
+  });
+
+  it('should parse minutes and seconds', () => {
+    expect(parseDuration('PT5M30S')).toBe(330);
+  });
+
+  it('should parse only seconds', () => {
+    expect(parseDuration('PT45S')).toBe(45);
+  });
+
+  it('should parse only hours', () => {
+    expect(parseDuration('PT2H')).toBe(7200);
+  });
+
+  it('should return undefined for invalid format', () => {
+    expect(parseDuration('invalid')).toBeUndefined();
+  });
+});
+
+describe('getVideoId', () => {
+  const originalLocation = window.location;
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+    });
+  });
+
+  it('should extract video id from /watch path', () => {
+    Object.defineProperty(window, 'location', {
+      value: new URL('https://youtube.com/watch?v=dQw4w9WgXcQ'),
+      writable: true,
+    });
+    expect(getVideoId()).toBe('dQw4w9WgXcQ');
+  });
+
+  it('should extract video id from /embed path', () => {
+    Object.defineProperty(window, 'location', {
+      value: new URL('https://youtube.com/embed/dQw4w9WgXcQ'),
+      writable: true,
+    });
+    expect(getVideoId()).toBe('dQw4w9WgXcQ');
+  });
+
+  it('should return undefined for non-video path', () => {
+    Object.defineProperty(window, 'location', {
+      value: new URL('https://youtube.com/feed'),
+      writable: true,
+    });
+    expect(getVideoId()).toBeUndefined();
+  });
+});
+
+describe('getMetaContent', () => {
+  beforeEach(() => {
+    document.head.innerHTML = '';
+  });
+
+  it('should get meta content by property', () => {
+    const meta = document.createElement('meta');
+    meta.setAttribute('property', 'og:title');
+    meta.setAttribute('content', 'Test Title');
+    document.head.appendChild(meta);
+
+    expect(getMetaContent('og:title')).toBe('Test Title');
+  });
+
+  it('should get meta content by name', () => {
+    const meta = document.createElement('meta');
+    meta.setAttribute('name', 'description');
+    meta.setAttribute('content', 'Test Description');
+    document.head.appendChild(meta);
+
+    expect(getMetaContent('description')).toBe('Test Description');
+  });
+
+  it('should return undefined when meta not found', () => {
+    expect(getMetaContent('og:title')).toBeUndefined();
+  });
+});
+
+describe('extractYouTubeMetadata', () => {
+  beforeEach(() => {
+    document.head.innerHTML = '';
+  });
+
+  it('should return correct url', () => {
+    const metadata = extractYouTubeMetadata();
+    expect(metadata.url).toBe(window.location.href);
+  });
+
+  it('should set platform to youtube', () => {
+    const metadata = extractYouTubeMetadata();
+    expect(metadata.platform).toBe('youtube');
+  });
+
+  it('should extract title from og:title', () => {
+    const meta = document.createElement('meta');
+    meta.setAttribute('property', 'og:title');
+    meta.setAttribute('content', 'Video Title');
+    document.head.appendChild(meta);
+
+    const metadata = extractYouTubeMetadata();
+    expect(metadata.title).toBe('Video Title');
+  });
+
+  it('should extract thumbnail from og:image', () => {
+    const meta = document.createElement('meta');
+    meta.setAttribute('property', 'og:image');
+    meta.setAttribute('content', 'https://example.com/thumb.jpg');
+    document.head.appendChild(meta);
+
+    const metadata = extractYouTubeMetadata();
+    expect(metadata.thumbnailUrl).toBe('https://example.com/thumb.jpg');
+  });
+
+  it('should construct thumbnail from video id when og:image absent', () => {
+    Object.defineProperty(window, 'location', {
+      value: new URL('https://youtube.com/watch?v=dQw4w9WgXcQ'),
+      writable: true,
+    });
+
+    const metadata = extractYouTubeMetadata();
+    expect(metadata.thumbnailUrl).toBe(
+      'https://img.youtube.com/vi/dQw4w9WgXcQ/maxresdefault.jpg',
+    );
+  });
+
+  it('should extract duration', () => {
+    const meta = document.createElement('meta');
+    meta.setAttribute('itemprop', 'duration');
+    meta.setAttribute('content', 'PT5M30S');
+    document.head.appendChild(meta);
+
+    const metadata = extractYouTubeMetadata();
+    expect(metadata.duration).toBe(330);
+  });
+});

--- a/apps/extension/src/content-scripts/parsers/youtube.ts
+++ b/apps/extension/src/content-scripts/parsers/youtube.ts
@@ -1,0 +1,62 @@
+import type { VideoMetadata } from 'core/universal/extension/communication/types';
+
+const ISO_8601_DURATION_RE = /^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?$/;
+
+const parseDuration = (isoDuration: string): number | undefined => {
+  const match = isoDuration.match(ISO_8601_DURATION_RE);
+  if (!match) return undefined;
+  const hours = Number.parseInt(match[1] || '0', 10);
+  const minutes = Number.parseInt(match[2] || '0', 10);
+  const seconds = Number.parseInt(match[3] || '0', 10);
+  return hours * 3600 + minutes * 60 + seconds;
+};
+
+const getMetaContent = (property: string): string | undefined => {
+  if (typeof document === 'undefined') return undefined;
+  const el =
+    document.querySelector(`meta[property="${property}"]`) ||
+    document.querySelector(`meta[name="${property}"]`) ||
+    document.querySelector(`meta[itemprop="${property}"]`);
+  return el?.getAttribute('content') ?? undefined;
+};
+
+const getVideoId = (): string | undefined => {
+  if (typeof document === 'undefined') return undefined;
+  const pathname = window.location.pathname;
+  if (pathname === '/watch') {
+    const urlParams = new URLSearchParams(window.location.search);
+    return urlParams.get('v') ?? undefined;
+  }
+  if (pathname.startsWith('/embed/')) {
+    return pathname.split('/')[2];
+  }
+  return undefined;
+};
+
+const extractYouTubeMetadata = (): VideoMetadata => {
+  if (typeof document === 'undefined') {
+    return { url: '', platform: 'youtube' };
+  }
+
+  const videoId = getVideoId();
+  const ogTitle = getMetaContent('og:title');
+  const docTitle = document.title?.replace(/ - YouTube$/, '');
+  const title = ogTitle || docTitle || undefined;
+  const durationIso = getMetaContent('duration');
+  const durationSeconds = durationIso ? parseDuration(durationIso) : undefined;
+  const ogImage = getMetaContent('og:image');
+  const thumbnailUrl =
+    ogImage || (videoId ? `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg` : undefined);
+  const videoUrl = window.location.href;
+
+  return {
+    url: videoUrl,
+    title,
+    platform: 'youtube',
+    videoId,
+    duration: durationSeconds,
+    thumbnailUrl,
+  };
+};
+
+export { extractYouTubeMetadata, parseDuration, getMetaContent, getVideoId };

--- a/apps/extension/src/content-scripts/parsers/youtube.ts
+++ b/apps/extension/src/content-scripts/parsers/youtube.ts
@@ -20,6 +20,8 @@ const getMetaContent = (property: string): string | undefined => {
   return el?.getAttribute('content') ?? undefined;
 };
 
+const YOUTU_BE_PATH_RE = /^\/([a-zA-Z0-9_-]{11})\/?/;
+
 const getVideoId = (): string | undefined => {
   if (typeof document === 'undefined') return undefined;
   const pathname = window.location.pathname;
@@ -30,6 +32,8 @@ const getVideoId = (): string | undefined => {
   if (pathname.startsWith('/embed/')) {
     return pathname.split('/')[2];
   }
+  const shortMatch = pathname.match(YOUTU_BE_PATH_RE);
+  if (shortMatch) return shortMatch[1];
   return undefined;
 };
 

--- a/apps/extension/src/content-scripts/parsers/youtube.ts
+++ b/apps/extension/src/content-scripts/parsers/youtube.ts
@@ -46,7 +46,10 @@ const extractYouTubeMetadata = (): VideoMetadata => {
   const durationSeconds = durationIso ? parseDuration(durationIso) : undefined;
   const ogImage = getMetaContent('og:image');
   const thumbnailUrl =
-    ogImage || (videoId ? `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg` : undefined);
+    ogImage ||
+    (videoId
+      ? `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`
+      : undefined);
   const videoUrl = window.location.href;
 
   return {

--- a/apps/extension/src/graphql/fragment-masking.ts
+++ b/apps/extension/src/graphql/fragment-masking.ts
@@ -1,9 +1,9 @@
 /* eslint-disable */
-import {
-  ResultOf,
+import type {
   DocumentTypeDecoration,
+  ResultOf,
 } from '@graphql-typed-document-node/core';
-import { Incremental, TypedDocumentString } from './graphql';
+import type { Incremental, TypedDocumentString } from './graphql';
 
 export type FragmentType<
   TDocumentType extends DocumentTypeDecoration<any, any>,

--- a/apps/extension/vitest.config.ts
+++ b/apps/extension/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
+});

--- a/apps/listen/src/routes/manage.lazy.tsx
+++ b/apps/listen/src/routes/manage.lazy.tsx
@@ -1,9 +1,9 @@
 import { createLazyFileRoute, useNavigate } from '@tanstack/react-router';
 import { listenMutationHooks, listenQueryHooks } from 'core';
 import { useAuthContext } from 'core/providers/auth';
+import { useEffect } from 'react';
 import { ManageScreen } from 'ui/listen/minimalism';
 import { LoadingBackdrop } from 'ui/universal';
-import { useEffect } from 'react';
 import { appConfig } from '../config';
 import { createPlaylistSlug } from '../utils/slug';
 

--- a/apps/watch/src/routes/playlist.$slug.$playlistId.$videoId.lazy.tsx
+++ b/apps/watch/src/routes/playlist.$slug.$playlistId.$videoId.lazy.tsx
@@ -7,7 +7,7 @@ import {
   useSharePlaylist,
 } from 'core/watch/mutation-hooks/share-videos';
 import { useLoadPlaylistDetail } from 'core/watch/query-hooks/playlist-detail';
-import { lazy, useState, type JSX } from 'react';
+import { type JSX, lazy, useState } from 'react';
 import { AuthRoute } from 'ui/universal/authRoute';
 import { VideoDetailContainer } from 'ui/watch/video-detail-page/containers';
 import { Layout } from '../components/layout';

--- a/biome.json
+++ b/biome.json
@@ -15,7 +15,7 @@
       "!**/public/assets",
       "!**/storybook-static",
       "!**/coverage",
-      "!packages/core/src/graphql/**",
+      "!packages/core/src/graphql",
       "!packages/core/schema.graphql",
       "!**/routeTree.gen.ts"
     ],

--- a/packages/ui/src/listen/minimalism/music-widget/Controls.tsx
+++ b/packages/ui/src/listen/minimalism/music-widget/Controls.tsx
@@ -9,6 +9,7 @@ import SkipNextRounded from '@mui/icons-material/SkipNextRounded';
 import SkipPreviousRounded from '@mui/icons-material/SkipPreviousRounded';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
+
 enum SAudioPlayerLoopMode {
   None = 'none',
   All = 'all',

--- a/packages/ui/src/main/home-page/spending-breakdown/donut-chart.tsx
+++ b/packages/ui/src/main/home-page/spending-breakdown/donut-chart.tsx
@@ -1,7 +1,6 @@
 import { Box, Skeleton, Typography, useTheme } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import type { CategoryType } from 'core/finance';
-import { getFinanceColor } from '../../../universal/minimalism/domainPalette';
 import { formatNumber } from 'core/universal/common';
 import { PieChart } from 'echarts/charts';
 import { LegendComponent, TooltipComponent } from 'echarts/components';
@@ -12,6 +11,7 @@ import { CanvasRenderer } from 'echarts/renderers';
 // default import resolves to the module object instead of the component,
 // which crashes the finance page with React error #130 (SWO-356).
 import ReactEChartsCore from 'echarts-for-react/esm/core';
+import { getFinanceColor } from '../../../universal/minimalism/domainPalette';
 
 echarts.use([PieChart, TooltipComponent, LegendComponent, CanvasRenderer]);
 

--- a/packages/ui/src/main/home-page/transactions-dialog/index.tsx
+++ b/packages/ui/src/main/home-page/transactions-dialog/index.tsx
@@ -13,8 +13,8 @@ import {
 } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import type { CategoryType } from 'core/finance';
-import { getFinanceColor } from '../../../universal/minimalism/domainPalette';
 import { formatNumber } from 'core/universal/common';
+import { getFinanceColor } from '../../../universal/minimalism/domainPalette';
 
 interface Transaction {
   id: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,12 +120,18 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.3
         version: 6.0.3(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))
+      jsdom:
+        specifier: ^25.0.1
+        version: 25.0.1
       typescript:
         specifier: ^5.6.2
         version: 5.8.2
       vite:
         specifier: ^8.1.2
         version: 8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0)
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(jsdom@25.0.1)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))
 
   apps/game:
     dependencies:
@@ -2031,20 +2037,9 @@ packages:
       '@csstools/css-parser-algorithms': ^3.0.5
       '@csstools/css-tokenizer': ^3.0.4
 
-  '@csstools/color-helpers@5.0.2':
-    resolution: {integrity: sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==}
-    engines: {node: '>=18'}
-
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
     engines: {node: '>=18'}
-
-  '@csstools/css-calc@2.1.2':
-    resolution: {integrity: sha512-TklMyb3uBB28b5uQdxjReG4L80NxAqgrECqLZFQbyLekwwlcDDS8r3f07DKqeo8C4926Br0gf/ZDe17Zv4wIuw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@csstools/css-parser-algorithms': ^3.0.4
-      '@csstools/css-tokenizer': ^3.0.3
 
   '@csstools/css-calc@2.1.4':
     resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
@@ -2053,13 +2048,6 @@ packages:
       '@csstools/css-parser-algorithms': ^3.0.5
       '@csstools/css-tokenizer': ^3.0.4
 
-  '@csstools/css-color-parser@3.0.8':
-    resolution: {integrity: sha512-pdwotQjCCnRPuNi06jFuP68cykU1f3ZWExLe/8MQ1LOs8Xq+fTkYgd+2V8mWUWMrOn9iS2HftPVaMZDaXzGbhQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@csstools/css-parser-algorithms': ^3.0.4
-      '@csstools/css-tokenizer': ^3.0.3
-
   '@csstools/css-color-parser@3.1.0':
     resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
     engines: {node: '>=18'}
@@ -2067,21 +2055,11 @@ packages:
       '@csstools/css-parser-algorithms': ^3.0.5
       '@csstools/css-tokenizer': ^3.0.4
 
-  '@csstools/css-parser-algorithms@3.0.4':
-    resolution: {integrity: sha512-Up7rBoV77rv29d3uKHUIVubz1BTcgyUK72IvCQAbfbMv584xHcGKCKbWh7i8hPrRJ7qU4Y8IO3IY9m+iTB7P3A==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@csstools/css-tokenizer': ^3.0.3
-
   '@csstools/css-parser-algorithms@3.0.5':
     resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@csstools/css-tokenizer': ^3.0.4
-
-  '@csstools/css-tokenizer@3.0.3':
-    resolution: {integrity: sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw==}
-    engines: {node: '>=18'}
 
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
@@ -6950,10 +6928,6 @@ packages:
 
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
-
-  es-object-atoms@1.1.1:
-    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
-    engines: {node: '>= 0.4'}
 
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
@@ -12373,10 +12347,10 @@ snapshots:
 
   '@asamuzakjp/css-color@3.1.1':
     dependencies:
-      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
-      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
-      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
-      '@csstools/css-tokenizer': 3.0.3
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
 
   '@auth0/auth0-auth-js@1.9.1':
@@ -14016,26 +13990,12 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
 
-  '@csstools/color-helpers@5.0.2': {}
-
   '@csstools/color-helpers@5.1.0': {}
-
-  '@csstools/css-calc@2.1.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)':
-    dependencies:
-      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
-      '@csstools/css-tokenizer': 3.0.3
 
   '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-
-  '@csstools/css-color-parser@3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)':
-    dependencies:
-      '@csstools/color-helpers': 5.0.2
-      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
-      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
-      '@csstools/css-tokenizer': 3.0.3
 
   '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
     dependencies:
@@ -14044,15 +14004,9 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
 
-  '@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3)':
-    dependencies:
-      '@csstools/css-tokenizer': 3.0.3
-
   '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
     dependencies:
       '@csstools/css-tokenizer': 3.0.4
-
-  '@csstools/css-tokenizer@3.0.3': {}
 
   '@csstools/css-tokenizer@3.0.4': {}
 
@@ -17128,7 +17082,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
       estree-walker: 2.0.2
-      picomatch: 4.0.4
+      picomatch: 4.0.5
     optionalDependencies:
       rollup: 4.62.2
 
@@ -18244,7 +18198,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(jsdom@25.0.1)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))
+      vitest: 4.1.9(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(jsdom@25.0.1)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -19915,10 +19869,6 @@ snapshots:
 
   es-module-lexer@2.1.0: {}
 
-  es-object-atoms@1.1.1:
-    dependencies:
-      es-errors: 1.3.0
-
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
@@ -20346,10 +20296,6 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
-  fdir@6.5.0(picomatch@4.0.4):
-    optionalDependencies:
-      picomatch: 4.0.4
-
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
@@ -20525,7 +20471,7 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-define-property: 1.0.1
       es-errors: 1.3.0
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
       function-bind: 1.1.2
       get-proto: 1.0.1
       gopd: 1.2.0
@@ -20540,7 +20486,7 @@ snapshots:
   get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
 
   get-stream@6.0.1: {}
 
@@ -22860,7 +22806,7 @@ snapshots:
       call-bind: 1.0.8
       call-bound: 1.0.4
       define-properties: 1.2.1
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
       has-symbols: 1.1.0
       object-keys: 1.1.1
 
@@ -25149,8 +25095,8 @@ snapshots:
 
   tinyglobby@0.2.17:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   tinypool@1.0.2: {}
 
@@ -25472,13 +25418,13 @@ snapshots:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       acorn: 8.17.0
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       webpack-virtual-modules: 0.6.2
 
   unplugin@3.2.0(esbuild@0.28.1)(rolldown@1.1.4)(rollup@2.79.2)(vite@6.4.3(@types/node@18.19.80)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.28.1)):
     dependencies:
       '@jridgewell/remapping': 2.3.5
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
       esbuild: 0.28.1
@@ -25490,7 +25436,7 @@ snapshots:
   unplugin@3.2.0(esbuild@0.28.1)(rolldown@1.1.4)(rollup@4.62.2)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.28.1)):
     dependencies:
       '@jridgewell/remapping': 2.3.5
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
       esbuild: 0.28.1
@@ -25688,7 +25634,7 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.3
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.2.4
@@ -25717,7 +25663,7 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.3
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.2.4


### PR DESCRIPTION
## Summary

Add YouTube and Vimeo metadata extractors and a page type detector. Detects page types by URL patterns and DOM content, extracts video metadata, and sets up the content script detection pipeline.

## Test plan

- `pnpm test:vitest` passes (30 tests: 17 YouTube, 13 page type detection)
- `pnpm lint` — no new errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Browser extension now recognizes YouTube, Vimeo, PDF, webpage, and generic video content.
  - Added metadata extraction for YouTube and Vimeo videos, including titles, video IDs, thumbnails, and durations when available.

- **Tests**
  - Added automated coverage for page detection and video metadata extraction.
  - Added browser-like test support to improve confidence in extension behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->