### PR TITLE
feat(extension): add status and feedback system with toasts and import history

### DIFF
--- a/apps/extension/src/components/ToastContainer.tsx
+++ b/apps/extension/src/components/ToastContainer.tsx
@@ -1,0 +1,32 @@
+import { Alert, Snackbar } from '@mui/material';
+import type { Toast } from '../hooks/useToast';
+
+interface ToastContainerProps {
+  toasts: Toast[];
+  onRemove: (id: string) => void;
+}
+
+const ToastContainer = ({ toasts, onRemove }: ToastContainerProps) => (
+  <>
+    {toasts.map((toast, index) => (
+      <Snackbar
+        key={toast.id}
+        open
+        autoHideDuration={4000}
+        onClose={() => onRemove(toast.id)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+        style={{ bottom: `${16 + index * 60}px` }}
+      >
+        <Alert
+          onClose={() => onRemove(toast.id)}
+          severity={toast.severity}
+          variant="filled"
+        >
+          {toast.message}
+        </Alert>
+      </Snackbar>
+    ))}
+  </>
+);
+
+export { ToastContainer };

--- a/apps/extension/src/hooks/useImportHistory.ts
+++ b/apps/extension/src/hooks/useImportHistory.ts
@@ -1,0 +1,48 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { ImportStatus } from 'core/universal/extension/communication/types';
+import { getItems, setItem } from 'core/universal/extension/storage';
+
+const IMPORTS_STORAGE_KEY = 'importHistory';
+
+const useImportHistory = () => {
+  const [imports, setImports] = useState<ImportStatus[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const loadImports = async () => {
+      try {
+        const result = await getItems([IMPORTS_STORAGE_KEY]);
+        const stored = result[IMPORTS_STORAGE_KEY];
+        if (stored) {
+          setImports(JSON.parse(stored));
+        }
+      } catch {
+        // ignore
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    loadImports();
+  }, []);
+
+  useEffect(() => {
+    if (!isLoading) {
+      setItem(IMPORTS_STORAGE_KEY, JSON.stringify(imports));
+    }
+  }, [imports, isLoading]);
+
+  const saveImports = useCallback(
+    (value: ImportStatus[] | ((prev: ImportStatus[]) => ImportStatus[])) => {
+      setImports(value);
+    },
+    [],
+  );
+
+  const clearHistory = useCallback(() => {
+    setImports([]);
+  }, []);
+
+  return { imports, isLoading, saveImports, clearHistory };
+};
+
+export { useImportHistory };

--- a/apps/extension/src/hooks/usePopupMessaging.ts
+++ b/apps/extension/src/hooks/usePopupMessaging.ts
@@ -3,7 +3,8 @@ import type {
   ImportStatus,
   PageContent,
 } from 'core/universal/extension/communication/types';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useImportHistory } from './useImportHistory';
 
 interface PopupMessagingState {
   content: PageContent | null;
@@ -15,11 +16,15 @@ interface PopupMessagingState {
 
 const CHROME_UNAVAILABLE = typeof chrome === 'undefined' || !chrome.runtime?.id;
 
-const usePopupMessaging = (): PopupMessagingState => {
+const usePopupMessaging = (
+  onStatusChange?: (status: ImportStatus) => void,
+): PopupMessagingState => {
   const [content, setContent] = useState<PageContent | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
-  const [imports, setImports] = useState<ImportStatus[]>([]);
+  const { imports, saveImports } = useImportHistory();
+  const onStatusChangeRef = useRef(onStatusChange);
+  onStatusChangeRef.current = onStatusChange;
 
   const sendMessage = useCallback((message: ExtensionMessage) => {
     if (CHROME_UNAVAILABLE) return;
@@ -44,7 +49,7 @@ const usePopupMessaging = (): PopupMessagingState => {
           setIsAuthenticated(message.payload.authenticated);
           break;
         case 'IMPORT_STATUS':
-          setImports((prev) => {
+          saveImports((prev) => {
             const existing = prev.findIndex(
               (i) => i.importId === message.payload.importId,
             );
@@ -55,6 +60,7 @@ const usePopupMessaging = (): PopupMessagingState => {
             }
             return [...prev, message.payload];
           });
+          onStatusChangeRef.current?.(message.payload);
           break;
       }
     };
@@ -80,7 +86,7 @@ const usePopupMessaging = (): PopupMessagingState => {
     return () => {
       chrome.runtime.onMessage.removeListener(handleMessage);
     };
-  }, []);
+  }, [saveImports]);
 
   return { content, isLoading, isAuthenticated, imports, sendMessage };
 };

--- a/apps/extension/src/hooks/useToast.ts
+++ b/apps/extension/src/hooks/useToast.ts
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+
+interface Toast {
+  id: string;
+  message: string;
+  severity: 'success' | 'error' | 'info' | 'warning';
+}
+
+const useToast = () => {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const addToast = (message: string, severity: Toast['severity']) => {
+    const id = `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+    setToasts((prev) => [...prev, { id, message, severity }]);
+    setTimeout(() => {
+      setToasts((prev) => prev.filter((t) => t.id !== id));
+    }, 4000);
+  };
+
+  const removeToast = (id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  };
+
+  return { toasts, addToast, removeToast };
+};
+
+export type { Toast };
+export { useToast };

--- a/apps/extension/src/popup.tsx
+++ b/apps/extension/src/popup.tsx
@@ -7,13 +7,18 @@ import {
   ThemeProvider,
   Typography,
 } from '@mui/material';
-import type { ExtensionMessage } from 'core/universal/extension/communication/types';
+import type {
+  ExtensionMessage,
+  ImportStatus,
+} from 'core/universal/extension/communication/types';
 import { useState } from 'react';
 import { AuthPanel } from './components/AuthPanel';
 import { AutoDetectTab } from './components/AutoDetectTab';
 import { ClipboardTab } from './components/ClipboardTab';
 import { RecentTab } from './components/RecentTab';
+import { ToastContainer } from './components/ToastContainer';
 import { usePopupMessaging } from './hooks/usePopupMessaging';
+import { useToast } from './hooks/useToast';
 
 const darkTheme = createTheme({
   palette: {
@@ -22,9 +27,25 @@ const darkTheme = createTheme({
 });
 
 const Popup = () => {
-  const { content, isLoading, isAuthenticated, imports, sendMessage } =
-    usePopupMessaging();
+  const { toasts, addToast, removeToast } = useToast();
   const [tabIndex, setTabIndex] = useState(0);
+
+  const handleStatusChange = (status: ImportStatus) => {
+    switch (status.status) {
+      case 'importing':
+        addToast('Importing...', 'info');
+        break;
+      case 'completed':
+        addToast('Import complete!', 'success');
+        break;
+      case 'failed':
+        addToast(status.error || 'Import failed', 'error');
+        break;
+    }
+  };
+
+  const { content, isLoading, isAuthenticated, imports, sendMessage } =
+    usePopupMessaging(handleStatusChange);
 
   const handleImport = (contentId: string, targetApp: 'library' | 'watch') => {
     const message: ExtensionMessage = {
@@ -62,6 +83,7 @@ const Popup = () => {
           </Box>
           <AuthPanel />
         </Box>
+        <ToastContainer toasts={toasts} onRemove={removeToast} />
       </ThemeProvider>
     );
   }
@@ -106,6 +128,7 @@ const Popup = () => {
           )}
         </Box>
       </Box>
+      <ToastContainer toasts={toasts} onRemove={removeToast} />
     </ThemeProvider>
   );
 };


### PR DESCRIPTION
## Summary

Add toast notifications for import status, persistent import history via chrome.storage.local, and wire up the popup to display real-time feedback during imports.

## Changes

- `useToast` hook with auto-dismiss after 4s
- `ToastContainer` component using MUI Snackbar + Alert
- `useImportHistory` hook persisting imports to chrome.storage.local
- `usePopupMessaging` now integrates with import history and fires toasts on status changes
- `popup.tsx` wired with toast system in both auth and unauthenticated views

## Test plan

- `pnpm --filter=extension lint` — no new errors