### PR TITLE
[WIP] fix(extension): query camelCase verificationUri (SWO-436)

### DIFF
--- a/apps/extension/src/background/auth.ts
+++ b/apps/extension/src/background/auth.ts
@@ -57,7 +57,7 @@ const startPairing = async (): Promise<{
             success
             data {
               userCode
-              verification_uri
+              verificationUri
             }
           }
         }
@@ -88,7 +88,7 @@ const startPairing = async (): Promise<{
 
   return {
     userCode: result.data.userCode,
-    verificationUri: result.data.verification_uri,
+    verificationUri: result.data.verificationUri,
   };
 };
 


### PR DESCRIPTION
origin/main (1c7761c) reverted the SWO-434/#439 camelCase fix, leaving createDeviceRequest querying data.verification_uri (snake). The live Hasura project uses graphql-default naming, so the field is verificationUri (camel) -- the snake query hits 'field verification_uri not found'.

Restores the camelCase query + parse to match the live CreateDeviceRequestOutput (userCode, verificationUri, verificationUriComplete, expiresIn, ...). config.ts already has the backendUrl default.

Depends on SWO-435 (Hasura output_type binding) being live for data to populate.

Linear: SWO-436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed account pairing to correctly retrieve and process the verification link from the authentication service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->