### PR TITLE
[WIP] fix(extension): parse token-poll response + default backendUrl to Hasura origin (SWO-434)

### DIFF
--- a/apps/extension/config.ts
+++ b/apps/extension/config.ts
@@ -1,6 +1,9 @@
+import { hasuraConfig } from './envConfig';
+
 const config = {
   allowedOrigin: import.meta.env.VITE_ALLOWED_ORIGIN,
-  backendUrl: import.meta.env.VITE_BACKEND_URL,
+  backendUrl:
+    import.meta.env.VITE_BACKEND_URL ?? new URL(hasuraConfig.url).origin,
 };
 
 export { config };

--- a/apps/extension/src/background/auth.ts
+++ b/apps/extension/src/background/auth.ts
@@ -109,21 +109,23 @@ const pollForDeviceToken = async (
 
     const json = await response.json();
 
-    if (json.token) {
-      await setItem(AUTH_TOKEN_KEY, json.token);
+    if (json.data?.token) {
+      await setItem(AUTH_TOKEN_KEY, json.data.token);
       return;
     }
 
-    if (json.error === 'authorization_pending') {
+    const status = json.message ?? json.error;
+
+    if (status === 'authorization_pending') {
       await new Promise((resolve) => setTimeout(resolve, interval * 1000));
       continue;
     }
 
-    if (json.error === 'access_denied') {
+    if (status === 'access_denied') {
       throw new Error('access_denied');
     }
 
-    if (json.error === 'expired_token') {
+    if (status === 'expired_token') {
       throw new Error('expired_token');
     }
 


### PR DESCRIPTION
Fixes the device-pairing token-polling path in apps/extension.

## Why (correcting an earlier wrong premise)
The extension polls the backend DIRECTLY at `${config.backendUrl}/auth/device/token` — it does NOT use a Hasura action, so the previously-suspected `exchangeDeviceToken` -> `getDeviceToken` rename was a red herring.

Two real defects vs the backend's AppResponse shape `{ success, message, data: { token } }`:
1. Read `json.token` but the token lives at `json.data.token` -> success was never detected, polling ran until timeout.
2. Read `json.error` but the backend returns `json.message` -> error states never detected.

Plus `VITE_BACKEND_URL` (config.backendUrl) was unset in apps/extension/.env, so the fetch URL was `undefined/auth/device/token`.

## Changes
- `auth.ts` pollForDeviceToken: parse `json.data?.token` and use `json.message ?? json.error` for status.
- `config.ts`: backendUrl defaults to the Hasura URL's origin (`new URL(hasuraConfig.url).origin`), with VITE_BACKEND_URL still available as an override.

Note: this assumes the deployed backend is reachable at the Hasura Cloud origin (per user). If not, set VITE_BACKEND_URL to the real sworld-backend URL.

Linear: SWO-434