### PR TITLE
[WIP] docs(skills): add design-principles, backend-ops, dev-environment-gotchas skills

### DIFF
--- a/.claude/skills/backend-ops/SKILL.md
+++ b/.claude/skills/backend-ops/SKILL.md
@@ -50,7 +50,7 @@ The owner's most common recurring ops ask: they have local `.mp3` files and ask 
 
 1. Owner = **shinabr2** by default.
 2. `name` + `artistName` from the filename — usually `Title - Artist.mp3`. Only ask if genuinely ambiguous; `artist_name` is NOT NULL so it must be set.
-3. `public: false` by default — see the `security-reviewer` skill's Hasura reference for why only the admin/DB owner may ever set `public: true`.
+3. `public: false` by default — publishing is an act of owning the database, not a user capability; only the admin/DB owner ever sets `public: true`.
 4. Upload the mp3 to GCS `audios/<shinabr2-id>/<slug>.mp3` and `insert_audios_one` via Hasura admin (one-off `tsx` script; no audio CLI yet).
 5. Quick dup-check by name+user first; verify the public URL returns 200 after.
 

--- a/.claude/skills/backend-ops/SKILL.md
+++ b/.claude/skills/backend-ops/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: backend-ops
+description: How to perform sworld operational tasks from the sworld-backend repo — GCS asset layout, operator CLIs, direct prod DB access, and the recurring "create audios" ingestion task. Auto-triggers when uploading media, ingesting mp3/video files, touching prod data directly, or working in sworld-backend/src/cli.
+user-invocable: false
+---
+
+# Backend Ops
+
+How to perform sworld operational tasks (create audios/videos, upload assets, touch prod data) from the **sworld-backend** repo (sibling to `sworld/`). This is separate from the `parallel-workflow` PR process — these are direct, already-authorized ops tasks, not feature work. Don't re-ask the user for credentials or access; they're already configured.
+
+## User-id aliases
+
+The owner has two sworld accounts, referred to by name instead of UUID:
+
+- **shinabr2** → `6ff27fda-03e8-4dcd-949b-f1328f955065` — **the default account for everything.** All ops (create audios/videos, playlists, ownership) use shinabr2 unless the user explicitly names `quachtan`. Don't ask which account; assume shinabr2.
+- **quachtan** / **quachtanqt** → `fe8b7813-472f-462c-a5cf-308b53009a40`
+
+Caveat: `~/.sworld-cli/config.json`'s `user-id` currently points at **quachtan** — for any CLI/script, override it (`--user-id 6ff27fda-...` or hardcode shinabr2 in a one-off script) rather than relying on the config default.
+
+## Assets live in GCP Cloud Storage
+
+All media/assets are in GCS, bucket **`sworld-prod.appspot.com`**. Public URL = `https://storage.googleapis.com/sworld-prod.appspot.com/<objectPath>`.
+
+Layout: `videos/<userId>/<videoId>/…` (HLS: `playlist.m3u8` + segments/`init.mp4`/`.m4s`), `audios/<userId>/<file>.mp3`, subtitles `videos/<userId>/<videoId>/<lang>.vtt`.
+
+## Credentials (already configured — reuse, don't ask)
+
+- **`~/.sworld-cli/config.json`**: `gcp-key` (service-account JSON at `/Users/tranvanvuong/Projects/sworld/cli.json`), `gcp-bucket` (`sworld-prod.appspot.com`), `hasura-endpoint` (`https://free-lamprey-59.hasura.app/v1/graphql`), `hasura-secret` (admin), `user-id` (see aliases above — override, don't trust the default).
+- GCS auth: `new Storage({ keyFilename })` with that `gcp-key`. `gcloud` ADC is NOT set up — always use the key file.
+- **`sworld-backend/.env`** also has: `GCP_STORAGE_BUCKET`, `HASURA_ADMIN_SECRET` + `HASURA_ENDPOINT`, `DATABASE_URL` (Neon Postgres, direct), Cloudinary, OpenAI, etc. `packages/core/.env` in the frontend repo also has `HASURA_GRAPHQL_URL` + `HASURA_ADMIN_SECRET` for quick admin queries via curl.
+
+## Talking to the production DB directly
+
+- Via **Hasura admin** (endpoint + admin secret above) with GraphQL — admin bypasses all row permissions. Use for reads (dup checks) and writes (insert audios rows, link playlist_audios, etc.).
+- Or Neon Postgres directly via `DATABASE_URL`.
+
+## Operator CLIs in `sworld-backend/src/cli/` (run via `npx tsx src/cli/<x>.ts`)
+
+- **convert.ts** — local video file → fMP4 HLS, upload to GCS, create/finalize the `videos` row (`--file`, `--title`, `--video-id`, `--playlist`, `--public`, `--dry-run`, `--user-id`).
+- **stream-m3u8.ts** — fix a failed video: process an `.m3u8` (master or media) → GCS, finalize an existing `videos` row (`--url`/`--file`, `--video-id`, `--referer`, `--playlist`). Also owns the shared CLI config (`config set <key> <value>`).
+- **upload-subtitle.ts** — upload a `.vtt` (local or URL) → GCS, insert/update `subtitles` row.
+- **repair-fmp4.ts** — repackage a video's stored `.ts` → fMP4 (fixes garbled desktop-Chrome audio).
+- **No audio CLI exists** — for audios, write a one-off `tsx` script that reads `~/.sworld-cli/config.json`, uploads the mp3 to `audios/<userId>/<file>.mp3` via `@google-cloud/storage`, then `insert_audios_one` via Hasura admin (GraphQL field names: `artistName`, `user_id`, `source`, `name`, `public`). A reusable `audio.ts` CLI would be a nice follow-up. Full CLI docs: `sworld-backend/src/cli/README.md`.
+
+## Recurring task: "create audios"
+
+The owner's most common recurring ops ask: they have local `.mp3` files and ask to "create new audios." Just do it — don't explain the plumbing (GCS, CLI scripts, pipeline) unless asked; keep it simple.
+
+**The flow for each mp3:**
+
+1. Owner = **shinabr2** by default.
+2. `name` + `artistName` from the filename — usually `Title - Artist.mp3`. Only ask if genuinely ambiguous; `artist_name` is NOT NULL so it must be set.
+3. `public: false` by default — see the `security-reviewer` skill's Hasura reference for why only the admin/DB owner may ever set `public: true`.
+4. Upload the mp3 to GCS `audios/<shinabr2-id>/<slug>.mp3` and `insert_audios_one` via Hasura admin (one-off `tsx` script; no audio CLI yet).
+5. Quick dup-check by name+user first; verify the public URL returns 200 after.
+
+Batches are common (a folder of mp3s).
+
+## Third-party video imports (javhd/JAV, Wishlist SWO-118 "Videos" comments)
+
+- Stream CDN is `sf16-sg.tiktokcdn.top`; it hotlink-checks Referer/Origin against the source site's domain — pass `--referer https://javhdz.im` to `stream-m3u8.ts` (also covers `--thumbnail` fetches, which reuse `--referer`).
+- Use **`javhdz.im`**, not `javhdz.ws` — `.ws` is DNS-sinkholed and TLS/SNI-blocked on this network; `.im` is a live mirror serving the same `/data/<code>.jpg` thumbnails and is accepted by the CDN as Referer too.
+- Video codes (e.g. `FNS-224`) become the video `title`/`slug`; playlists are actress names, usually already existing (find by id given in the comment, don't recreate by slug lookup unless no id is given).

--- a/.claude/skills/backend-ops/SKILL.md
+++ b/.claude/skills/backend-ops/SKILL.md
@@ -40,21 +40,21 @@ Layout: `videos/<userId>/<videoId>/…` (HLS: `playlist.m3u8` + segments/`init.m
 - **stream-m3u8.ts** — fix a failed video: process an `.m3u8` (master or media) → GCS, finalize an existing `videos` row (`--url`/`--file`, `--video-id`, `--referer`, `--playlist`). Also owns the shared CLI config (`config set <key> <value>`).
 - **upload-subtitle.ts** — upload a `.vtt` (local or URL) → GCS, insert/update `subtitles` row.
 - **repair-fmp4.ts** — repackage a video's stored `.ts` → fMP4 (fixes garbled desktop-Chrome audio).
-- **No audio CLI exists** — for audios, write a one-off `tsx` script that reads `~/.sworld-cli/config.json`, uploads the mp3 to `audios/<userId>/<file>.mp3` via `@google-cloud/storage`, then `insert_audios_one` via Hasura admin (GraphQL field names: `artistName`, `user_id`, `source`, `name`, `public`). A reusable `audio.ts` CLI would be a nice follow-up. Full CLI docs: `sworld-backend/src/cli/README.md`.
+- **audio.ts** — publish a local `.mp3` to the listen library: no transcode, just upload verbatim to GCS + insert the `audios` row (`--file <path>` or `--dir <path>` for a whole folder, `--name`/`--artist` overrides, `--public`, `--dry-run`, `--skip-db`, `--user-id`). Handles dup-checking and filename metadata parsing itself — see below. Full CLI docs: `sworld-backend/src/cli/README.md`.
 
 ## Recurring task: "create audios"
 
-The owner's most common recurring ops ask: they have local `.mp3` files and ask to "create new audios." Just do it — don't explain the plumbing (GCS, CLI scripts, pipeline) unless asked; keep it simple.
+The owner's most common recurring ops ask: they have local `.mp3` files and ask to "create new audios." Just run `audio.ts` — don't explain the plumbing (GCS, CLI internals) unless asked; keep it simple.
 
-**The flow for each mp3:**
+```bash
+# One file (name + artist parsed from "Title - Artist.mp3"):
+npx tsx src/cli/audio.ts --file './Shape of You - Ed Sheeran.mp3' --user-id 6ff27fda-03e8-4dcd-949b-f1328f955065
 
-1. Owner = **shinabr2** by default.
-2. `name` + `artistName` from the filename — usually `Title - Artist.mp3`. Only ask if genuinely ambiguous; `artist_name` is NOT NULL so it must be set.
-3. `public: false` by default — publishing is an act of owning the database, not a user capability; only the admin/DB owner ever sets `public: true`.
-4. Upload the mp3 to GCS `audios/<shinabr2-id>/<slug>.mp3` and `insert_audios_one` via Hasura admin (one-off `tsx` script; no audio CLI yet).
-5. Quick dup-check by name+user first; verify the public URL returns 200 after.
+# A whole folder, dry-run first:
+npx tsx src/cli/audio.ts --dir ./album --user-id 6ff27fda-03e8-4dcd-949b-f1328f955065 --dry-run
+```
 
-Batches are common (a folder of mp3s).
+The CLI already handles the flow the owner cares about: `name`/`artist` parsed from the filename (`artist_name` is NOT NULL — a file with no parseable artist and no `--artist` is reported and skipped, not silently defaulted), `public: false` by default (add `--public` only if explicitly asked — publishing is an act of owning the database, see the `security-reviewer` skill's publishing-is-owner-only invariant), an existing `(user_id, name)` skipped as a dup, and a `Created / Skipped / Failed` tally on a batch. Owner = **shinabr2** by default (`--user-id`, since `~/.sworld-cli/config.json`'s default points at quachtan).
 
 ## Third-party video imports (javhd/JAV, Wishlist SWO-118 "Videos" comments)
 

--- a/.claude/skills/backend-ops/SKILL.md
+++ b/.claude/skills/backend-ops/SKILL.md
@@ -25,7 +25,7 @@ Layout: `videos/<userId>/<videoId>/…` (HLS: `playlist.m3u8` + segments/`init.m
 
 ## Credentials (already configured — reuse, don't ask)
 
-- **`~/.sworld-cli/config.json`**: `gcp-key` (service-account JSON at `/Users/tranvanvuong/Projects/sworld/cli.json`), `gcp-bucket` (`sworld-prod.appspot.com`), `hasura-endpoint` (`https://free-lamprey-59.hasura.app/v1/graphql`), `hasura-secret` (admin), `user-id` (see aliases above — override, don't trust the default).
+- **`~/.sworld-cli/config.json`**: `gcp-key` (path to the service-account JSON — read the value from the config, don't hardcode a path), `gcp-bucket` (`sworld-prod.appspot.com`), `hasura-endpoint` (`https://free-lamprey-59.hasura.app/v1/graphql`), `hasura-secret` (admin), `user-id` (see aliases above — override, don't trust the default).
 - GCS auth: `new Storage({ keyFilename })` with that `gcp-key`. `gcloud` ADC is NOT set up — always use the key file.
 - **`sworld-backend/.env`** also has: `GCP_STORAGE_BUCKET`, `HASURA_ADMIN_SECRET` + `HASURA_ENDPOINT`, `DATABASE_URL` (Neon Postgres, direct), Cloudinary, OpenAI, etc. `packages/core/.env` in the frontend repo also has `HASURA_GRAPHQL_URL` + `HASURA_ADMIN_SECRET` for quick admin queries via curl.
 

--- a/.claude/skills/backend-ops/SKILL.md
+++ b/.claude/skills/backend-ops/SKILL.md
@@ -54,7 +54,7 @@ npx tsx src/cli/audio.ts --file './Shape of You - Ed Sheeran.mp3' --user-id 6ff2
 npx tsx src/cli/audio.ts --dir ./album --user-id 6ff27fda-03e8-4dcd-949b-f1328f955065 --dry-run
 ```
 
-The CLI already handles the flow the owner cares about: `name`/`artist` parsed from the filename (`artist_name` is NOT NULL — a file with no parseable artist and no `--artist` is reported and skipped, not silently defaulted), `public: false` by default (add `--public` only if explicitly asked — publishing is an act of owning the database, see the `security-reviewer` skill's publishing-is-owner-only invariant), an existing `(user_id, name)` skipped as a dup, and a `Created / Skipped / Failed` tally on a batch. Owner = **shinabr2** by default (`--user-id`, since `~/.sworld-cli/config.json`'s default points at quachtan).
+The CLI already handles the flow the owner cares about: `name`/`artist` parsed from the filename (`artist_name` is NOT NULL — a file with no parseable artist and no `--artist` is reported and skipped, not silently defaulted), `public: false` by default (add `--public` only if explicitly asked — publishing is an act of owning the database, not a user capability, so only flip it on explicit instruction), an existing `(user_id, name)` skipped as a dup, and a `Created / Skipped / Failed` tally on a batch. Owner = **shinabr2** by default (`--user-id`, since `~/.sworld-cli/config.json`'s default points at quachtan).
 
 ## Third-party video imports (javhd/JAV, Wishlist SWO-118 "Videos" comments)
 

--- a/.claude/skills/design-principles/SKILL.md
+++ b/.claude/skills/design-principles/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: design-principles
+description: Owner's cross-app product/UX principles — generous spacing, input-vs-view app affordances, and the Listen app's design north star. Auto-triggers when designing or reviewing layout, spacing, navigation affordances (FAB/drawer/dashboard), or any UI work in apps/listen.
+user-invocable: false
+---
+
+# Design Principles
+
+These are product-taste decisions from the owner (vincent), not derived from the code — get them wrong and a technically-correct PR still misses the point.
+
+## Generous spacing, always
+
+Across ALL apps (listen, watch, til, game, docs, main), the design language is **generous spacing** — large paddings/margins, airy layouts, roomy components, deliberately. More spacing reads as more generous to the end user; dense, neat, tightly-packed UI is explicitly disliked.
+
+- Never suggest tightening density, shrinking components, or "filling empty space" to make a layout more compact.
+- If something looks off in an airy layout, the fix is almost never *less space* — it's fixing broken-looking content (grey/placeholder holes, failed-avatar icons) so the emptiness reads as intentional, not shrinking the footprint.
+
+## Input-heavy apps get a FAB; view-first apps get a management dashboard
+
+Decided 2026-07-04 (SWO-379):
+
+- **Input-heavy apps** — main's finance + journal, and til — surface their primary create action as a **floating action button** (FAB), because users input a lot.
+- **View-first apps** — watch and listen — must **NOT** get a create FAB. Their surfaces stay purely about consumption. All content management (upload, edit, delete, playlists) belongs in a dedicated per-app **management dashboard** (SWO-387 watch, SWO-388 listen), never in the primary browsing UI.
+- Create actions never belong in the avatar drawer either — that drawer is for **settings + logout only**, in any app.
+
+**Why:** the distinction is how much the end user inputs; a FAB overweights a rare/admin action in a consumption app.
+
+**How to apply:** when adding any create/manage affordance to watch or listen, route it to the management-dashboard concept, not a FAB or a drawer item.
+
+## Listen app design north star
+
+- **Player-first home.** Opening the app = one click and your songs play. The home must NOT become a browse/grid like the watch site.
+- **One-screen principle.** The home and the playlist-detail page are the *same screen, same UX*: Header + feeling filter (tags) + player (`MusicWidget` + `PlayingList`). Rule of thumb: **any page where you can play audio must be this same screen** — only the data (which songs) differs.
+- **Standalone songs = audios not in any playlist.** These are the home's default collection (home shows standalone, playlists hold the rest — confirm before shipping, it's a deliberate departure from "home shows all audios").
+- **Playlist access = a drawer, not a page** (proposed): a quiet header icon opens a source-switcher drawer (Songs + each playlist + New), tapping one reloads the same screen. Avoid a separate `/playlists` grid — it breaks the one-screen feel.
+- **Aesthetic: elegant, simple, minimal — deliberately NOT a cluttered "commercialized" music app.** Lots of whitespace, one accent, calm now-playing focal point.
+
+Applies to any `apps/listen` UI work. See the `architecture` skill's "one page = one query" rule before adding a data fetch for a listen feature — most "like page X" needs are already in the current page's query.
+
+See also the `mui` skill's two-case styling model (global=theme, situational=sx) for how these principles get implemented in code.

--- a/.claude/skills/dev-environment-gotchas/SKILL.md
+++ b/.claude/skills/dev-environment-gotchas/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: dev-environment-gotchas
+description: Known traps in the sworld local dev/build tooling — stale package dists, turbo cache masking bundle changes, Node version pinning, pnpm's dependency cooldown, CodeGraph setup, and bundle-size vs error-tracking tradeoffs. Auto-triggers when a dev server fails to resolve a core/ui subpath, a build "works" but the change isn't visible, adding/upgrading a dependency, or trimming bundle size for perf.
+user-invocable: false
+---
+
+# Dev Environment Gotchas
+
+Symptoms in this repo that look like framework bugs but have a known, boring cause. Check here before assuming Vite/Turbo/pnpm is broken.
+
+## `core`/`ui` dev-watch gutting dist
+
+`packages/core` and `packages/ui`'s `dev` script is `tsup ... --watch`, while `tsup.config.ts` has `clean: true` and a full `src/**/*.ts` entry glob. Running the dev script directly (or via a stray `turbo watch`) wipes `dist/` and rebuilds **only the root entry**, leaving `dist/providers/…`, `dist/<domain>/query-hooks/…`, etc. missing.
+
+**Symptom:** an app dev server fails with `Failed to resolve import "core/providers/auth"` (or any `core`/`ui` subpath) — looks like a Vite resolver bug, isn't. Check `find packages/core/dist -name index.mjs | wc -l` (healthy ≈ 58, gutted = 1) and run `pnpm --filter core build` (or `--filter ui`).
+
+## Listen dev serves `ui`/`core` from dist, not source
+
+`apps/listen`'s vite dev server resolves `ui` and `core` through their package.json `exports`, which point to `./dist/` — there is **no** `resolve.alias` to source in `apps/listen/vite.config.ts`. Editing `packages/ui/src/**` or `packages/core/src/**` does **not** show up via HMR; the browser keeps running the last-built `dist`.
+
+**To live-verify a `packages/ui`/`packages/core` source change in the listen app:** rebuild the dist first, then restart the dev server —
+```
+pnpm exec turbo run build --filter=ui   # or --filter=listen to chain core→ui→listen
+pkill -f "vite --port 3001"
+rm -rf apps/listen/node_modules/.vite
+pnpm exec vite --port 3001 --force
+```
+Tell: a new `console.log`/behavior never appears no matter how many times you restart — that's stale dist, not a caching fluke.
+
+## Turbo cache can mask a bundle verification
+
+Don't trust `pnpm exec turbo build` output that reports a cache hit ("FULL TURBO" / "cached") when verifying what a dependency or code change actually did to a built bundle — turbo restores `dist/` from cache when its input hash matches, which can be a dist built **before** the change under test, making a broken tree look verified.
+
+**How to apply:** for bundle verification, run the app's `vite build` directly (with any env vars that gate conditional providers, e.g. `VITE_PUBLIC_POSTHOG_KEY`) or `turbo build --force`. Confirm the log shows a real build ("✓ built in …"), then probe the served dist — see the `e2e-testing` skill's Playwright-probe pattern for reading runtime console output.
+
+## Node version and package managers
+
+- The whole workspace (`sworld`, `sworld-backend`, `sworld-hasura-v2`) runs **Node 24.18.0**, exact-pinned. Local: `nvm use 24`. If a non-interactive shell warns `Unsupported engine`, it's likely on the default alias — prefix with `source ~/.nvm/nvm.sh && nvm use 24.18.0`.
+- **Pinning convention:** pin the **exact** version (`24.18.0`) in `.nvmrc`, Dockerfiles (`node:24.18.0-slim`, never the moving `node:24-slim` tag), and CI `actions/setup-node`. Keep `engines.node` as a **range** (`>=24`) — it's a floor, not a pin.
+- **Package manager differs per repo:** `sworld` = pnpm workspace (`pnpm-lock.yaml`); `sworld-backend` and `sworld-hasura-v2` = **npm** (`package-lock.json`) — use `npm ci`/`npm outdated` there, not pnpm.
+- **`apps/game` is a dead/frozen app** — still on Vite 3 + Jest, deliberately excluded from the Node 24 migration, stays on Node 22. Jest survives only here; the rest of the frontend uses Vitest. Don't assume it's maintained or apply workspace-wide tooling changes to it without checking first.
+
+## pnpm's dependency cooldown can freeze dep work for days
+
+`pnpm-workspace.yaml` sets `minimumReleaseAge: 10080` (7 days, SWO-355) — pnpm refuses to *resolve* any version published more recently than that. See the `supply-chain-security` skill for why this exists. **Frozen installs (CI, `--frozen-lockfile`) are unaffected — only local re-resolves are.**
+
+**The trap:** adding/changing ANY dependency triggers a broad re-resolve. If a recent toolchain bump pulled fresh packages (e.g. a major Vite upgrade), every re-resolve trips the cooldown on them (`ERR_PNPM_NO_MATURE_MATCHING_VERSION`) one package at a time until they age past 7 days — effectively freezing dependency work for a week after a big bump.
+
+**Fixes, in order:** wait it out; add vetted, intentionally-upgraded packages to `minimumReleaseAgeExclude:` in `pnpm-workspace.yaml` (enumerate the full set by iterating — the error names one package at a time); or a one-off `pnpm install --config.minimumReleaseAge=0` (still drags collateral re-resolve churn). **Never hand-edit `pnpm-lock.yaml`** to dodge this — let the tool own the lockfile.
+
+## CodeGraph index lives at the workspace root
+
+The CodeGraph index (`.codegraph/`) is initialized at the **workspace root** (`/Users/tranvanvuong/Projects/sworld`, not inside any single repo), so one graph covers all three repos — `sworld`, `sworld-backend`, `sworld-hasura-v2` — and cross-repo structural queries work. The workspace root isn't a git repo, so the index is machine-local; if `codegraph_*` tools ever report "not initialized," re-run `codegraph init -i` at the workspace root. Reach for `codegraph_*` first for structural questions (definitions, callers, impact) across any of the three repos — grep only for literal text.
+
+## Don't defer error tracking for bundle size
+
+Never lazy-load or defer Rollbar to shave initial bundle size, even under a Lighthouse/perf budget. Deferring error tracking creates a blind spot for init/first-paint crashes — exactly the errors most worth catching — and the bytes saved aren't worth losing that coverage. When trimming a bundle, cut elsewhere (chunking, vendor splitting, right-sizing the budget); treat Rollbar as load-bearing and eager.

--- a/.claude/skills/dev-environment-gotchas/SKILL.md
+++ b/.claude/skills/dev-environment-gotchas/SKILL.md
@@ -31,7 +31,7 @@ Tell: a new `console.log`/behavior never appears no matter how many times you re
 
 Don't trust `pnpm exec turbo build` output that reports a cache hit ("FULL TURBO" / "cached") when verifying what a dependency or code change actually did to a built bundle — turbo restores `dist/` from cache when its input hash matches, which can be a dist built **before** the change under test, making a broken tree look verified.
 
-**How to apply:** for bundle verification, run the app's `vite build` directly (with any env vars that gate conditional providers, e.g. `VITE_PUBLIC_POSTHOG_KEY`) or `turbo build --force`. Confirm the log shows a real build ("✓ built in …"), then serve the dist and drive it headlessly with Playwright to read the console for runtime errors (a throwaway probe script — see the `e2e-testing` skill if one exists for the exact pattern).
+**How to apply:** for bundle verification, run the app's `vite build` directly (with any env vars that gate conditional providers, e.g. `VITE_PUBLIC_POSTHOG_KEY`) or `turbo build --force`. Confirm the log shows a real build ("✓ built in …"), then serve the dist and drive it headlessly with Playwright to read the console for runtime errors: launch a browser, register `page.on('console'/'pageerror')` handlers, navigate to the served dist, and check what got logged — a throwaway script deleted after use, not a checked-in test.
 
 ## Node version and package managers
 

--- a/.claude/skills/dev-environment-gotchas/SKILL.md
+++ b/.claude/skills/dev-environment-gotchas/SKILL.md
@@ -23,7 +23,7 @@ Symptoms in this repo that look like framework bugs but have a known, boring cau
 pnpm exec turbo run build --filter=ui   # or --filter=listen to chain core→ui→listen
 pkill -f "vite --port 3001"
 rm -rf apps/listen/node_modules/.vite
-pnpm exec vite --port 3001 --force
+cd apps/listen && pnpm exec vite --port 3001 --force
 ```
 Tell: a new `console.log`/behavior never appears no matter how many times you restart — that's stale dist, not a caching fluke.
 
@@ -38,15 +38,13 @@ Don't trust `pnpm exec turbo build` output that reports a cache hit ("FULL TURBO
 - The whole workspace (`sworld`, `sworld-backend`, `sworld-hasura-v2`) runs **Node 24.18.0**, exact-pinned. Local: `nvm use 24`. If a non-interactive shell warns `Unsupported engine`, it's likely on the default alias — prefix with `source ~/.nvm/nvm.sh && nvm use 24.18.0`.
 - **Pinning convention:** pin the **exact** version (`24.18.0`) in `.nvmrc`, Dockerfiles (`node:24.18.0-slim`, never the moving `node:24-slim` tag), and CI `actions/setup-node`. Keep `engines.node` as a **range** (`>=24`) — it's a floor, not a pin.
 - **Package manager differs per repo:** `sworld` = pnpm workspace (`pnpm-lock.yaml`); `sworld-backend` and `sworld-hasura-v2` = **npm** (`package-lock.json`) — use `npm ci`/`npm outdated` there, not pnpm.
-- **`apps/game` is a dead/frozen app** — still on Vite 3 + Jest, deliberately excluded from the Node 24 migration, stays on Node 22. Jest survives only here; the rest of the frontend uses Vitest. Don't assume it's maintained or apply workspace-wide tooling changes to it without checking first.
+- **`apps/game` is a dead/frozen app** — still on Vite 6 (the rest of the frontend is on Vite 8) + Jest, deliberately excluded from the Node 24 migration, pinned to Node 22 in its CI workflows (`.github/workflows/live-game-fe.yml`). Jest survives only here; the rest of the frontend uses Vitest. Don't assume it's maintained or apply workspace-wide tooling changes to it without checking first.
 
 ## pnpm's dependency cooldown can freeze dep work for days
 
-`pnpm-workspace.yaml` sets `minimumReleaseAge: 10080` (7 days, SWO-355) — pnpm refuses to *resolve* any version published more recently than that. See the `supply-chain-security` skill for why this exists. **Frozen installs (CI, `--frozen-lockfile`) are unaffected — only local re-resolves are.**
+`pnpm-workspace.yaml` sets `minimumReleaseAge: 10080` (7 days, SWO-355). See the `supply-chain-security` skill for what this setting is, why it exists, and how to fix a cooldown block (`minimumReleaseAgeExclude`, never hand-editing the lockfile).
 
-**The trap:** adding/changing ANY dependency triggers a broad re-resolve. If a recent toolchain bump pulled fresh packages (e.g. a major Vite upgrade), every re-resolve trips the cooldown on them (`ERR_PNPM_NO_MATURE_MATCHING_VERSION`) one package at a time until they age past 7 days — effectively freezing dependency work for a week after a big bump.
-
-**Fixes, in order:** wait it out; add vetted, intentionally-upgraded packages to `minimumReleaseAgeExclude:` in `pnpm-workspace.yaml` (enumerate the full set by iterating — the error names one package at a time); or a one-off `pnpm install --config.minimumReleaseAge=0` (still drags collateral re-resolve churn). **Never hand-edit `pnpm-lock.yaml`** to dodge this — let the tool own the lockfile.
+**The sworld-specific trap this skill exists to flag:** adding/changing ANY dependency triggers a broad re-resolve. If a recent toolchain bump pulled fresh packages (e.g. a major Vite upgrade), every re-resolve trips the cooldown on them (`ERR_PNPM_NO_MATURE_MATCHING_VERSION`) one package at a time until they age past 7 days — effectively freezing dependency work for a week after a big bump. Frozen installs (CI, `--frozen-lockfile`) are unaffected; only local re-resolves are.
 
 ## CodeGraph index lives at the workspace root
 

--- a/.claude/skills/dev-environment-gotchas/SKILL.md
+++ b/.claude/skills/dev-environment-gotchas/SKILL.md
@@ -31,7 +31,7 @@ Tell: a new `console.log`/behavior never appears no matter how many times you re
 
 Don't trust `pnpm exec turbo build` output that reports a cache hit ("FULL TURBO" / "cached") when verifying what a dependency or code change actually did to a built bundle — turbo restores `dist/` from cache when its input hash matches, which can be a dist built **before** the change under test, making a broken tree look verified.
 
-**How to apply:** for bundle verification, run the app's `vite build` directly (with any env vars that gate conditional providers, e.g. `VITE_PUBLIC_POSTHOG_KEY`) or `turbo build --force`. Confirm the log shows a real build ("✓ built in …"), then probe the served dist — see the `e2e-testing` skill's Playwright-probe pattern for reading runtime console output.
+**How to apply:** for bundle verification, run the app's `vite build` directly (with any env vars that gate conditional providers, e.g. `VITE_PUBLIC_POSTHOG_KEY`) or `turbo build --force`. Confirm the log shows a real build ("✓ built in …"), then serve the dist and drive it headlessly with Playwright to read the console for runtime errors (a throwaway probe script — see the `e2e-testing` skill if one exists for the exact pattern).
 
 ## Node version and package managers
 

--- a/.claude/skills/dev-environment-gotchas/SKILL.md
+++ b/.claude/skills/dev-environment-gotchas/SKILL.md
@@ -42,9 +42,11 @@ Don't trust `pnpm exec turbo build` output that reports a cache hit ("FULL TURBO
 
 ## pnpm's dependency cooldown can freeze dep work for days
 
-`pnpm-workspace.yaml` sets `minimumReleaseAge: 10080` (7 days, SWO-355). See the `supply-chain-security` skill for what this setting is, why it exists, and how to fix a cooldown block (`minimumReleaseAgeExclude`, never hand-editing the lockfile).
+`pnpm-workspace.yaml` sets `minimumReleaseAge: 10080` (7 days, SWO-355) — pnpm refuses to *resolve* any version published more recently than that. See the `supply-chain-security` skill for what this setting is and why it exists. Frozen installs (CI, `--frozen-lockfile`) are unaffected — only local re-resolves are.
 
-**The sworld-specific trap this skill exists to flag:** adding/changing ANY dependency triggers a broad re-resolve. If a recent toolchain bump pulled fresh packages (e.g. a major Vite upgrade), every re-resolve trips the cooldown on them (`ERR_PNPM_NO_MATURE_MATCHING_VERSION`) one package at a time until they age past 7 days — effectively freezing dependency work for a week after a big bump. Frozen installs (CI, `--frozen-lockfile`) are unaffected; only local re-resolves are.
+**The sworld-specific trap:** adding/changing ANY dependency triggers a broad re-resolve. If a recent toolchain bump pulled fresh packages (e.g. a major Vite upgrade), every re-resolve trips the cooldown on them (`ERR_PNPM_NO_MATURE_MATCHING_VERSION`) — one package at a time, since pnpm only reports the next blocked package per run — until they age past 7 days, effectively freezing dependency work for a week after a big bump.
+
+**Fixes, in order:** wait it out; add each vetted, intentionally-upgraded package to `minimumReleaseAgeExclude:` in `pnpm-workspace.yaml`, re-running and repeating until no package trips the cooldown (pnpm surfaces them one at a time — there's no single command that lists them all up front); or a one-off `pnpm install --config.minimumReleaseAge=0` for a genuinely urgent unblock (still drags collateral re-resolve churn). **Never hand-edit `pnpm-lock.yaml`** to dodge this — let the tool own the lockfile.
 
 ## CodeGraph index lives at the workspace root
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,9 +60,10 @@ When work spans the backend or schema, the change lands in those repos, not here
 
 **Skills** (`.claude/skills/`) — task-triggered conventions. They fire automatically, but reach for them deliberately too:
 
-- _Code:_ `code-conventions`, `react`, `mui`, `architecture`, `mutation-data-flow`, `error-handling`, `e2e-testing`
+- _Code:_ `code-conventions`, `react`, `mui`, `architecture`, `mutation-data-flow`, `error-handling`, `e2e-testing`, `design-principles`
 - _Workflow:_ `parallel-workflow`, `micro-prs`, `pr-descriptions`, `writing-task-specs`, `reviewing-pull-requests`, `product-planning`
 - _Meta / quality:_ `grill-me`, `skill-creator`, `thermo-nuclear-code-quality-review`, `security-reviewer`, `supply-chain-security`
+- _Ops:_ `backend-ops`, `dev-environment-gotchas`
 
 **Tasks & requirements** — the source of truth for work is **Linear** (team **SWorld**, key `SWO`). A **project is an app** (Til, Watch, Listen, Game, Docs, Main — Main covers the main app's finance, journal, and library areas) — every issue belongs to one. Bugs and small features are single issues; a large feature is a **parent issue** (with sub-issues) inside the app's project, its description + a Linear document holding the spec, with blocking relations encoding the dependency waves. Status lives in the issue state (`Backlog → Todo → In Progress → In Review → Done`). See the `writing-task-specs` skill for how to author them and `parallel-workflow` for how state moves as work ships.
 


### PR DESCRIPTION
## Summary

No user-facing changes. Adds three new skills — `design-principles`, `backend-ops`, `dev-environment-gotchas` — porting knowledge that only lived in Claude Code's session memory into checked-in `.claude/skills/`, so any agent working in this repo has it. AGENTS.md's skills index is updated to list them. SWO-430.

## Test plan

- [ ] CI green