### PR TITLE
[WIP] fix(extension): align device-request query to backend snake_case keys (SWO-433)

### DIFF
--- a/apps/extension/src/background/auth.ts
+++ b/apps/extension/src/background/auth.ts
@@ -57,7 +57,7 @@ const startPairing = async (): Promise<{
             success
             data {
               userCode
-              verificationUri
+              verification_uri
             }
           }
         }
@@ -88,7 +88,7 @@ const startPairing = async (): Promise<{
 
   return {
     userCode: result.data.userCode,
-    verificationUri: result.data.verificationUri,
+    verificationUri: result.data.verification_uri,
   };
 };
 


### PR DESCRIPTION
Aligns the extension's device-pairing query to the backend's actual JSON keys.

## Why
The extension queried `createDeviceRequest.data.verificationUri` (camelCase), but the backend returns `verification_uri` (snake_case) and Hasura was stripping the payload (see SWO-432). The field came back undefined and `startPairing()` threw.

## Changes
- `apps/extension/src/background/auth.ts`: query field `verificationUri` → `verification_uri`; parse at line 91 updated to match.
- No logic or abstraction changes; raw fetch approach preserved.

## Note
This only takes effect at runtime once SWO-432's metadata is deployed to Hasura Cloud. The `exchangeDeviceToken` → `getDeviceToken` action rename (PR #81) is a SEPARATE outstanding mismatch — tracked as a follow-up.

Linear: SWO-433

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the pairing flow to correctly read the verification link from the backend response.
  - Users can now complete authentication pairing without issues caused by the response field naming change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->