### PR TITLE
[WIP] feat(watch): replace drawer actions with Manage library link

### DIFF
--- a/apps/watch/src/components/layout/index.tsx
+++ b/apps/watch/src/components/layout/index.tsx
@@ -1,18 +1,12 @@
-import { Link } from '@tanstack/react-router';
+import { Link, useNavigate } from '@tanstack/react-router';
 import { Auth } from 'core';
-import { useSaveUserSettings } from 'core/user-settings/mutation-hooks';
-import { useLoadUserSettings } from 'core/user-settings/query-hooks';
 import type React from 'react';
 import { lazy, Suspense, useState } from 'react';
 import { FullPageContainer } from 'ui/universal/containers/full-page';
 import { Header } from 'ui/universal/header';
-import { Notification } from 'ui/universal/notification';
 import { SettingsPanel } from 'ui/watch/home-page/settings';
 import { appConfig } from '../../config';
-import {
-  clearStandaloneCache,
-  writeStandaloneCache,
-} from '../../standalone-mode';
+import { clearStandaloneCache } from '../../standalone-mode';
 
 const Notifications = lazy(() => import('ui/watch/notifications'));
 
@@ -23,34 +17,10 @@ interface LayoutProps {
 const Layout = (props: LayoutProps) => {
   const { children } = props;
   const authContext = Auth.useAuthContext();
-  const { signOut, user, getAccessToken } = authContext;
+  const { signOut, user } = authContext;
+  const navigate = useNavigate();
   const [settingOpen, toggleSetting] = useState<boolean>(false);
-  const [saving, setSaving] = useState<boolean>(false);
-  const [error, setError] = useState<string | null>(null);
   const { sites } = appConfig;
-
-  const { settings } = useLoadUserSettings({ getAccessToken });
-  const { saveUserSettings } = useSaveUserSettings({ getAccessToken });
-
-  // Settled order: persist to the DB (source of truth) first, then mirror into
-  // the boot cache, then hard-reload so the router picks up the new history. On
-  // failure, leave the cache untouched and surface the error — never reload into
-  // a state the DB didn't accept.
-  const handleStandaloneModeChange = async (next: boolean) => {
-    if (!settings || saving) {
-      return;
-    }
-
-    setSaving(true);
-    try {
-      await saveUserSettings(settings, { watch: { standaloneMode: next } });
-      writeStandaloneCache(next);
-      window.location.reload();
-    } catch {
-      setSaving(false);
-      setError('Failed to save setting. Please try again.');
-    }
-  };
 
   return (
     <FullPageContainer>
@@ -75,17 +45,9 @@ const Layout = (props: LayoutProps) => {
             clearStandaloneCache();
             signOut();
           },
+          manage: user ? () => navigate({ to: '/manage' }) : undefined,
         }}
-        standaloneMode={settings?.watch.standaloneMode ?? false}
-        onStandaloneModeChange={handleStandaloneModeChange}
-        saving={saving}
       />
-      {error && (
-        <Notification
-          notification={{ message: error, severity: 'error' }}
-          onClose={() => setError(null)}
-        />
-      )}
       {children}
     </FullPageContainer>
   );

--- a/packages/ui/src/watch/home-page/settings/index.test.tsx
+++ b/packages/ui/src/watch/home-page/settings/index.test.tsx
@@ -3,10 +3,6 @@ import { describe, expect, it, vi } from 'vitest';
 import { SettingsPanel } from '.';
 import '@testing-library/jest-dom';
 
-vi.mock('./upload-button', () => ({
-  UploadButton: () => <div data-testid="mock-upload-button">Upload Button</div>,
-}));
-
 describe('SettingsPanel', () => {
   const defaultProps = {
     open: true,
@@ -19,11 +15,9 @@ describe('SettingsPanel', () => {
   it('renders correctly when open', () => {
     render(<SettingsPanel {...defaultProps} />);
 
-    // Check if logout button is rendered
     const logoutButton = screen.getByText('Logout');
     expect(logoutButton).toBeInTheDocument();
 
-    // Check if logout icon is present
     const logoutIcon = screen.getByTestId('LogoutIcon');
     expect(logoutIcon).toBeInTheDocument();
   });
@@ -31,7 +25,6 @@ describe('SettingsPanel', () => {
   it('does not render when closed', () => {
     render(<SettingsPanel {...defaultProps} open={false} />);
 
-    // Check if logout button is not rendered
     const logoutButton = screen.queryByText('Logout');
     expect(logoutButton).not.toBeInTheDocument();
   });
@@ -39,51 +32,37 @@ describe('SettingsPanel', () => {
   it('calls logout function when logout button is clicked', () => {
     render(<SettingsPanel {...defaultProps} />);
 
-    // Click logout button
     const logoutButton = screen.getByText('Logout');
     fireEvent.click(logoutButton);
 
-    // Check if logout function was called
     expect(defaultProps.actions.logout).toHaveBeenCalledTimes(1);
   });
 
-  it('renders the standalone toggle reflecting the current value', () => {
-    render(<SettingsPanel {...defaultProps} standaloneMode={true} />);
-
-    const toggle = screen.getByLabelText('Standalone mode');
-    expect(toggle).toBeChecked();
-  });
-
-  it('reports standalone toggle changes', () => {
-    const onStandaloneModeChange = vi.fn();
+  it('renders manage library button when manage action is provided', () => {
+    const manage = vi.fn();
     render(
-      <SettingsPanel
-        {...defaultProps}
-        standaloneMode={false}
-        onStandaloneModeChange={onStandaloneModeChange}
-      />,
+      <SettingsPanel {...defaultProps} actions={{ logout: vi.fn(), manage }} />,
     );
 
-    fireEvent.click(screen.getByLabelText('Standalone mode'));
-    expect(onStandaloneModeChange).toHaveBeenCalledWith(true);
+    const manageButton = screen.getByText('Manage library');
+    expect(manageButton).toBeInTheDocument();
+
+    fireEvent.click(manageButton);
+    expect(manage).toHaveBeenCalledTimes(1);
   });
 
-  it('disables the standalone toggle while saving', () => {
-    render(
-      <SettingsPanel {...defaultProps} standaloneMode={false} saving={true} />,
-    );
+  it('does not render manage library button when manage action is omitted', () => {
+    render(<SettingsPanel {...defaultProps} />);
 
-    expect(screen.getByLabelText('Standalone mode')).toBeDisabled();
+    expect(screen.queryByText('Manage library')).not.toBeInTheDocument();
   });
 
   it('calls toggle function when drawer is closed', () => {
     render(<SettingsPanel {...defaultProps} />);
 
-    // Find the backdrop (overlay) of the drawer
     const backdrop = screen.getByRole('presentation').firstChild;
     fireEvent.click(backdrop as Element);
 
-    // Check if toggle function was called with false
     expect(defaultProps.toggle).toHaveBeenCalledWith(false);
   });
 });

--- a/packages/ui/src/watch/home-page/settings/index.tsx
+++ b/packages/ui/src/watch/home-page/settings/index.tsx
@@ -1,43 +1,30 @@
 import Logout from '@mui/icons-material/Logout';
-import PhoneIphone from '@mui/icons-material/PhoneIphone';
+import VideoLibrary from '@mui/icons-material/VideoLibrary';
 import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
 import Drawer from '@mui/material/Drawer';
 import List from '@mui/material/List';
-import ListItem from '@mui/material/ListItem';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
-import Switch from '@mui/material/Switch';
-import { UploadButton } from './upload-button';
 
 interface SettingsPanelProps {
   open: boolean;
   toggle: React.Dispatch<React.SetStateAction<boolean>>;
   actions: {
     logout: () => void;
+    manage?: () => void;
   };
-  standaloneMode?: boolean;
-  onStandaloneModeChange?: (value: boolean) => void;
-  saving?: boolean;
 }
 
 const texts = {
   logout: 'Logout',
-  standalone: 'Standalone mode',
-  standaloneHint: 'Hide the URL and act like an app',
+  manage: 'Manage library',
 };
 
 const SettingsPanel = (props: SettingsPanelProps) => {
-  const {
-    open,
-    toggle,
-    actions,
-    standaloneMode,
-    onStandaloneModeChange,
-    saving,
-  } = props;
-  const { logout } = actions;
+  const { open, toggle, actions } = props;
+  const { logout, manage } = actions;
 
   return (
     <Drawer anchor="right" open={open} onClose={() => toggle(false)}>
@@ -50,25 +37,14 @@ const SettingsPanel = (props: SettingsPanelProps) => {
         }}
       >
         <List sx={{ flex: 1 }}>
-          <UploadButton />
-          <ListItem>
-            <ListItemIcon>
-              <PhoneIphone />
-            </ListItemIcon>
-            <ListItemText
-              primary={texts.standalone}
-              secondary={texts.standaloneHint}
-            />
-            <Switch
-              edge="end"
-              checked={standaloneMode ?? false}
-              disabled={saving}
-              onChange={(event) =>
-                onStandaloneModeChange?.(event.target.checked)
-              }
-              slotProps={{ input: { 'aria-label': texts.standalone } }}
-            />
-          </ListItem>
+          {manage ? (
+            <ListItemButton onClick={manage}>
+              <ListItemIcon>
+                <VideoLibrary />
+              </ListItemIcon>
+              <ListItemText primary={texts.manage} />
+            </ListItemButton>
+          ) : null}
         </List>
         <Divider />
         <List>


### PR DESCRIPTION
SettingsPanel now matches listen pattern: optional manage action shows 'Manage library' button. Removed UploadButton and standalone mode toggle from drawer. Layout passes manage navigation action.

SWO-444

**Test plan**
- `pnpm typecheck` in packages/ui + apps/watch
- `pnpm lint`