### PR TITLE
[WIP] feat(watch): add /manage route

### DIFF
--- a/apps/watch/src/routeTree.gen.ts
+++ b/apps/watch/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import { Route as rootRouteImport } from './routes/__root'
 
 const HistoryLazyRouteImport = createFileRoute('/history')()
+const ManageLazyRouteImport = createFileRoute('/manage')()
 const IndexLazyRouteImport = createFileRoute('/')()
 const VideoSlugIdLazyRouteImport = createFileRoute('/video/$slug/$id')()
 const PlaylistSlugPlaylistIdVideoIdLazyRouteImport = createFileRoute(
@@ -24,6 +25,11 @@ const HistoryLazyRoute = HistoryLazyRouteImport.update({
   path: '/history',
   getParentRoute: () => rootRouteImport,
 } as any).lazy(() => import('./routes/history.lazy').then((d) => d.Route))
+const ManageLazyRoute = ManageLazyRouteImport.update({
+  id: '/manage',
+  path: '/manage',
+  getParentRoute: () => rootRouteImport,
+} as any).lazy(() => import('./routes/manage.lazy').then((d) => d.Route))
 const IndexLazyRoute = IndexLazyRouteImport.update({
   id: '/',
   path: '/',
@@ -50,12 +56,14 @@ const PlaylistSlugPlaylistIdVideoIdLazyRoute =
 export interface FileRoutesByFullPath {
   '/': typeof IndexLazyRoute
   '/history': typeof HistoryLazyRoute
+  '/manage': typeof ManageLazyRoute
   '/video/$slug/$id': typeof VideoSlugIdLazyRoute
   '/playlist/$slug/$playlistId/$videoId': typeof PlaylistSlugPlaylistIdVideoIdLazyRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexLazyRoute
   '/history': typeof HistoryLazyRoute
+  '/manage': typeof ManageLazyRoute
   '/video/$slug/$id': typeof VideoSlugIdLazyRoute
   '/playlist/$slug/$playlistId/$videoId': typeof PlaylistSlugPlaylistIdVideoIdLazyRoute
 }
@@ -63,6 +71,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexLazyRoute
   '/history': typeof HistoryLazyRoute
+  '/manage': typeof ManageLazyRoute
   '/video/$slug/$id': typeof VideoSlugIdLazyRoute
   '/playlist/$slug/$playlistId/$videoId': typeof PlaylistSlugPlaylistIdVideoIdLazyRoute
 }
@@ -71,18 +80,21 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/history'
+    | '/manage'
     | '/video/$slug/$id'
     | '/playlist/$slug/$playlistId/$videoId'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
     | '/history'
+    | '/manage'
     | '/video/$slug/$id'
     | '/playlist/$slug/$playlistId/$videoId'
   id:
     | '__root__'
     | '/'
     | '/history'
+    | '/manage'
     | '/video/$slug/$id'
     | '/playlist/$slug/$playlistId/$videoId'
   fileRoutesById: FileRoutesById
@@ -90,6 +102,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexLazyRoute: typeof IndexLazyRoute
   HistoryLazyRoute: typeof HistoryLazyRoute
+  ManageLazyRoute: typeof ManageLazyRoute
   VideoSlugIdLazyRoute: typeof VideoSlugIdLazyRoute
   PlaylistSlugPlaylistIdVideoIdLazyRoute: typeof PlaylistSlugPlaylistIdVideoIdLazyRoute
 }
@@ -101,6 +114,13 @@ declare module '@tanstack/react-router' {
       path: '/history'
       fullPath: '/history'
       preLoaderRoute: typeof HistoryLazyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/manage': {
+      id: '/manage'
+      path: '/manage'
+      fullPath: '/manage'
+      preLoaderRoute: typeof ManageLazyRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -130,6 +150,7 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexLazyRoute: IndexLazyRoute,
   HistoryLazyRoute: HistoryLazyRoute,
+  ManageLazyRoute: ManageLazyRoute,
   VideoSlugIdLazyRoute: VideoSlugIdLazyRoute,
   PlaylistSlugPlaylistIdVideoIdLazyRoute:
     PlaylistSlugPlaylistIdVideoIdLazyRoute,

--- a/apps/watch/src/routes/manage.lazy.tsx
+++ b/apps/watch/src/routes/manage.lazy.tsx
@@ -1,0 +1,39 @@
+import { createLazyFileRoute, useNavigate } from '@tanstack/react-router';
+import { useAuthContext } from 'core/providers/auth';
+import { useEffect } from 'react';
+import { LoadingBackdrop } from 'ui/universal';
+import { ManageScreen } from 'ui/watch/manage';
+import { appConfig } from '../config';
+
+const Content = () => {
+  const { user, signOut } = useAuthContext();
+
+  return (
+    <ManageScreen sites={appConfig.sites} user={user} onLogout={signOut} />
+  );
+};
+
+const Manage = () => {
+  const { isLoading, user } = useAuthContext();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!isLoading && !user) {
+      navigate({ to: '/' });
+    }
+  }, [isLoading, user, navigate]);
+
+  if (isLoading) {
+    return <LoadingBackdrop message="Valuable things deserve waiting" />;
+  }
+
+  if (!user) {
+    return null;
+  }
+
+  return <Content />;
+};
+
+export const Route = createLazyFileRoute('/manage')({
+  component: Manage,
+});

--- a/packages/ui/src/watch/manage/index.tsx
+++ b/packages/ui/src/watch/manage/index.tsx
@@ -1,0 +1,54 @@
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import type { Auth } from 'core';
+import { useState } from 'react';
+import { FullWidthContainer } from '../../universal';
+import { Header } from '../../universal/header';
+import { SettingsPanel } from '../home-page/settings';
+
+interface HeaderSites {
+  main: string;
+  listen: string;
+  watch: string;
+  til: string;
+}
+
+interface ManageScreenProps {
+  sites: HeaderSites;
+  user: Auth.CustomUser | null;
+  onLogout: () => void;
+}
+
+const ManageScreen = (props: ManageScreenProps) => {
+  const { sites, user, onLogout } = props;
+
+  const [settingsOpen, setSettingsOpen] = useState(false);
+
+  return (
+    <FullWidthContainer>
+      <Header
+        user={user}
+        onAvatarClick={() => setSettingsOpen(true)}
+        siteChoices={{ sites, activeSite: 'watch' }}
+      />
+      <SettingsPanel
+        open={settingsOpen}
+        toggle={setSettingsOpen}
+        actions={{ logout: onLogout }}
+      />
+      <Box sx={{ maxWidth: 'xl', mx: 'auto', width: '100%', px: 3 }}>
+        <Box sx={{ my: 4 }}>
+          <Typography variant="h4" component="h1" sx={{ mb: 1 }}>
+            Manage library
+          </Typography>
+          <Typography variant="body1" color="text.secondary">
+            Import videos and configure your app experience.
+          </Typography>
+        </Box>
+      </Box>
+    </FullWidthContainer>
+  );
+};
+
+export { ManageScreen };
+export type { ManageScreenProps };


### PR DESCRIPTION
Auth-gated route (signed-in only) that renders ManageScreen. Follows listen manage.lazy.tsx pattern. Anonymous visitors redirected to /.

SWO-442

**Test plan**
- `pnpm typecheck` in apps/watch
- `pnpm lint`