### PR TITLE
feat(extension): add watch app API integration for video imports

### DIFF
--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -1,4 +1,9 @@
 import { removeItems, setItem } from 'core/universal/extension/storage';
+import type {
+  PageContent,
+  PdfMetadata,
+  VideoMetadata,
+} from 'core/universal/extension/communication/types';
 import { config } from '../config';
 import {
   getToken,
@@ -8,16 +13,14 @@ import {
   startPairing,
 } from './background/auth';
 import { importBook } from './background/library';
+import { importVideo } from './background/watch';
 import { createImportRecord, updateImportStatus } from './background/imports';
-import type {
-  PdfMetadata,
-  PageContent,
-} from 'core/universal/extension/communication/types';
 
 console.log('Background script starting...');
 
 let currentPageContent: PageContent | null = null;
 let currentPdfMetadata: PdfMetadata | null = null;
+let storedVideoMetadata: VideoMetadata | null = null;
 
 const importBookAsync = async (metadata: PdfMetadata): Promise<void> => {
   const record = createImportRecord('library', metadata.title);
@@ -126,8 +129,14 @@ chrome.runtime.onMessage.addListener(async (message, _sender, sendResponse) => {
       return;
     }
 
+    case 'VIDEO_METADATA_EXTRACTED': {
+      storedVideoMetadata = data;
+      sendResponse({ success: true });
+      return;
+    }
+
     case 'REQUEST_TAB_CONTENT': {
-      sendResponse({ content: currentPageContent });
+      sendResponse({ content: currentPageContent ?? storedVideoMetadata ?? null });
       return;
     }
 
@@ -136,18 +145,46 @@ chrome.runtime.onMessage.addListener(async (message, _sender, sendResponse) => {
         contentId: string;
         targetApp: 'library' | 'watch';
       };
-      if (targetApp === 'library' && currentPdfMetadata) {
+
+      if (targetApp === 'library') {
+        if (!currentPdfMetadata) {
+          sendResponse({ started: false, error: 'No PDF metadata available' });
+          return;
+        }
         importBookAsync(currentPdfMetadata);
         sendResponse({ started: true });
-      } else {
-        sendResponse({
-          started: false,
-          error:
-            targetApp !== 'library'
-              ? 'Unsupported target app'
-              : 'No PDF metadata available',
-        });
+        return;
       }
+
+      if (targetApp === 'watch') {
+        if (!storedVideoMetadata) {
+          sendResponse({ success: false, error: 'No video metadata available' });
+          return;
+        }
+
+        const record = createImportRecord('watch', storedVideoMetadata.title);
+        updateImportStatus(record.importId, 'importing');
+
+        try {
+          const result = await importVideo(storedVideoMetadata);
+
+          if (result.success) {
+            updateImportStatus(record.importId, 'completed');
+            sendResponse({ success: true, videoId: result.videoId });
+          } else {
+            updateImportStatus(record.importId, 'failed', result.error);
+            sendResponse({ success: false, error: result.error });
+          }
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : 'Unknown error';
+          updateImportStatus(record.importId, 'failed', message);
+          sendResponse({ success: false, error: message });
+        }
+        return;
+      }
+
+      sendResponse({ started: false, error: 'Unsupported target app' });
       return;
     }
   }

--- a/apps/extension/src/background/watch.ts
+++ b/apps/extension/src/background/watch.ts
@@ -1,0 +1,62 @@
+import { getToken } from './auth';
+import { hasuraConfig } from '../../envConfig';
+import type { VideoMetadata } from 'core/universal/extension/communication/types';
+
+const importVideo = async (
+  metadata: VideoMetadata,
+): Promise<{ success: boolean; videoId?: string; error?: string }> => {
+  const token = await getToken();
+
+  if (!token) {
+    return { success: false, error: 'Not authenticated' };
+  }
+
+  const response = await fetch(hasuraConfig.url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      query: `
+        mutation InsertVideo($object: videos_insert_input!) {
+          insert_videos_one(object: $object) {
+            id
+            title
+          }
+        }
+      `,
+      variables: {
+        object: {
+          title: metadata.title || 'Untitled Video',
+          source: metadata.url,
+          video_url: metadata.url,
+          sId: metadata.videoId,
+          thumbnailUrl: metadata.thumbnailUrl,
+          duration: metadata.duration,
+          status: 'ready',
+          keepOriginalSource: true,
+        },
+      },
+    }),
+  });
+
+  const json = await response.json();
+
+  if (json.errors) {
+    return {
+      success: false,
+      error: json.errors[0]?.message ?? 'Failed to import video',
+    };
+  }
+
+  const video = json.data?.insert_videos_one;
+
+  if (!video?.id) {
+    return { success: false, error: 'No video ID returned' };
+  }
+
+  return { success: true, videoId: video.id };
+};
+
+export { importVideo };

--- a/apps/extension/src/content-scripts/content.ts
+++ b/apps/extension/src/content-scripts/content.ts
@@ -1,28 +1,58 @@
 import type { ExtensionMessage } from 'core/universal/extension/communication/types';
 
 import { isPdfPage, parsePdfDocument } from './parsers/pdf';
+import {
+  detectPageType,
+  extractYouTubeMetadata,
+  extractVimeoMetadata,
+} from './parsers/detector';
 
 const main = async () => {
   const url = window.location.href;
   const contentType = document.contentType;
 
-  if (!isPdfPage(url, contentType)) {
+  if (isPdfPage(url, contentType)) {
+    try {
+      const metadata = await parsePdfDocument(url);
+
+      const message: ExtensionMessage = {
+        source: 'content-script',
+        target: 'background',
+        type: 'PDF_METADATA_EXTRACTED',
+        payload: metadata,
+      };
+
+      chrome.runtime.sendMessage(message);
+    } catch (error) {
+      console.error('Failed to parse PDF metadata:', error);
+    }
     return;
   }
 
-  try {
-    const metadata = await parsePdfDocument(url);
+  const pageType = detectPageType(url);
 
+  if (pageType === 'youtube') {
+    const metadata = extractYouTubeMetadata();
     const message: ExtensionMessage = {
       source: 'content-script',
       target: 'background',
-      type: 'PDF_METADATA_EXTRACTED',
+      type: 'VIDEO_METADATA_EXTRACTED',
       payload: metadata,
     };
-
     chrome.runtime.sendMessage(message);
-  } catch (error) {
-    console.error('Failed to parse PDF metadata:', error);
+    return;
+  }
+
+  if (pageType === 'vimeo') {
+    const metadata = extractVimeoMetadata();
+    const message: ExtensionMessage = {
+      source: 'content-script',
+      target: 'background',
+      type: 'VIDEO_METADATA_EXTRACTED',
+      payload: metadata,
+    };
+    chrome.runtime.sendMessage(message);
+    return;
   }
 };
 


### PR DESCRIPTION
## Summary

Wire the background service worker to import YouTube/Vimeo videos via Hasura `insert_videos_one` mutation when the user clicks "Import to Watch" in the popup.

## Changes

- `background/watch.ts` — calls `insert_videos_one` mutation mapping `VideoMetadata` → `videos_insert_input`
- `background/imports.ts` — shared import manager with ID generation, status tracking, persistence
- `background.ts` — new handlers for `VIDEO_METADATA_EXTRACTED`, `REQUEST_TAB_CONTENT`, and `IMPORT_CONTENT` (watch target)
- `content-scripts/content.ts` — now detects video pages and sends `VIDEO_METADATA_EXTRACTED`

## Test plan

- `pnpm --filter=extension lint` — no new errors