### PR TITLE
feat(extension): add library app API integration for PDF imports

### DIFF
--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -7,8 +7,34 @@ import {
   pollForDeviceToken,
   startPairing,
 } from './background/auth';
+import { importBook } from './background/library';
+import {
+  createImportRecord,
+  updateImportStatus,
+} from './background/imports';
+import type {
+  PdfMetadata,
+  PageContent,
+} from 'core/universal/extension/communication/types';
 
 console.log('Background script starting...');
+
+let currentPageContent: PageContent | null = null;
+let currentPdfMetadata: PdfMetadata | null = null;
+
+const importBookAsync = async (metadata: PdfMetadata): Promise<void> => {
+  const record = createImportRecord('library', metadata.title);
+
+  updateImportStatus(record.importId, 'importing');
+
+  const result = await importBook(metadata);
+
+  if (result.success) {
+    updateImportStatus(record.importId, 'completed');
+  } else {
+    updateImportStatus(record.importId, 'failed', result.error);
+  }
+};
 
 chrome.runtime.onInstalled.addListener(() => {
   console.log('Extension installed/updated');
@@ -86,6 +112,34 @@ chrome.runtime.onMessage.addListener(async (message, _sender, sendResponse) => {
     case 'LOGOUT': {
       await logout();
       sendResponse({ success: true });
+      return;
+    }
+
+    case 'PDF_METADATA_EXTRACTED': {
+      currentPdfMetadata = message.payload as PdfMetadata;
+      currentPageContent = {
+        url: currentPdfMetadata.url,
+        title: currentPdfMetadata.title || 'Untitled PDF',
+        pageType: 'pdf',
+        description: currentPdfMetadata.author ? `Author: ${currentPdfMetadata.author}` : undefined,
+      };
+      sendResponse({ received: true });
+      return;
+    }
+
+    case 'REQUEST_TAB_CONTENT': {
+      sendResponse({ content: currentPageContent });
+      return;
+    }
+
+    case 'IMPORT_CONTENT': {
+      const { targetApp } = message.payload as { contentId: string; targetApp: 'library' | 'watch' };
+      if (targetApp === 'library' && currentPdfMetadata) {
+        importBookAsync(currentPdfMetadata);
+        sendResponse({ started: true });
+      } else {
+        sendResponse({ started: false, error: targetApp !== 'library' ? 'Unsupported target app' : 'No PDF metadata available' });
+      }
       return;
     }
   }

--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -8,10 +8,7 @@ import {
   startPairing,
 } from './background/auth';
 import { importBook } from './background/library';
-import {
-  createImportRecord,
-  updateImportStatus,
-} from './background/imports';
+import { createImportRecord, updateImportStatus } from './background/imports';
 import type {
   PdfMetadata,
   PageContent,
@@ -121,7 +118,9 @@ chrome.runtime.onMessage.addListener(async (message, _sender, sendResponse) => {
         url: currentPdfMetadata.url,
         title: currentPdfMetadata.title || 'Untitled PDF',
         pageType: 'pdf',
-        description: currentPdfMetadata.author ? `Author: ${currentPdfMetadata.author}` : undefined,
+        description: currentPdfMetadata.author
+          ? `Author: ${currentPdfMetadata.author}`
+          : undefined,
       };
       sendResponse({ received: true });
       return;
@@ -133,12 +132,21 @@ chrome.runtime.onMessage.addListener(async (message, _sender, sendResponse) => {
     }
 
     case 'IMPORT_CONTENT': {
-      const { targetApp } = message.payload as { contentId: string; targetApp: 'library' | 'watch' };
+      const { targetApp } = message.payload as {
+        contentId: string;
+        targetApp: 'library' | 'watch';
+      };
       if (targetApp === 'library' && currentPdfMetadata) {
         importBookAsync(currentPdfMetadata);
         sendResponse({ started: true });
       } else {
-        sendResponse({ started: false, error: targetApp !== 'library' ? 'Unsupported target app' : 'No PDF metadata available' });
+        sendResponse({
+          started: false,
+          error:
+            targetApp !== 'library'
+              ? 'Unsupported target app'
+              : 'No PDF metadata available',
+        });
       }
       return;
     }

--- a/apps/extension/src/background/imports.ts
+++ b/apps/extension/src/background/imports.ts
@@ -1,11 +1,18 @@
-import { getItems, setItem, removeItems } from 'core/universal/extension/storage';
+import {
+  getItems,
+  setItem,
+  removeItems,
+} from 'core/universal/extension/storage';
 import type { ImportStatus } from 'core/universal/extension/communication/types';
 
 const STORAGE_KEY = 'importHistory';
 
 const imports = new Map<string, ImportStatus>();
 
-const createImportRecord = (targetApp: 'library' | 'watch', title?: string): ImportStatus => {
+const createImportRecord = (
+  targetApp: 'library' | 'watch',
+  title?: string,
+): ImportStatus => {
   const record: ImportStatus = {
     importId: crypto.randomUUID(),
     status: 'pending',
@@ -19,7 +26,11 @@ const createImportRecord = (targetApp: 'library' | 'watch', title?: string): Imp
   return record;
 };
 
-const updateImportStatus = (importId: string, status: ImportStatus['status'], error?: string): void => {
+const updateImportStatus = (
+  importId: string,
+  status: ImportStatus['status'],
+  error?: string,
+): void => {
   const record = imports.get(importId);
   if (!record) return;
 
@@ -58,4 +69,9 @@ const persistHistory = async (): Promise<void> => {
   await setItem(STORAGE_KEY, JSON.stringify(records));
 };
 
-export { createImportRecord, updateImportStatus, getImportHistory, clearImportHistory };
+export {
+  createImportRecord,
+  updateImportStatus,
+  getImportHistory,
+  clearImportHistory,
+};

--- a/apps/extension/src/background/imports.ts
+++ b/apps/extension/src/background/imports.ts
@@ -1,0 +1,61 @@
+import { getItems, setItem, removeItems } from 'core/universal/extension/storage';
+import type { ImportStatus } from 'core/universal/extension/communication/types';
+
+const STORAGE_KEY = 'importHistory';
+
+const imports = new Map<string, ImportStatus>();
+
+const createImportRecord = (targetApp: 'library' | 'watch', title?: string): ImportStatus => {
+  const record: ImportStatus = {
+    importId: crypto.randomUUID(),
+    status: 'pending',
+    targetApp,
+    title,
+  };
+
+  imports.set(record.importId, record);
+  persistHistory();
+
+  return record;
+};
+
+const updateImportStatus = (importId: string, status: ImportStatus['status'], error?: string): void => {
+  const record = imports.get(importId);
+  if (!record) return;
+
+  record.status = status;
+  if (error) {
+    record.error = error;
+  }
+
+  imports.set(importId, record);
+  persistHistory();
+
+  chrome.runtime.sendMessage({
+    source: 'background',
+    target: 'popup',
+    type: 'IMPORT_STATUS',
+    payload: { ...record },
+  });
+};
+
+const getImportHistory = async (): Promise<ImportStatus[]> => {
+  const result = await getItems([STORAGE_KEY]);
+  try {
+    return JSON.parse(result[STORAGE_KEY] ?? '[]');
+  } catch {
+    return [];
+  }
+};
+
+const clearImportHistory = async (): Promise<void> => {
+  imports.clear();
+  await removeItems([STORAGE_KEY]);
+};
+
+const persistHistory = async (): Promise<void> => {
+  const records = Array.from(imports.values());
+  await setItem(STORAGE_KEY, JSON.stringify(records));
+};
+
+export { createImportRecord, updateImportStatus, getImportHistory, clearImportHistory };

--- a/apps/extension/src/background/library.ts
+++ b/apps/extension/src/background/library.ts
@@ -2,7 +2,9 @@ import { getToken } from './auth';
 import { hasuraConfig } from '../../envConfig';
 import type { PdfMetadata } from 'core/universal/extension/communication/types';
 
-const importBook = async (metadata: PdfMetadata): Promise<{ success: boolean; bookId?: string; error?: string }> => {
+const importBook = async (
+  metadata: PdfMetadata,
+): Promise<{ success: boolean; bookId?: string; error?: string }> => {
   const token = await getToken();
   if (!token) {
     return { success: false, error: 'Not authenticated' };
@@ -38,7 +40,10 @@ const importBook = async (metadata: PdfMetadata): Promise<{ success: boolean; bo
   const json = await response.json();
 
   if (json.errors) {
-    return { success: false, error: json.errors[0]?.message ?? 'Failed to insert book' };
+    return {
+      success: false,
+      error: json.errors[0]?.message ?? 'Failed to insert book',
+    };
   }
 
   const book = json.data?.insert_books_one;

--- a/apps/extension/src/background/library.ts
+++ b/apps/extension/src/background/library.ts
@@ -1,0 +1,52 @@
+import { getToken } from './auth';
+import { hasuraConfig } from '../../envConfig';
+import type { PdfMetadata } from 'core/universal/extension/communication/types';
+
+const importBook = async (metadata: PdfMetadata): Promise<{ success: boolean; bookId?: string; error?: string }> => {
+  const token = await getToken();
+  if (!token) {
+    return { success: false, error: 'Not authenticated' };
+  }
+
+  const response = await fetch(hasuraConfig.url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      query: `
+        mutation InsertBook($object: books_insert_input!) {
+          insert_books_one(object: $object) {
+            id
+            title
+          }
+        }
+      `,
+      variables: {
+        object: {
+          title: metadata.title || 'Untitled',
+          author: metadata.author || '',
+          source: metadata.url,
+          totalPages: metadata.pageCount,
+          status: 'ready',
+        },
+      },
+    }),
+  });
+
+  const json = await response.json();
+
+  if (json.errors) {
+    return { success: false, error: json.errors[0]?.message ?? 'Failed to insert book' };
+  }
+
+  const book = json.data?.insert_books_one;
+  if (!book?.id) {
+    return { success: false, error: 'No book ID returned' };
+  }
+
+  return { success: true, bookId: book.id };
+};
+
+export { importBook };


### PR DESCRIPTION
## Summary

Wire the background service worker to import PDFs as books via Hasura `insert_books_one` mutation when the user clicks "Import to Library" in the popup.

## Changes

- `background/library.ts` — calls `insert_books_one` mutation mapping `PdfMetadata` → `books_insert_input`
- `background/imports.ts` — shared import manager with ID generation, status tracking, chrome.storage.local persistence, and `IMPORT_STATUS` message dispatch
- `background.ts` — new handlers for `PDF_METADATA_EXTRACTED`, `REQUEST_TAB_CONTENT`, and `IMPORT_CONTENT` (library target)

## Test plan

- `pnpm --filter=extension lint` — no new errors