### PR TITLE
feat(extension): implement popup UI with tab navigation and auth flow

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -11,6 +11,9 @@
     "codegen": "dotenvx run -- graphql-codegen --config codegen.ts"
   },
   "dependencies": {
+    "@emotion/react": "^11.10.5",
+    "@emotion/styled": "^11.10.5",
+    "@mui/material": "^9.1.2",
     "core": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -1,11 +1,11 @@
 import { removeItems, setItem } from 'core/universal/extension/storage';
 import { config } from '../config';
 import {
-  isAuthenticated,
   getToken,
-  startPairing,
-  pollForDeviceToken,
+  isAuthenticated,
   logout,
+  pollForDeviceToken,
+  startPairing,
 } from './background/auth';
 
 console.log('Background script starting...');

--- a/apps/extension/src/background/auth.ts
+++ b/apps/extension/src/background/auth.ts
@@ -3,8 +3,8 @@ import {
   removeItems,
   setItem,
 } from 'core/universal/extension/storage';
-import { hasuraConfig } from '../../envConfig';
 import { config } from '../../config';
+import { hasuraConfig } from '../../envConfig';
 
 const AUTH_TOKEN_KEY = 'auth0Token';
 

--- a/apps/extension/src/components/ActionCard.tsx
+++ b/apps/extension/src/components/ActionCard.tsx
@@ -1,11 +1,11 @@
 import {
-  Card,
-  CardContent,
-  CardActions,
-  Button,
-  Typography,
-  Chip,
   Box,
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  Chip,
+  Typography,
 } from '@mui/material';
 
 interface ActionCardProps {

--- a/apps/extension/src/components/ActionCard.tsx
+++ b/apps/extension/src/components/ActionCard.tsx
@@ -1,0 +1,61 @@
+import {
+  Card,
+  CardContent,
+  CardActions,
+  Button,
+  Typography,
+  Chip,
+  Box,
+} from '@mui/material';
+
+interface ActionCardProps {
+  title: string;
+  description?: string;
+  url: string;
+  typeLabel: string;
+  onImport: () => void;
+  importButtonLabel: string;
+  disabled?: boolean;
+}
+
+const ActionCard = ({
+  title,
+  description,
+  url,
+  typeLabel,
+  onImport,
+  importButtonLabel,
+  disabled,
+}: ActionCardProps) => (
+  <Card variant="outlined">
+    <CardContent>
+      <Box display="flex" alignItems="center" gap={1} mb={1}>
+        <Typography variant="subtitle2" fontWeight="bold" noWrap>
+          {title}
+        </Typography>
+        <Chip label={typeLabel} size="small" variant="outlined" />
+      </Box>
+      {description && (
+        <Typography variant="body2" color="text.secondary" mb={1}>
+          {description}
+        </Typography>
+      )}
+      <Typography variant="caption" color="text.disabled" noWrap>
+        {url}
+      </Typography>
+    </CardContent>
+    <CardActions>
+      <Button
+        variant="contained"
+        size="small"
+        onClick={onImport}
+        disabled={disabled}
+        fullWidth
+      >
+        {importButtonLabel}
+      </Button>
+    </CardActions>
+  </Card>
+);
+
+export { ActionCard };

--- a/apps/extension/src/components/AuthPanel.tsx
+++ b/apps/extension/src/components/AuthPanel.tsx
@@ -1,0 +1,142 @@
+import { useState, useEffect, useCallback } from 'react';
+import {
+  Box,
+  Typography,
+  Button,
+  CircularProgress,
+  Alert,
+} from '@mui/material';
+
+const AuthPanel = () => {
+  const [userCode, setUserCode] = useState('');
+  const [verificationUri, setVerificationUri] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [copied, setCopied] = useState(false);
+
+  const startPairing = useCallback(() => {
+    setIsLoading(true);
+    setError('');
+
+    chrome.runtime.sendMessage(
+      { type: 'START_PAIRING' },
+      (
+        response:
+          | {
+              success: boolean;
+              userCode: string;
+              verificationUri: string;
+              deviceCode: string;
+              interval: number;
+              expiresIn: number;
+              error?: string;
+            }
+          | undefined,
+      ) => {
+        if (!response || !response.success) {
+          setError(response?.error || 'Failed to start pairing');
+          setIsLoading(false);
+          return;
+        }
+
+        setUserCode(response.userCode);
+        setVerificationUri(response.verificationUri);
+        setIsLoading(false);
+
+        chrome.runtime.sendMessage(
+          {
+            type: 'POLL_FOR_TOKEN',
+            data: {
+              deviceCode: response.deviceCode,
+              interval: response.interval,
+              expiresIn: response.expiresIn,
+            },
+          },
+          (pollResponse: { success: boolean; error?: string } | undefined) => {
+            if (!pollResponse || !pollResponse.success) {
+              setError(pollResponse?.error || 'Pairing failed');
+            }
+          },
+        );
+      },
+    );
+  }, []);
+
+  useEffect(() => {
+    startPairing();
+  }, [startPairing]);
+
+  const handleCopyCode = () => {
+    navigator.clipboard.writeText(userCode);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  if (isLoading) {
+    return (
+      <Box display="flex" justifyContent="center" p={4}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box p={2}>
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+        <Button variant="outlined" onClick={startPairing} fullWidth>
+          Retry Pairing
+        </Button>
+      </Box>
+    );
+  }
+
+  return (
+    <Box p={2}>
+      <Typography variant="h6" gutterBottom>
+        Connect Your Account
+      </Typography>
+      <Typography variant="body2" color="text.secondary" gutterBottom>
+        Visit the verification URL and enter the code below to connect your
+        account:
+      </Typography>
+      <Box
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        bgcolor="grey.900"
+        borderRadius={1}
+        p={2}
+        my={2}
+      >
+        <Typography
+          variant="h4"
+          fontFamily="monospace"
+          fontWeight="bold"
+          letterSpacing={4}
+        >
+          {userCode}
+        </Typography>
+      </Box>
+      <Button
+        variant="contained"
+        fullWidth
+        onClick={handleCopyCode}
+        sx={{ mb: 1 }}
+      >
+        {copied ? 'Copied!' : 'Copy Code'}
+      </Button>
+      <Button
+        variant="outlined"
+        fullWidth
+        onClick={() => window.open(verificationUri, '_blank')}
+      >
+        Open Verification Page
+      </Button>
+    </Box>
+  );
+};
+
+export { AuthPanel };

--- a/apps/extension/src/components/AuthPanel.tsx
+++ b/apps/extension/src/components/AuthPanel.tsx
@@ -1,11 +1,11 @@
-import { useState, useEffect, useCallback } from 'react';
 import {
+  Alert,
   Box,
-  Typography,
   Button,
   CircularProgress,
-  Alert,
+  Typography,
 } from '@mui/material';
+import { useCallback, useEffect, useState } from 'react';
 
 const AuthPanel = () => {
   const [userCode, setUserCode] = useState('');

--- a/apps/extension/src/components/AutoDetectTab.tsx
+++ b/apps/extension/src/components/AutoDetectTab.tsx
@@ -1,0 +1,55 @@
+import { Box, Typography, CircularProgress } from '@mui/material';
+import type { PageContent } from 'core/universal/extension/communication/types';
+import { ActionCard } from './ActionCard';
+
+interface AutoDetectTabProps {
+  content: PageContent | null;
+  isLoading: boolean;
+  onImport: (contentId: string, targetApp: 'library' | 'watch') => void;
+}
+
+const AutoDetectTab = ({
+  content,
+  isLoading,
+  onImport,
+}: AutoDetectTabProps) => {
+  if (isLoading) {
+    return (
+      <Box display="flex" justifyContent="center" p={4}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (!content) {
+    return (
+      <Box p={2}>
+        <Typography color="text.secondary" align="center">
+          No content detected on this page.
+        </Typography>
+      </Box>
+    );
+  }
+
+  const isVideo = ['youtube', 'vimeo', 'video-generic'].includes(
+    content.pageType,
+  );
+  const isPdf = content.pageType === 'pdf';
+  const targetApp = isVideo ? ('watch' as const) : ('library' as const);
+  const typeLabel = isPdf ? 'PDF Document' : isVideo ? 'Video' : 'Web Page';
+
+  return (
+    <Box p={2}>
+      <ActionCard
+        title={content.title}
+        description={content.description}
+        url={content.url}
+        typeLabel={typeLabel}
+        onImport={() => onImport(content.url, targetApp)}
+        importButtonLabel={isVideo ? 'Import to Watch' : 'Import to Library'}
+      />
+    </Box>
+  );
+};
+
+export { AutoDetectTab };

--- a/apps/extension/src/components/AutoDetectTab.tsx
+++ b/apps/extension/src/components/AutoDetectTab.tsx
@@ -1,4 +1,4 @@
-import { Box, Typography, CircularProgress } from '@mui/material';
+import { Box, CircularProgress, Typography } from '@mui/material';
 import type { PageContent } from 'core/universal/extension/communication/types';
 import { ActionCard } from './ActionCard';
 

--- a/apps/extension/src/components/ClipboardTab.tsx
+++ b/apps/extension/src/components/ClipboardTab.tsx
@@ -1,5 +1,5 @@
+import { Box, Button, TextField, Typography } from '@mui/material';
 import { useState } from 'react';
-import { Box, Typography, TextField, Button } from '@mui/material';
 
 interface ClipboardTabProps {
   onImportClipboard: (text: string) => void;

--- a/apps/extension/src/components/ClipboardTab.tsx
+++ b/apps/extension/src/components/ClipboardTab.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+import { Box, Typography, TextField, Button } from '@mui/material';
+
+interface ClipboardTabProps {
+  onImportClipboard: (text: string) => void;
+}
+
+const ClipboardTab = ({ onImportClipboard }: ClipboardTabProps) => {
+  const [text, setText] = useState('');
+
+  const handleImport = () => {
+    if (text.trim()) {
+      onImportClipboard(text.trim());
+    }
+  };
+
+  return (
+    <Box p={2}>
+      <Typography color="text.secondary" gutterBottom>
+        Paste content below to detect and import.
+      </Typography>
+      <TextField
+        fullWidth
+        multiline
+        minRows={3}
+        maxRows={6}
+        placeholder="Paste URL, text, or ISBN here..."
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+      />
+      <Button
+        variant="contained"
+        fullWidth
+        onClick={handleImport}
+        disabled={!text.trim()}
+        sx={{ mt: 1 }}
+      >
+        Import
+      </Button>
+    </Box>
+  );
+};
+
+export { ClipboardTab };

--- a/apps/extension/src/components/ImportStatusBadge.tsx
+++ b/apps/extension/src/components/ImportStatusBadge.tsx
@@ -1,0 +1,31 @@
+import { Chip, CircularProgress } from '@mui/material';
+import type { ImportStatus } from 'core/universal/extension/communication/types';
+
+interface ImportStatusBadgeProps {
+  status: ImportStatus['status'];
+}
+
+const statusConfig: Record<
+  ImportStatus['status'],
+  { label: string; color: 'default' | 'primary' | 'success' | 'error' }
+> = {
+  pending: { label: 'Pending', color: 'default' },
+  importing: { label: 'Importing', color: 'primary' },
+  completed: { label: 'Completed', color: 'success' },
+  failed: { label: 'Failed', color: 'error' },
+};
+
+const ImportStatusBadge = ({ status }: ImportStatusBadgeProps) => {
+  const config = statusConfig[status];
+
+  return (
+    <Chip
+      label={config.label}
+      color={config.color}
+      size="small"
+      icon={status === 'importing' ? <CircularProgress size={12} /> : undefined}
+    />
+  );
+};
+
+export { ImportStatusBadge };

--- a/apps/extension/src/components/RecentTab.tsx
+++ b/apps/extension/src/components/RecentTab.tsx
@@ -1,0 +1,66 @@
+import {
+  Box,
+  Typography,
+  List,
+  ListItem,
+  ListItemText,
+  Button,
+} from '@mui/material';
+import type { ImportStatus } from 'core/universal/extension/communication/types';
+import { ImportStatusBadge } from './ImportStatusBadge';
+
+interface RecentTabProps {
+  imports: ImportStatus[];
+  onRetry: (importId: string) => void;
+}
+
+const RecentTab = ({ imports, onRetry }: RecentTabProps) => {
+  if (imports.length === 0) {
+    return (
+      <Box p={2}>
+        <Typography color="text.secondary" align="center">
+          No recent imports.
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box p={2}>
+      <Typography variant="subtitle2" gutterBottom>
+        Recent Imports
+      </Typography>
+      <List disablePadding>
+        {imports.map((imp) => (
+          <ListItem
+            key={imp.importId}
+            divider
+            secondaryAction={
+              imp.status === 'failed' ? (
+                <Button
+                  size="small"
+                  color="error"
+                  onClick={() => onRetry(imp.importId)}
+                >
+                  Retry
+                </Button>
+              ) : null
+            }
+          >
+            <ListItemText
+              primary={imp.title || imp.importId}
+              secondary={
+                <Box display="flex" alignItems="center" gap={1} mt={0.5}>
+                  <ImportStatusBadge status={imp.status} />
+                  <Typography variant="caption">{imp.targetApp}</Typography>
+                </Box>
+              }
+            />
+          </ListItem>
+        ))}
+      </List>
+    </Box>
+  );
+};
+
+export { RecentTab };

--- a/apps/extension/src/components/RecentTab.tsx
+++ b/apps/extension/src/components/RecentTab.tsx
@@ -1,10 +1,10 @@
 import {
   Box,
-  Typography,
+  Button,
   List,
   ListItem,
   ListItemText,
-  Button,
+  Typography,
 } from '@mui/material';
 import type { ImportStatus } from 'core/universal/extension/communication/types';
 import { ImportStatusBadge } from './ImportStatusBadge';

--- a/apps/extension/src/graphql/fragment-masking.ts
+++ b/apps/extension/src/graphql/fragment-masking.ts
@@ -1,9 +1,9 @@
 /* eslint-disable */
-import {
-  ResultOf,
+import type {
   DocumentTypeDecoration,
+  ResultOf,
 } from '@graphql-typed-document-node/core';
-import { Incremental, TypedDocumentString } from './graphql';
+import type { Incremental, TypedDocumentString } from './graphql';
 
 export type FragmentType<
   TDocumentType extends DocumentTypeDecoration<any, any>,

--- a/apps/extension/src/hooks/usePopupMessaging.ts
+++ b/apps/extension/src/hooks/usePopupMessaging.ts
@@ -1,0 +1,88 @@
+import { useState, useEffect, useCallback } from 'react';
+import type {
+  PageContent,
+  ImportStatus,
+  ExtensionMessage,
+} from 'core/universal/extension/communication/types';
+
+interface PopupMessagingState {
+  content: PageContent | null;
+  isLoading: boolean;
+  isAuthenticated: boolean;
+  imports: ImportStatus[];
+  sendMessage: (message: ExtensionMessage) => void;
+}
+
+const CHROME_UNAVAILABLE = typeof chrome === 'undefined' || !chrome.runtime?.id;
+
+const usePopupMessaging = (): PopupMessagingState => {
+  const [content, setContent] = useState<PageContent | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [imports, setImports] = useState<ImportStatus[]>([]);
+
+  const sendMessage = useCallback((message: ExtensionMessage) => {
+    if (CHROME_UNAVAILABLE) return;
+    chrome.runtime.sendMessage(message);
+  }, []);
+
+  useEffect(() => {
+    if (CHROME_UNAVAILABLE) {
+      setIsLoading(false);
+      return;
+    }
+
+    const handleMessage = (message: ExtensionMessage) => {
+      if (message.source !== 'background' || message.target !== 'popup') return;
+
+      switch (message.type) {
+        case 'CURRENT_TAB_CONTENT':
+          setContent(message.payload);
+          setIsLoading(false);
+          break;
+        case 'AUTH_STATE_CHANGED':
+          setIsAuthenticated(message.payload.authenticated);
+          break;
+        case 'IMPORT_STATUS':
+          setImports((prev) => {
+            const existing = prev.findIndex(
+              (i) => i.importId === message.payload.importId,
+            );
+            if (existing >= 0) {
+              const updated = [...prev];
+              updated[existing] = message.payload;
+              return updated;
+            }
+            return [...prev, message.payload];
+          });
+          break;
+      }
+    };
+
+    chrome.runtime.onMessage.addListener(handleMessage);
+
+    chrome.runtime.sendMessage(
+      { type: 'GET_AUTH_STATUS' },
+      (response: { authenticated: boolean } | undefined) => {
+        if (response) {
+          setIsAuthenticated(response.authenticated);
+        }
+      },
+    );
+
+    const requestMessage: ExtensionMessage = {
+      source: 'popup',
+      target: 'background',
+      type: 'REQUEST_TAB_CONTENT',
+    };
+    chrome.runtime.sendMessage(requestMessage);
+
+    return () => {
+      chrome.runtime.onMessage.removeListener(handleMessage);
+    };
+  }, []);
+
+  return { content, isLoading, isAuthenticated, imports, sendMessage };
+};
+
+export { usePopupMessaging };

--- a/apps/extension/src/hooks/usePopupMessaging.ts
+++ b/apps/extension/src/hooks/usePopupMessaging.ts
@@ -1,9 +1,9 @@
-import { useState, useEffect, useCallback } from 'react';
 import type {
-  PageContent,
-  ImportStatus,
   ExtensionMessage,
+  ImportStatus,
+  PageContent,
 } from 'core/universal/extension/communication/types';
+import { useCallback, useEffect, useState } from 'react';
 
 interface PopupMessagingState {
   content: PageContent | null;

--- a/apps/extension/src/main.tsx
+++ b/apps/extension/src/main.tsx
@@ -1,5 +1,7 @@
-import React from 'react';
 import ReactDOM from 'react-dom/client';
-import Popup from './popup';
+import { Popup } from './popup';
 
-ReactDOM.createRoot(document.getElementById('root')!).render(<Popup />);
+const rootElement = document.getElementById('root');
+if (rootElement) {
+  ReactDOM.createRoot(rootElement).render(<Popup />);
+}

--- a/apps/extension/src/popup.tsx
+++ b/apps/extension/src/popup.tsx
@@ -1,23 +1,113 @@
-import { getItems } from 'core/universal/extension/storage';
-import React, { useEffect, useState } from 'react';
+import { useState } from 'react';
+import {
+  ThemeProvider,
+  createTheme,
+  CssBaseline,
+  Box,
+  Tabs,
+  Tab,
+  Typography,
+} from '@mui/material';
+import { AuthPanel } from './components/AuthPanel';
+import { AutoDetectTab } from './components/AutoDetectTab';
+import { ClipboardTab } from './components/ClipboardTab';
+import { RecentTab } from './components/RecentTab';
+import { usePopupMessaging } from './hooks/usePopupMessaging';
+import type { ExtensionMessage } from 'core/universal/extension/communication/types';
+
+const darkTheme = createTheme({
+  palette: {
+    mode: 'dark',
+  },
+});
 
 const Popup = () => {
-  const [hasToken, setHasToken] = useState(false);
+  const { content, isLoading, isAuthenticated, imports, sendMessage } =
+    usePopupMessaging();
+  const [tabIndex, setTabIndex] = useState(0);
 
-  useEffect(() => {
-    const getToken = async () => {
-      const token = await getItems(['auth0Token']);
-      setHasToken(!!token.auth0Token);
+  const handleImport = (contentId: string, targetApp: 'library' | 'watch') => {
+    const message: ExtensionMessage = {
+      source: 'popup',
+      target: 'background',
+      type: 'IMPORT_CONTENT',
+      payload: { contentId, targetApp },
     };
-    getToken();
-  }, []);
+    sendMessage(message);
+  };
+
+  const handleRetry = (importId: string) => {
+    const message: ExtensionMessage = {
+      source: 'popup',
+      target: 'background',
+      type: 'RETRY_IMPORT',
+      payload: { importId },
+    };
+    sendMessage(message);
+  };
+
+  const handleImportClipboard = (text: string) => {
+    handleImport(text, 'library');
+  };
+
+  if (!isAuthenticated) {
+    return (
+      <ThemeProvider theme={darkTheme}>
+        <CssBaseline />
+        <Box width={400} minHeight={400}>
+          <Box sx={{ borderBottom: 1, borderColor: 'divider' }} p={2}>
+            <Typography variant="h6" fontWeight="bold">
+              SWorld
+            </Typography>
+          </Box>
+          <AuthPanel />
+        </Box>
+      </ThemeProvider>
+    );
+  }
 
   return (
-    <div style={{ width: 300, padding: 16 }}>
-      <h3>Extension Status</h3>
-      <p>Authenticated: {hasToken ? '✅' : '❌'}</p>
-    </div>
+    <ThemeProvider theme={darkTheme}>
+      <CssBaseline />
+      <Box
+        width={400}
+        minHeight={400}
+        maxHeight={600}
+        display="flex"
+        flexDirection="column"
+      >
+        <Box sx={{ borderBottom: 1, borderColor: 'divider' }} p={2}>
+          <Typography variant="h6" fontWeight="bold">
+            SWorld
+          </Typography>
+        </Box>
+        <Tabs
+          value={tabIndex}
+          onChange={(_, newIndex) => setTabIndex(newIndex)}
+          variant="fullWidth"
+        >
+          <Tab label="Auto-Detect" />
+          <Tab label="Clipboard" />
+          <Tab label="Recent" />
+        </Tabs>
+        <Box flex={1} overflow="auto">
+          {tabIndex === 0 && (
+            <AutoDetectTab
+              content={content}
+              isLoading={isLoading}
+              onImport={handleImport}
+            />
+          )}
+          {tabIndex === 1 && (
+            <ClipboardTab onImportClipboard={handleImportClipboard} />
+          )}
+          {tabIndex === 2 && (
+            <RecentTab imports={imports} onRetry={handleRetry} />
+          )}
+        </Box>
+      </Box>
+    </ThemeProvider>
   );
 };
 
-export default Popup;
+export { Popup };

--- a/apps/extension/src/popup.tsx
+++ b/apps/extension/src/popup.tsx
@@ -1,19 +1,19 @@
-import { useState } from 'react';
 import {
-  ThemeProvider,
-  createTheme,
-  CssBaseline,
   Box,
-  Tabs,
+  CssBaseline,
+  createTheme,
   Tab,
+  Tabs,
+  ThemeProvider,
   Typography,
 } from '@mui/material';
+import type { ExtensionMessage } from 'core/universal/extension/communication/types';
+import { useState } from 'react';
 import { AuthPanel } from './components/AuthPanel';
 import { AutoDetectTab } from './components/AutoDetectTab';
 import { ClipboardTab } from './components/ClipboardTab';
 import { RecentTab } from './components/RecentTab';
 import { usePopupMessaging } from './hooks/usePopupMessaging';
-import type { ExtensionMessage } from 'core/universal/extension/communication/types';
 
 const darkTheme = createTheme({
   palette: {

--- a/apps/listen/src/routes/manage.lazy.tsx
+++ b/apps/listen/src/routes/manage.lazy.tsx
@@ -1,9 +1,9 @@
 import { createLazyFileRoute, useNavigate } from '@tanstack/react-router';
 import { listenMutationHooks, listenQueryHooks } from 'core';
 import { useAuthContext } from 'core/providers/auth';
+import { useEffect } from 'react';
 import { ManageScreen } from 'ui/listen/minimalism';
 import { LoadingBackdrop } from 'ui/universal';
-import { useEffect } from 'react';
 import { appConfig } from '../config';
 import { createPlaylistSlug } from '../utils/slug';
 

--- a/apps/watch/src/routes/playlist.$slug.$playlistId.$videoId.lazy.tsx
+++ b/apps/watch/src/routes/playlist.$slug.$playlistId.$videoId.lazy.tsx
@@ -7,7 +7,7 @@ import {
   useSharePlaylist,
 } from 'core/watch/mutation-hooks/share-videos';
 import { useLoadPlaylistDetail } from 'core/watch/query-hooks/playlist-detail';
-import { lazy, useState, type JSX } from 'react';
+import { type JSX, lazy, useState } from 'react';
 import { AuthRoute } from 'ui/universal/authRoute';
 import { VideoDetailContainer } from 'ui/watch/video-detail-page/containers';
 import { Layout } from '../components/layout';

--- a/biome.json
+++ b/biome.json
@@ -15,7 +15,7 @@
       "!**/public/assets",
       "!**/storybook-static",
       "!**/coverage",
-      "!packages/core/src/graphql/**",
+      "!packages/core/src/graphql",
       "!packages/core/schema.graphql",
       "!**/routeTree.gen.ts"
     ],

--- a/packages/ui/src/listen/minimalism/music-widget/Controls.tsx
+++ b/packages/ui/src/listen/minimalism/music-widget/Controls.tsx
@@ -9,6 +9,7 @@ import SkipNextRounded from '@mui/icons-material/SkipNextRounded';
 import SkipPreviousRounded from '@mui/icons-material/SkipPreviousRounded';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
+
 enum SAudioPlayerLoopMode {
   None = 'none',
   All = 'all',

--- a/packages/ui/src/main/home-page/spending-breakdown/donut-chart.tsx
+++ b/packages/ui/src/main/home-page/spending-breakdown/donut-chart.tsx
@@ -1,7 +1,6 @@
 import { Box, Skeleton, Typography, useTheme } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import type { CategoryType } from 'core/finance';
-import { getFinanceColor } from '../../../universal/minimalism/domainPalette';
 import { formatNumber } from 'core/universal/common';
 import { PieChart } from 'echarts/charts';
 import { LegendComponent, TooltipComponent } from 'echarts/components';
@@ -12,6 +11,7 @@ import { CanvasRenderer } from 'echarts/renderers';
 // default import resolves to the module object instead of the component,
 // which crashes the finance page with React error #130 (SWO-356).
 import ReactEChartsCore from 'echarts-for-react/esm/core';
+import { getFinanceColor } from '../../../universal/minimalism/domainPalette';
 
 echarts.use([PieChart, TooltipComponent, LegendComponent, CanvasRenderer]);
 

--- a/packages/ui/src/main/home-page/transactions-dialog/index.tsx
+++ b/packages/ui/src/main/home-page/transactions-dialog/index.tsx
@@ -13,8 +13,8 @@ import {
 } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import type { CategoryType } from 'core/finance';
-import { getFinanceColor } from '../../../universal/minimalism/domainPalette';
 import { formatNumber } from 'core/universal/common';
+import { getFinanceColor } from '../../../universal/minimalism/domainPalette';
 
 interface Transaction {
   id: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,15 @@ importers:
 
   apps/extension:
     dependencies:
+      '@emotion/react':
+        specifier: ^11.10.5
+        version: 11.14.0(@types/react@19.2.17)(react@19.2.7)
+      '@emotion/styled':
+        specifier: ^11.10.5
+        version: 11.14.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      '@mui/material':
+        specifier: ^9.1.2
+        version: 9.1.2(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       core:
         specifier: workspace:*
         version: link:../../packages/core
@@ -15174,7 +15183,7 @@ snapshots:
 
   '@emotion/babel-plugin@11.13.5':
     dependencies:
-      '@babel/helper-module-imports': 7.25.9
+      '@babel/helper-module-imports': 7.29.7
       '@babel/runtime': 7.29.7
       '@emotion/hash': 0.9.2
       '@emotion/memoize': 0.9.0
@@ -15206,7 +15215,7 @@ snapshots:
 
   '@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      '@babel/runtime': 7.26.10
+      '@babel/runtime': 7.29.7
       '@emotion/babel-plugin': 11.13.5
       '@emotion/cache': 11.14.0
       '@emotion/serialize': 1.3.3
@@ -15232,7 +15241,7 @@ snapshots:
 
   '@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      '@babel/runtime': 7.26.10
+      '@babel/runtime': 7.29.7
       '@emotion/babel-plugin': 11.13.5
       '@emotion/is-prop-valid': 1.3.1
       '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)


### PR DESCRIPTION
## Summary

Rewrite extension popup with tab navigation (Auto-Detect, Clipboard, Recent), auth-aware UI with pairing flow, content display with import actions, and import history with retry support.

## Test plan

- `pnpm lint` — no new errors
- Manual test: open popup on various page types to verify tab switching and content detection