### PR TITLE
feat(extension): add clipboard content processor

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite build --watch",
     "build": "vite build",
+    "test": "vitest",
     "lint": "biome lint --quit-on-problem .",
     "format": "biome format --write .",
     "test": "vitest",

--- a/apps/extension/src/content-scripts/parsers/clipboard.test.ts
+++ b/apps/extension/src/content-scripts/parsers/clipboard.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ExtensionMessage } from 'core/universal/extension/communication/types';
+import {
+  extractUrls,
+  detectContentType,
+  initClipboardListener,
+  cleanupClipboardListener,
+} from './clipboard';
+
+const mockSendMessage = vi.fn();
+
+vi.stubGlobal('chrome', {
+  runtime: {
+    sendMessage: mockSendMessage,
+  },
+});
+
+const createPasteEvent = (text: string): Event => {
+  const event = new Event('paste', {
+    bubbles: true,
+    cancelable: true,
+  });
+  Object.defineProperty(event, 'clipboardData', {
+    value: {
+      getData: (format: string) => (format === 'text' ? text : ''),
+      types: ['text/plain'],
+    },
+    configurable: true,
+  });
+  return event;
+};
+
+describe('extractUrls', () => {
+  it('returns empty array for text with no URLs', () => {
+    expect(extractUrls('hello world')).toEqual([]);
+  });
+
+  it('returns empty array for empty string', () => {
+    expect(extractUrls('')).toEqual([]);
+  });
+
+  it('returns a single URL', () => {
+    expect(extractUrls('https://example.com')).toEqual(['https://example.com']);
+  });
+
+  it('returns a single URL from text with surrounding content', () => {
+    expect(extractUrls('Visit https://example.com today')).toEqual([
+      'https://example.com',
+    ]);
+  });
+
+  it('returns multiple URLs', () => {
+    expect(
+      extractUrls('https://example.com and https://test.com/path?q=1'),
+    ).toEqual(['https://example.com', 'https://test.com/path?q=1']);
+  });
+
+  it('handles URLs with various protocols', () => {
+    expect(extractUrls('http://example.com')).toEqual(['http://example.com']);
+  });
+});
+
+describe('detectContentType', () => {
+  it('returns url when text is a single URL', () => {
+    expect(detectContentType('https://example.com', ['https://example.com'])).toBe(
+      'url',
+    );
+  });
+
+  it('returns text for plain text with no URLs', () => {
+    expect(detectContentType('hello world', [])).toBe('text');
+  });
+
+  it('returns text for empty string', () => {
+    expect(detectContentType('', [])).toBe('text');
+  });
+
+  it('returns isbn for valid ISBN-13 starting with 978', () => {
+    expect(detectContentType('9781234567890', [])).toBe('isbn');
+  });
+
+  it('returns isbn for valid ISBN-13 starting with 979', () => {
+    expect(detectContentType('9791234567890', [])).toBe('isbn');
+  });
+
+  it('returns isbn for ISBN-13 with hyphens stripped', () => {
+    expect(detectContentType('978-3-16-148410-0', [])).toBe('isbn');
+  });
+
+  it('returns unknown for text shorter than 13 digits', () => {
+    expect(detectContentType('978123456789', [])).toBe('text');
+  });
+
+  it('returns unknown for mixed content with URL and text', () => {
+    expect(
+      detectContentType('hello https://example.com', ['https://example.com']),
+    ).toBe('unknown');
+  });
+
+  it('returns unknown for multiple URLs', () => {
+    expect(
+      detectContentType('https://example.com https://test.com', [
+        'https://example.com',
+        'https://test.com',
+      ]),
+    ).toBe('unknown');
+  });
+
+  it('returns isbn when text contains ISBN with label', () => {
+    expect(detectContentType('isbn 9781234567890', [])).toBe('isbn');
+  });
+});
+
+describe('initClipboardListener', () => {
+  beforeEach(() => {
+    mockSendMessage.mockReset();
+  });
+
+  afterEach(() => {
+    cleanupClipboardListener();
+  });
+
+  it('attaches a paste event listener to the document', () => {
+    const addSpy = vi.spyOn(document, 'addEventListener');
+    initClipboardListener();
+    expect(addSpy).toHaveBeenCalledWith('paste', expect.any(Function));
+    addSpy.mockRestore();
+  });
+
+  it('sends USER_CLIPBOARD_ACTION message on paste with a URL', () => {
+    initClipboardListener();
+    document.dispatchEvent(createPasteEvent('https://example.com'));
+
+    const expectedMessage: ExtensionMessage = {
+      source: 'content-script',
+      target: 'background',
+      type: 'USER_CLIPBOARD_ACTION',
+      payload: {
+        text: 'https://example.com',
+        url: 'https://example.com',
+        detectedType: 'url',
+      },
+    };
+
+    expect(mockSendMessage).toHaveBeenCalledWith(expectedMessage);
+  });
+
+  it('sends USER_CLIPBOARD_ACTION message on paste with plain text', () => {
+    initClipboardListener();
+    document.dispatchEvent(createPasteEvent('hello world'));
+
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'USER_CLIPBOARD_ACTION',
+        payload: expect.objectContaining({
+          text: 'hello world',
+          detectedType: 'text',
+        }),
+      }),
+    );
+  });
+
+  it('does not send a message when clipboard data is empty', () => {
+    initClipboardListener();
+    document.dispatchEvent(createPasteEvent(''));
+    expect(mockSendMessage).not.toHaveBeenCalled();
+  });
+
+  it('sends message with correct ExtensionMessage structure', () => {
+    initClipboardListener();
+    document.dispatchEvent(createPasteEvent('some text'));
+
+    const [message] = mockSendMessage.mock.calls[0];
+    expect(message).toHaveProperty('source', 'content-script');
+    expect(message).toHaveProperty('target', 'background');
+    expect(message).toHaveProperty('type', 'USER_CLIPBOARD_ACTION');
+    expect(message).toHaveProperty('payload');
+    expect(message.payload).toHaveProperty('text');
+    expect(message.payload).toHaveProperty('detectedType');
+  });
+});
+
+describe('cleanupClipboardListener', () => {
+  it('removes the paste event listener', () => {
+    const removeSpy = vi.spyOn(document, 'removeEventListener');
+    initClipboardListener();
+    cleanupClipboardListener();
+    expect(removeSpy).toHaveBeenCalledWith('paste', expect.any(Function));
+    removeSpy.mockRestore();
+  });
+
+  it('does not throw if called without init', () => {
+    expect(cleanupClipboardListener).not.toThrow();
+  });
+});

--- a/apps/extension/src/content-scripts/parsers/clipboard.test.ts
+++ b/apps/extension/src/content-scripts/parsers/clipboard.test.ts
@@ -1,10 +1,10 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { ExtensionMessage } from 'core/universal/extension/communication/types';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
-  extractUrls,
-  detectContentType,
-  initClipboardListener,
   cleanupClipboardListener,
+  detectContentType,
+  extractUrls,
+  initClipboardListener,
 } from './clipboard';
 
 const mockSendMessage = vi.fn();

--- a/apps/extension/src/content-scripts/parsers/clipboard.test.ts
+++ b/apps/extension/src/content-scripts/parsers/clipboard.test.ts
@@ -62,9 +62,9 @@ describe('extractUrls', () => {
 
 describe('detectContentType', () => {
   it('returns url when text is a single URL', () => {
-    expect(detectContentType('https://example.com', ['https://example.com'])).toBe(
-      'url',
-    );
+    expect(
+      detectContentType('https://example.com', ['https://example.com']),
+    ).toBe('url');
   });
 
   it('returns text for plain text with no URLs', () => {

--- a/apps/extension/src/content-scripts/parsers/clipboard.ts
+++ b/apps/extension/src/content-scripts/parsers/clipboard.ts
@@ -1,4 +1,7 @@
-import type { ClipboardContent, ExtensionMessage } from 'core/universal/extension/communication/types';
+import type {
+  ClipboardContent,
+  ExtensionMessage,
+} from 'core/universal/extension/communication/types';
 
 const URL_REGEX = /https?:\/\/[^\s<>"']+/g;
 
@@ -66,4 +69,9 @@ const cleanupClipboardListener = (): void => {
   }
 };
 
-export { extractUrls, detectContentType, initClipboardListener, cleanupClipboardListener };
+export {
+  extractUrls,
+  detectContentType,
+  initClipboardListener,
+  cleanupClipboardListener,
+};

--- a/apps/extension/src/content-scripts/parsers/clipboard.ts
+++ b/apps/extension/src/content-scripts/parsers/clipboard.ts
@@ -1,0 +1,69 @@
+import type { ClipboardContent, ExtensionMessage } from 'core/universal/extension/communication/types';
+
+const URL_REGEX = /https?:\/\/[^\s<>"']+/g;
+
+const extractUrls = (text: string): string[] => {
+  return text.match(URL_REGEX) ?? [];
+};
+
+const detectContentType = (
+  text: string,
+  urls: string[],
+): 'url' | 'text' | 'isbn' | 'unknown' => {
+  const trimmed = text.trim();
+
+  if (urls.length === 1 && urls[0] === trimmed) {
+    return 'url';
+  }
+
+  if (urls.length === 0) {
+    const digitsOnly = trimmed.replace(/\D/g, '');
+    if (digitsOnly.length === 13 && /^97[89]/.test(digitsOnly)) {
+      return 'isbn';
+    }
+    return 'text';
+  }
+
+  return 'unknown';
+};
+
+let handlePaste: ((event: Event) => void) | null = null;
+
+const initClipboardListener = (): void => {
+  if (typeof document === 'undefined') return;
+
+  handlePaste = (event: Event) => {
+    const pasteEvent = event as ClipboardEvent;
+    const pastedText = pasteEvent.clipboardData?.getData('text');
+    if (!pastedText) return;
+
+    const urls = extractUrls(pastedText);
+    const detectedType = detectContentType(pastedText, urls);
+
+    const content: ClipboardContent = {
+      text: pastedText,
+      detectedType,
+      ...(urls.length > 0 && { url: urls[0] }),
+    };
+
+    const message: ExtensionMessage = {
+      source: 'content-script',
+      target: 'background',
+      type: 'USER_CLIPBOARD_ACTION',
+      payload: content,
+    };
+
+    chrome.runtime.sendMessage(message);
+  };
+
+  document.addEventListener('paste', handlePaste);
+};
+
+const cleanupClipboardListener = (): void => {
+  if (handlePaste) {
+    document.removeEventListener('paste', handlePaste);
+    handlePaste = null;
+  }
+};
+
+export { extractUrls, detectContentType, initClipboardListener, cleanupClipboardListener };

--- a/apps/extension/vitest.config.ts
+++ b/apps/extension/vitest.config.ts
@@ -1,8 +1,14 @@
+import path from 'path';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+  },
+  resolve: {
+    alias: {
+      core: path.resolve(__dirname, '../../packages/core/src'),
+    },
   },
 });


### PR DESCRIPTION
## Summary

Add clipboard content processor that listens for paste events, extracts clipboard data, categorizes content (URL/text/ISBN/unknown), and sends `USER_CLIPBOARD_ACTION` messages to the background script.

## Test plan

- `pnpm test:vitest` passes (23 tests)
- `pnpm lint` — no new errors