### PR TITLE
chore(main): trigger redeploy

### DIFF
--- a/apps/main/src/main.tsx
+++ b/apps/main/src/main.tsx
@@ -1,3 +1,4 @@
+// Trigger redeploy
 import { createRouter, RouterProvider } from '@tanstack/react-router';
 import { AuthProvider } from 'core/providers/auth';
 import { QueryProvider } from 'core/providers/query';


### PR DESCRIPTION
## Summary
Trivial change to `apps/main/src/main.tsx` to trigger a web app re-deploy via CI. No functional changes.

## Test plan
- Merge to redeploy the main web app (carries the existing `AUTH_TOKEN` push to the extension in `core/providers/auth`).
- Extension side is rebuilt locally (not in this PR) with `VITE_ALLOWED_ORIGIN=https://shinabr2.com` and a console.log in `onMessageExternal` to confirm token receipt.

🤖 Generated with OpenCode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an internal comment; no user-facing functionality or behavior has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->