### PR TITLE
feat(skills): add wait-for-pr-merge skill + keep-local-main-fresh rule to parallel-workflow

### DIFF
--- a/.claude/skills/parallel-workflow/SKILL.md
+++ b/.claude/skills/parallel-workflow/SKILL.md
@@ -9,7 +9,7 @@ user-invocable: false
 ## Non-negotiable prerequisites
 
 - **The Linear issue is the source of truth.** A Linear issue (in the **SWorld** team) is REQUIRED before starting any work. NEVER start working without one — if there isn't one, create it first (see `writing-task-specs`).
-- **ALWAYS work in a dedicated worktree.** NEVER create branches or make changes in the main worktree. The main worktree must stay clean — the *only* permitted operation there is `git pull --ff-only origin main` (run in each of the three repo worktrees as needed) to advance local `main` (a fast-forward, which updates the branch pointer and the tracked files in the checkout). No branch work, no manual edits. See Git fundamentals.
+- **ALWAYS work in a dedicated worktree.** NEVER create branches or make changes in the main worktree. The main worktree must stay clean — the *only* permitted operations there advance the local `main` ref (`git pull --ff-only origin main` when it sits on `main`, `git fetch origin main:main` otherwise — see "Keep local `main` fresh" below). No branch work, no manual edits.
 
 ## Scope: all three repos
 
@@ -28,13 +28,18 @@ This workflow applies to the whole workspace — **sworld** (frontend), **sworld
 
 ### Keep local `main` fresh
 
-Fetching only advances the `origin/main` **ref** — the local `main` branch pointer stays stale, so any lazy reference to local `main` (a code read, a diff, a new worktree base) is wrong. Because of the parallel-worktree workflow, local `main` is *chronically* behind. So also keep the local pointer current: run **`git pull --ff-only origin main` in the relevant repo's main worktree** (each of the three repos has its own `.git` and its own `main`). Run it in *every* repo whose `main` you are about to read off or branch from. Name the `origin main` target explicitly so the pull can't depend on — or advance — the wrong upstream. `--ff-only` so a diverged `main` errors loudly instead of silently creating a merge commit.
+Fetching only advances the `origin/main` **ref** — the local `main` branch pointer stays stale, so any lazy reference to local `main` (a code read, a diff, a new worktree base) is wrong. Because of the parallel-worktree workflow, local `main` is *chronically* behind. So also keep the local pointer current. Each of the three repos has its own `.git` and its own `main`; refresh *every* repo whose `main` you are about to read off or branch from.
 
-Run it:
+Two equivalent ways to fast-forward local `main` to `origin/main` — pick by what the repo's **main worktree** (the first entry in `git worktree list`) is checked out on:
+
+- **Main worktree sits on `main`** → run `git pull --ff-only origin main` **in that worktree**. Advances the `main` branch pointer and updates the tracked files in its checkout. `--ff-only` so a diverged `main` errors loudly instead of silently creating a merge commit. Name the `origin main` target explicitly so the pull can't depend on — or advance — the wrong upstream.
+- **Main worktree sits on a feature branch** (the common case here — e.g. `chore/…`) → run `git fetch origin main:main` from any worktree of that repo. It advances the local `main` ref to `origin/main` without a checkout and without touching any working tree; it errors loudly (refuses) if `main` *is* checked out somewhere in the repo, which is the tell to use `git pull --ff-only` in that worktree instead.
+
+Never rebase `main`; never create merge commits on it. Run it:
 
 1. After every merged-worktree cleanup (see loop Step 1) — for the repo whose PR just merged.
 2. Before starting new work / before any code read on `main` in that repo.
-3. **Standalone, on demand** — whenever the user says "refresh main", "update main", "pull main", or any equivalent. Just run it in the relevant main worktree(s) and report the result; it is a one-command action per repo, never a question. If the user doesn't name a repo, run it for all three (`sworld`, `sworld-backend`, `sworld-hasura-v2`).
+3. **Standalone, on demand** — whenever the user says "refresh main", "update main", "pull main", or any equivalent. Just run it in the relevant repo(s) and report the result; it is a one-command action per repo, never a question. If the user doesn't name a repo, run it for all three (`sworld`, `sworld-backend`, `sworld-hasura-v2`).
 
 ## Before starting
 

--- a/.claude/skills/parallel-workflow/SKILL.md
+++ b/.claude/skills/parallel-workflow/SKILL.md
@@ -30,10 +30,16 @@ This workflow applies to the whole workspace — **sworld** (frontend), **sworld
 
 Fetching only advances the `origin/main` **ref** — the local `main` branch pointer stays stale, so any lazy reference to local `main` (a code read, a diff, a new worktree base) is wrong. Because of the parallel-worktree workflow, local `main` is *chronically* behind. So also keep the local pointer current. Each of the three repos has its own `.git` and its own `main`; refresh *every* repo whose `main` you are about to read off or branch from.
 
-Two equivalent ways to fast-forward local `main` to `origin/main` — pick by what the repo's **main worktree** (the first entry in `git worktree list`) is checked out on:
+Two equivalent ways to fast-forward local `main` to `origin/main` — pick by what the repo's **main worktree** (the first entry in `git worktree list`) is checked out on. Probe it cheaply:
 
-- **Main worktree sits on `main`** → run `git pull --ff-only origin main` **in that worktree**. Advances the `main` branch pointer and updates the tracked files in its checkout. `--ff-only` so a diverged `main` errors loudly instead of silently creating a merge commit. Name the `origin main` target explicitly so the pull can't depend on — or advance — the wrong upstream.
-- **Main worktree sits on a feature branch** (the common case here — e.g. `chore/…`) → run `git fetch origin main:main` from any worktree of that repo. It advances the local `main` ref to `origin/main` without a checkout and without touching any working tree; it errors loudly (refuses) if `main` *is* checked out somewhere in the repo, which is the tell to use `git pull --ff-only` in that worktree instead.
+```bash
+# Emits "main" if that repo's main worktree sits on `main`, else the feature branch name (empty = detached).
+git -C "$repo" worktree list --porcelain | awk '
+  /^branch refs\/heads\//{sub(/^branch refs\/heads\//,""); print; found=1} /^$/{if(!found)print"detached"; exit}'
+```
+
+- **Main worktree sits on `main`** → run **`git pull --ff-only origin main`** in that worktree. Advances the `main` branch pointer and updates the tracked files in its checkout. `--ff-only` so a diverged `main` errors loudly instead of silently creating a merge commit. Name the `origin main` target explicitly so the pull can't depend on — or advance — the wrong upstream.
+- **Main worktree sits on a feature branch** (the common case here — e.g. `chore/…`) → run **`git fetch origin main:main`** from any worktree of that repo. It advances the local `main` ref to `origin/main` without a checkout and without touching any working tree; it refuses loudly if `main` *is* checked out somewhere in the repo — that refusal IS the tell to use `git pull --ff-only` in that worktree instead.
 
 Never rebase `main`; never create merge commits on it. Run it:
 

--- a/.claude/skills/parallel-workflow/SKILL.md
+++ b/.claude/skills/parallel-workflow/SKILL.md
@@ -9,7 +9,7 @@ user-invocable: false
 ## Non-negotiable prerequisites
 
 - **The Linear issue is the source of truth.** A Linear issue (in the **SWorld** team) is REQUIRED before starting any work. NEVER start working without one — if there isn't one, create it first (see `writing-task-specs`).
-- **ALWAYS work in a dedicated worktree.** NEVER create branches or make changes in the main worktree. The main worktree must stay clean.
+- **ALWAYS work in a dedicated worktree.** NEVER create branches or make changes in the main worktree. The main worktree must stay clean — the *only* permitted operation there is `git pull --ff-only origin main` (run in each of the three repo worktrees as needed) to advance local `main` (a fast-forward, which updates the branch pointer and the tracked files in the checkout). No branch work, no manual edits. See Git fundamentals.
 
 ## Scope: all three repos
 
@@ -25,6 +25,16 @@ This workflow applies to the whole workspace — **sworld** (frontend), **sworld
 - "main branch" ALWAYS means `origin/main` — fetch first with `git fetch origin main`. The local `main` is often stale.
 - ALWAYS `git merge`, NEVER `git rebase`. This applies everywhere — syncing, resolving divergence, integrating changes.
 - **Sync before analyzing, not just before coding.** Before exploring or reasoning about code anywhere in this workspace (any of the three repos), check `git status` and pull/fast-forward to `origin/main` first. Analyzing a stale checkout produces wrong conclusions and clarifying questions that contradict what's actually on main.
+
+### Keep local `main` fresh
+
+Fetching only advances the `origin/main` **ref** — the local `main` branch pointer stays stale, so any lazy reference to local `main` (a code read, a diff, a new worktree base) is wrong. Because of the parallel-worktree workflow, local `main` is *chronically* behind. So also keep the local pointer current: run **`git pull --ff-only origin main` in the relevant repo's main worktree** (each of the three repos has its own `.git` and its own `main`). Run it in *every* repo whose `main` you are about to read off or branch from. Name the `origin main` target explicitly so the pull can't depend on — or advance — the wrong upstream. `--ff-only` so a diverged `main` errors loudly instead of silently creating a merge commit.
+
+Run it:
+
+1. After every merged-worktree cleanup (see loop Step 1) — for the repo whose PR just merged.
+2. Before starting new work / before any code read on `main` in that repo.
+3. **Standalone, on demand** — whenever the user says "refresh main", "update main", "pull main", or any equivalent. Just run it in the relevant main worktree(s) and report the result; it is a one-command action per repo, never a question. If the user doesn't name a repo, run it for all three (`sworld`, `sworld-backend`, `sworld-hasura-v2`).
 
 ## Before starting
 

--- a/.claude/skills/wait-for-pr-merge/SKILL.md
+++ b/.claude/skills/wait-for-pr-merge/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: wait-for-pr-merge
+description: Poll one or more PRs until each merges (or closes), cleaning up each PR the moment it merges — remove its worktree, delete its local branch, refresh local main, mark its Linear issue Done. Use whenever the user says "wait for PR X to merge", "wait for PRs X and Y to merge", "watch these PRs until they merge", "let me know when PR X lands", "poll PR X", or invokes /wait-for-pr-merge. This is post-READY watching only — it does NOT fix CI, conflicts, or review comments (that is "the loop"; see parallel-workflow).
+user-invocable: true
+---
+
+# Wait for PR merge
+
+The human merges a READY PR by hand on GitHub. This skill watches for that merge and does the cleanup, so the user can say "wait for PR X to merge" and walk away instead of manually re-checking GitHub. It accepts **one or more** PRs and handles each independently — each PR is cleaned up the moment *it* merges, without waiting for the others.
+
+**Scope boundary:** this skill assumes each PR is already READY and the user is merging manually. It does **NOT** touch CI, conflicts, or review comments — that is the loop ("do the loop"; see [`parallel-workflow`](../parallel-workflow/SKILL.md)). If a PR simply isn't merged yet, keep waiting; never start fixing things under this skill.
+
+## Workspace: three repos
+
+Each PR belongs to exactly one of the three repos (`sworld`, `sworld-backend`, `sworld-hasura-v2`, all under `ShinaBR2`). All cleanup (worktree removal, branch deletion, local `main` refresh) runs **in the repo the PR belongs to** — never cross-repo. Resolve the repo from each PR via `gh pr view <N> --json repository -q '.repository.nameWithOwner'` (gives `ShinaBR2/<repo>`), then map to the local clone path:
+
+- `ShinaBR2/sworld` → `<workspace>/sworld`
+- `ShinaBR2/sworld-backend` → `<workspace>/sworld-backend`
+- `ShinaBR2/sworld-hasura-v2` → `<workspace>/sworld-hasura-v2`
+
+All `git -C` commands below take that local path. If the repo can't be resolved or isn't one of the three, report and drop the PR from the poll — don't guess.
+
+## 1. Poll until a PR needs attention
+
+Track the set of PR numbers the user gave. Poll `gh pr view <N> --json state` for each, on an interval (~2 min), in the **background**, so the sleep burns nothing and you are only re-invoked when a PR needs attention. **NEVER** use `gh pr view --watch` / `gh pr checks --watch`.
+
+A failed `gh` call (auth, network, bad PR number) must NOT be mistaken for `OPEN` — otherwise the loop spins silently forever. Treat only a successful, non-empty state as truth; retry a few times before declaring a PR unreachable.
+
+Keep the script **portable across sh / bash / zsh** — the background shell is not guaranteed to be any one of them:
+
+- NO bash-only constructs (`declare -A`, associative arrays). Track transient failures with an inline retry instead of a cross-iteration counter.
+- Put the PR numbers in **positional parameters** (`set -- …`) and loop with `for n in "$@"`. Do NOT write `for n in $LIST` — zsh does not word-split an unquoted variable, so it would iterate once over the whole string and poll a bogus PR.
+
+```sh
+# Set the PRs still being watched as positional params (splits correctly in sh/bash/zsh).
+# Replace the numbers below with the PR numbers from THIS invocation (3645 3646 are only an example).
+# Exits as soon as any PR is terminal (MERGED/CLOSED) or stays unreachable after 3 quick retries.
+set -- 3645 3646
+while true; do
+  hit=0
+  for n in "$@"; do
+    s=""; i=1
+    while [ "$i" -le 3 ]; do
+      s=$(gh pr view "$n" --json state -q .state 2>/dev/null)
+      [ -n "$s" ] && break
+      i=$((i + 1)); sleep 5
+    done
+    if [ -z "$s" ]; then
+      echo "ERROR:$n:gh-unreachable"; hit=1
+    elif [ "$s" = "MERGED" ] || [ "$s" = "CLOSED" ]; then
+      echo "FINAL:$n:$s"; hit=1
+    fi
+  done
+  [ "$hit" = 1 ] && exit 0
+  sleep 120
+done
+```
+
+Run it with the background flag. When it exits, read the `FINAL:<n>:<state>` and `ERROR:<n>:...` lines and handle each (below). Then **re-launch the poll for the PRs still pending** and repeat, until none are left.
+
+## 2. Handle each event
+
+For every `FINAL:<n>:<state>` / `ERROR:<n>:...` line, first resolve the PR's repo:
+
+```bash
+name_with_owner=$(gh pr view <N> --json repository -q '.repository.nameWithOwner')
+case "$name_with_owner" in
+  ShinaBR2/sworld)          repo="<workspace>/sworld" ;;
+  ShinaBR2/sworld-backend)  repo="<workspace>/sworld-backend" ;;
+  ShinaBR2/sworld-hasura-v2) repo="<workspace>/sworld-hasura-v2" ;;
+  *) echo "PR <N>: unknown repo '$name_with_owner' — dropping from poll"; drop; continue ;;
+esac
+```
+
+### MERGED → clean up + mark Linear issue Done
+
+Resolve the branch and its worktree **exactly** — never substring-match, and never act on an empty branch (an empty value matches every worktree):
+
+Every step below must **abort this PR's cleanup on failure** and report the partial state — never fall through to a later step or claim completion.
+
+```bash
+ branch=$(gh pr view <N> --json headRefName -q .headRefName)
+[ -n "$branch" ] || { echo "PR <N>: cannot resolve branch — aborting cleanup"; exit 1; }
+
+# Exact worktree path for this branch (porcelain, exact ref match; handles paths with spaces).
+wt=$(git -C "$repo" worktree list --porcelain | awk -v b="refs/heads/$branch" '
+  /^worktree /{p=substr($0,10)} $0=="branch "b{print p}')
+
+# Only ever remove a MERGED worktree; skip if none. Abort if removal fails.
+[ -n "$wt" ] && { git -C "$repo" worktree remove "$wt" || { echo "PR <N>: worktree remove failed — aborting"; exit 1; }; }
+
+# squash-merge leaves the branch not-fully-merged, so -D. Abort if deletion fails.
+git -C "$repo" branch -D "$branch" || { echo "PR <N>: branch delete failed — aborting"; exit 1; }
+```
+
+Then mark the linked Linear issue `Done` (the parallel-workflow CI loop's Step 1 does this when *it* observes the merge; mirror it here so the manual-merge path stays consistent). Extract `SWO-NNN` from the PR body — the branch name is **not** authoritative:
+
+```bash
+swo=$(gh pr view <N> --json body -q .body | grep -oE 'SWO-[0-9]+' | head -n1)
+[ -n "$swo" ] && linear issue update "$swo" -s "Done" || echo "PR <N>: no SWO-NNN found in body — skipping Linear update"
+```
+
+### CLOSED without merge → stop watching it
+
+Report that the PR was closed without merging and drop it from the pending set. Do **not** clean up — the branch and worktree may still be wanted.
+
+### ERROR (unreachable) → surface it
+
+Report that the PR could not be polled and drop it from the pending set so the user can decide. Never keep silently looping on it.
+
+## 3. After the round
+
+- For **each** repo that had a merge this round, refresh its local `main` **once** — fast-forward only, never rebase. Use the `main:<refspec>` fetch so it works even when the repo's main worktree is checked out on a feature branch (common here — see `parallel-workflow` "Keep local main fresh"); it advances the local `main` ref to `origin/main` without needing to be on `main`, without touching any working tree, and errors loudly if `main` has diverged. Resolve the repo path explicitly via `git -C` — never rely on the current directory, which may still be a PR worktree. Propagate a failed refresh: it must stop success reporting and prevent relaunching the poll for that repo.
+  ```bash
+  git -C "$repo" fetch origin main:main || { echo "$repo: main refresh failed — stop, do not relaunch"; exit 1; }
+  ```
+  (If no worktree in that repo has `main` checked out — the common case here — this always fast-forwards cleanly. If a future `git pull --ff-only origin main` from the main worktree is preferred and that worktree sits on `main`, that is equivalent and also acceptable.)
+- Report per PR: cleaned-up+moved-to-Done (merged), closed-without-merge, or unreachable.
+- If PRs remain pending, re-launch the poll (step 1) for just those. When the pending set is empty, report the final tally and stop.

--- a/.claude/skills/wait-for-pr-merge/SKILL.md
+++ b/.claude/skills/wait-for-pr-merge/SKILL.md
@@ -68,7 +68,7 @@ case "$name_with_owner" in
   ShinaBR2/sworld)          repo="<workspace>/sworld" ;;
   ShinaBR2/sworld-backend)  repo="<workspace>/sworld-backend" ;;
   ShinaBR2/sworld-hasura-v2) repo="<workspace>/sworld-hasura-v2" ;;
-  *) echo "PR <N>: unknown repo '$name_with_owner' — dropping from poll"; drop; continue ;;
+  *) echo "PR <N>: unknown repo '$name_with_owner' — dropping from poll"; continue ;;
 esac
 ```
 
@@ -79,7 +79,7 @@ Resolve the branch and its worktree **exactly** — never substring-match, and n
 Every step below must **abort this PR's cleanup on failure** and report the partial state — never fall through to a later step or claim completion.
 
 ```bash
- branch=$(gh pr view <N> --json headRefName -q .headRefName)
+branch=$(gh pr view <N> --json headRefName -q .headRefName)
 [ -n "$branch" ] || { echo "PR <N>: cannot resolve branch — aborting cleanup"; exit 1; }
 
 # Exact worktree path for this branch (porcelain, exact ref match; handles paths with spaces).

--- a/.claude/skills/wait-for-pr-merge/SKILL.md
+++ b/.claude/skills/wait-for-pr-merge/SKILL.md
@@ -12,43 +12,50 @@ The human merges a READY PR by hand on GitHub. This skill watches for that merge
 
 ## Workspace: three repos
 
-Each PR belongs to exactly one of the three repos (`sworld`, `sworld-backend`, `sworld-hasura-v2`, all under `ShinaBR2`). All cleanup (worktree removal, branch deletion, local `main` refresh) runs **in the repo the PR belongs to** — never cross-repo. Resolve the repo from each PR via `gh pr view <N> --json repository -q '.repository.nameWithOwner'` (gives `ShinaBR2/<repo>`), then map to the local clone path:
+Each PR belongs to exactly one of the three repos (`sworld`, `sworld-backend`, `sworld-hasura-v2`, all under `ShinaBR2`). All cleanup (worktree removal, branch deletion, local `main` refresh) runs **in the repo the PR belongs to** — never cross-repo. The repo is resolved once up front (see §1's resolve step) and maps to the local clone path:
 
-- `ShinaBR2/sworld` → `<workspace>/sworld`
-- `ShinaBR2/sworld-backend` → `<workspace>/sworld-backend`
-- `ShinaBR2/sworld-hasura-v2` → `<workspace>/sworld-hasura-v2`
+- `sworld` → `<workspace>/sworld`
+- `sworld-backend` → `<workspace>/sworld-backend`
+- `sworld-hasura-v2` → `<workspace>/sworld-hasura-v2`
 
-All `git -C` commands below take that local path. If the repo can't be resolved or isn't one of the three, report and drop the PR from the poll — don't guess.
+All `git -C` commands below take that local path. If a PR's repo can't be resolved or isn't one of the three, report and drop the PR from the poll — don't guess.
 
-## 1. Poll until a PR needs attention
+## 1. Resolve each PR's repo, then poll
 
-Track the set of PR numbers the user gave. Poll `gh pr view <N> --json state` for each, on an interval (~2 min), in the **background**, so the sleep burns nothing and you are only re-invoked when a PR needs attention. **NEVER** use `gh pr view --watch` / `gh pr checks --watch`.
+Every `gh pr view <N>` in this skill MUST be **repository-qualified** — a bare `gh pr view <N>` resolves against the *current* repo's remote only, so a `sworld-backend` or `sworld-hasura-v2` PR number looked up from a `sworld` worktree either fails or, where numbers collide, resolves the **wrong PR**. Resolve each PR's repo **once up front**, then pass `--repo ShinaBR2/<repo>` on every `gh pr view`.
 
-A failed `gh` call (auth, network, bad PR number) must NOT be mistaken for `OPEN` — otherwise the loop spins silently forever. Treat only a successful, non-empty state as truth; retry a few times before declaring a PR unreachable.
-
-Keep the script **portable across sh / bash / zsh** — the background shell is not guaranteed to be any one of them:
-
-- NO bash-only constructs (`declare -A`, associative arrays). Track transient failures with an inline retry instead of a cross-iteration counter.
-- Put the PR numbers in **positional parameters** (`set -- …`) and loop with `for n in "$@"`. Do NOT write `for n in $LIST` — zsh does not word-split an unquoted variable, so it would iterate once over the whole string and poll a bogus PR.
+**Resolve step (you run it, not the background script).** For each PR number, probe the three repos until one returns a PR with that number — that repo owns it:
 
 ```sh
-# Set the PRs still being watched as positional params (splits correctly in sh/bash/zsh).
-# Replace the numbers below with the PR numbers from THIS invocation (3645 3646 are only an example).
-# Exits as soon as any PR is terminal (MERGED/CLOSED) or stays unreachable after 3 quick retries.
-set -- 3645 3646
+for n in <N1> <N2>; do
+  for r in sworld sworld-backend sworld-hasura-v2; do
+    gh pr view "$n" --repo "ShinaBR2/$r" --json state >/dev/null 2>&1 && { echo "$n:$r"; break; }
+  done
+done
+```
+
+Build the resolved pairs as `<num>:<repo>` and pass them to the background poll. A failed `gh` call (auth, network, bad PR number) must NOT be mistaken for `OPEN` — otherwise the loop spins silently forever. Treat only a successful, non-empty state as truth; retry a few times before declaring a PR unreachable. **NEVER** use `gh pr view --watch` / `gh pr checks --watch`.
+
+Keep the poll script **portable across sh / bash / zsh** — the background shell is not guaranteed to be any one of them: NO bash-only constructs (`declare -A`, associative arrays); put the resolved pairs in **positional parameters** (`set -- …`) and loop with `for pair in "$@"`. Do NOT write `for pair in $LIST` — zsh does not word-split an unquoted variable, so it would iterate once over the whole string and poll a bogus pair.
+
+```sh
+# Replace the pairs below with the RESOLVED pairs from the step above (445:sworld 446:sworld-backend are only an example).
+# Exits as soon as any tracked PR is terminal (MERGED/CLOSED) or stays unreachable after 3 quick retries.
+set -- 445:sworld 446:sworld-backend
 while true; do
   hit=0
-  for n in "$@"; do
+  for pair in "$@"; do
+    n="${pair%%:*}"; repo="${pair#*:}"
     s=""; i=1
     while [ "$i" -le 3 ]; do
-      s=$(gh pr view "$n" --json state -q .state 2>/dev/null)
+      s=$(gh pr view "$n" --repo "ShinaBR2/$repo" --json state -q .state 2>/dev/null)
       [ -n "$s" ] && break
       i=$((i + 1)); sleep 5
     done
     if [ -z "$s" ]; then
       echo "ERROR:$n:gh-unreachable"; hit=1
     elif [ "$s" = "MERGED" ] || [ "$s" = "CLOSED" ]; then
-      echo "FINAL:$n:$s"; hit=1
+      echo "FINAL:$n:$repo:$s"; hit=1
     fi
   done
   [ "$hit" = 1 ] && exit 0
@@ -56,19 +63,18 @@ while true; do
 done
 ```
 
-Run it with the background flag. When it exits, read the `FINAL:<n>:<state>` and `ERROR:<n>:...` lines and handle each (below). Then **re-launch the poll for the PRs still pending** and repeat, until none are left.
+Run it with the background flag. When it exits, read the `FINAL:<n>:<repo>:<state>` and `ERROR:<n>:...` lines and handle each (below). Then **re-launch the poll for the PRs still pending** (re-resolving is not needed — the repo is stable) and repeat, until none are left.
 
 ## 2. Handle each event
 
-For every `FINAL:<n>:<state>` / `ERROR:<n>:...` line, first resolve the PR's repo:
+Each `FINAL` line already carries the resolved repo (`FINAL:<n>:<repo>:<state>`). Map it to the repo's local clone path (and remember it — every `gh pr view <N>` below MUST keep `--repo "ShinaBR2/$repo"`, and every git command below uses `git -C "$repo_path"`):
 
 ```bash
-name_with_owner=$(gh pr view <N> --json repository -q '.repository.nameWithOwner')
-case "$name_with_owner" in
-  ShinaBR2/sworld)          repo="<workspace>/sworld" ;;
-  ShinaBR2/sworld-backend)  repo="<workspace>/sworld-backend" ;;
-  ShinaBR2/sworld-hasura-v2) repo="<workspace>/sworld-hasura-v2" ;;
-  *) echo "PR <N>: unknown repo '$name_with_owner' — dropping from poll"; continue ;;
+case "$repo" in
+  sworld)           repo_path="<workspace>/sworld" ;;
+  sworld-backend)   repo_path="<workspace>/sworld-backend" ;;
+  sworld-hasura-v2) repo_path="<workspace>/sworld-hasura-v2" ;;
+  *) echo "PR <N>: unknown repo '$repo' — dropping from poll"; continue ;;
 esac
 ```
 
@@ -79,24 +85,24 @@ Resolve the branch and its worktree **exactly** — never substring-match, and n
 Every step below must **abort this PR's cleanup on failure** and report the partial state — never fall through to a later step or claim completion.
 
 ```bash
-branch=$(gh pr view <N> --json headRefName -q .headRefName)
+branch=$(gh pr view <N> --repo "ShinaBR2/$repo" --json headRefName -q .headRefName)
 [ -n "$branch" ] || { echo "PR <N>: cannot resolve branch — aborting cleanup"; exit 1; }
 
 # Exact worktree path for this branch (porcelain, exact ref match; handles paths with spaces).
-wt=$(git -C "$repo" worktree list --porcelain | awk -v b="refs/heads/$branch" '
+wt=$(git -C "$repo_path" worktree list --porcelain | awk -v b="refs/heads/$branch" '
   /^worktree /{p=substr($0,10)} $0=="branch "b{print p}')
 
 # Only ever remove a MERGED worktree; skip if none. Abort if removal fails.
-[ -n "$wt" ] && { git -C "$repo" worktree remove "$wt" || { echo "PR <N>: worktree remove failed — aborting"; exit 1; }; }
+[ -n "$wt" ] && { git -C "$repo_path" worktree remove "$wt" || { echo "PR <N>: worktree remove failed — aborting"; exit 1; }; }
 
 # squash-merge leaves the branch not-fully-merged, so -D. Abort if deletion fails.
-git -C "$repo" branch -D "$branch" || { echo "PR <N>: branch delete failed — aborting"; exit 1; }
+git -C "$repo_path" branch -D "$branch" || { echo "PR <N>: branch delete failed — aborting"; exit 1; }
 ```
 
 Then mark the linked Linear issue `Done` (the parallel-workflow CI loop's Step 1 does this when *it* observes the merge; mirror it here so the manual-merge path stays consistent). Extract `SWO-NNN` from the PR body — the branch name is **not** authoritative:
 
 ```bash
-swo=$(gh pr view <N> --json body -q .body | grep -oE 'SWO-[0-9]+' | head -n1)
+swo=$(gh pr view <N> --repo "ShinaBR2/$repo" --json body -q .body | grep -oE 'SWO-[0-9]+' | head -n1)
 [ -n "$swo" ] && linear issue update "$swo" -s "Done" || echo "PR <N>: no SWO-NNN found in body — skipping Linear update"
 ```
 
@@ -110,10 +116,20 @@ Report that the PR could not be polled and drop it from the pending set so the u
 
 ## 3. After the round
 
-- For **each** repo that had a merge this round, refresh its local `main` **once** — fast-forward only, never rebase. Use the `main:<refspec>` fetch so it works even when the repo's main worktree is checked out on a feature branch (common here — see `parallel-workflow` "Keep local main fresh"); it advances the local `main` ref to `origin/main` without needing to be on `main`, without touching any working tree, and errors loudly if `main` has diverged. Resolve the repo path explicitly via `git -C` — never rely on the current directory, which may still be a PR worktree. Propagate a failed refresh: it must stop success reporting and prevent relaunching the poll for that repo.
+- For **each** repo that had a merge this round, refresh its local `main` **once** — fast-forward only, never rebase. Pick the command the same way as `parallel-workflow`'s "Keep local `main` fresh":
   ```bash
-  git -C "$repo" fetch origin main:main || { echo "$repo: main refresh failed — stop, do not relaunch"; exit 1; }
+  # Is that repo's main worktree sitting on `main`? (empty/detached => feature-branch case)
+  onmain=$(git -C "$repo_path" worktree list --porcelain | awk '
+    /^branch refs\/heads\//{sub(/^branch refs\/heads\//,""); print; found=1} /^$/{if(!found)print"detached"; exit}')
   ```
-  (If no worktree in that repo has `main` checked out — the common case here — this always fast-forwards cleanly. If a future `git pull --ff-only origin main` from the main worktree is preferred and that worktree sits on `main`, that is equivalent and also acceptable.)
+  - **`main`** → run **`git pull --ff-only origin main`** in that main worktree.
+  - **feature branch / detached** → run **`git -C "$repo_path" fetch origin main:main`** (advances the local `main` ref to `origin/main` without a checkout; refuses loudly if `main` *is* checked out somewhere — that refusal is the tell to use `pull --ff-only` in that worktree instead).
+  Resolve the repo path explicitly via `git -C` — never rely on the current directory, which may still be a PR worktree. Propagate a failed refresh: it must stop success reporting and prevent relaunching the poll for that repo.
+  ```bash
+  case "$onmain" in
+    main) (cd "$repo_path" && git pull --ff-only origin main) || { echo "$repo: main refresh failed — stop"; exit 1; } ;;
+    *)    git -C "$repo_path" fetch origin main:main || { echo "$repo: main refresh failed — stop"; exit 1; } ;;
+  esac
+  ```
 - Report per PR: cleaned-up+moved-to-Done (merged), closed-without-merge, or unreachable.
 - If PRs remain pending, re-launch the poll (step 1) for just those. When the pending set is empty, report the final tally and stop.


### PR DESCRIPTION
## Summary
- **parallel-workflow**: keeps local `main` fresh. Fetching only advances the `origin/main` ref; the local `main` pointer stays stale (chronically, under parallel worktrees). Adds a dedicated "Keep local `main` fresh" subsection giving the correct fast-forward command for each case — `git pull --ff-only origin main` when the main worktree sits on `main`, `git fetch origin main:main` when it sits on a feature branch (the common case here — the main worktrees are on `chore/...` branches). Also tightens the "main worktree must stay clean" prerequisite to name both forms. Runs after merged-worktree cleanup, before any code read on `main`, and on demand ("refresh main").
- **wait-for-pr-merge**: new user-invocable skill that polls one or more READY PRs until each merges (or closes), then cleans up each the moment it merges — `worktree remove`, `branch -D`, refresh local `main`, mark the linked Linear issue `Done`. Adapts the single-repo reference to sworld's three-repo layout (resolve repo per PR, run `git -C "$repo"` cleanup in that repo only). Scope boundary: post-READY watching only — does NOT touch CI/conflicts/review comments (that is the loop).

SWO-438

## Test plan
- [ ] Skills render as markdown (frontmatter valid, no broken links).
- [ ] `git fetch origin main:main` works from a feature-branch main worktree; `git pull --ff-only origin main` works when on `main`.
- [ ] On demand: saying "refresh main" runs the refresh for the named repo (or all three if unnamed) and reports.
- [ ] Triggering `wait-for-pr-merge` for a merged PR removes the worktree, deletes the branch, refreshes `main`, and sets the Linear issue to `Done`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a workflow skill for monitoring pull requests until they are merged, closed, or unreachable.
  * Automatically reports outcomes and performs follow-up cleanup after successful merges.
  * Updates linked work items to “Done” when applicable.

* **Documentation**
  * Clarified how to safely keep the local `main` branch current during parallel work.
  * Documented fast-forward-only refresh commands and restrictions on merging or rebasing `main`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->