### PR TITLE
[WIP] fix(watch): wire standalone mode on /manage page

### DIFF
--- a/apps/watch/src/routes/manage.lazy.tsx
+++ b/apps/watch/src/routes/manage.lazy.tsx
@@ -1,15 +1,57 @@
 import { createLazyFileRoute, useNavigate } from '@tanstack/react-router';
 import { useAuthContext } from 'core/providers/auth';
-import { useEffect } from 'react';
-import { LoadingBackdrop } from 'ui/universal';
+import { useSaveUserSettings } from 'core/user-settings/mutation-hooks';
+import { useLoadUserSettings } from 'core/user-settings/query-hooks';
+import { useEffect, useState } from 'react';
+import { LoadingBackdrop, Notification } from 'ui/universal';
 import { ManageScreen } from 'ui/watch/manage';
 import { appConfig } from '../config';
+import { clearStandaloneCache, writeStandaloneCache } from '../standalone-mode';
 
 const Content = () => {
-  const { user, signOut } = useAuthContext();
+  const { user, signOut, getAccessToken } = useAuthContext();
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const { settings } = useLoadUserSettings({ getAccessToken });
+  const { saveUserSettings } = useSaveUserSettings({ getAccessToken });
+
+  const handleStandaloneModeChange = async (next: boolean) => {
+    if (!settings || saving) {
+      return;
+    }
+
+    setSaving(true);
+    try {
+      await saveUserSettings(settings, { watch: { standaloneMode: next } });
+      writeStandaloneCache(next);
+      window.location.reload();
+    } catch {
+      setSaving(false);
+      setError('Failed to save setting. Please try again.');
+    }
+  };
 
   return (
-    <ManageScreen sites={appConfig.sites} user={user} onLogout={signOut} />
+    <>
+      <ManageScreen
+        sites={appConfig.sites}
+        user={user}
+        onLogout={() => {
+          clearStandaloneCache();
+          signOut();
+        }}
+        standaloneMode={settings?.watch.standaloneMode ?? false}
+        onStandaloneModeChange={handleStandaloneModeChange}
+        saving={saving}
+      />
+      {error && (
+        <Notification
+          notification={{ message: error, severity: 'error' }}
+          onClose={() => setError(null)}
+        />
+      )}
+    </>
   );
 };
 

--- a/packages/ui/src/watch/manage/index.tsx
+++ b/packages/ui/src/watch/manage/index.tsx
@@ -1,12 +1,14 @@
 import AddIcon from '@mui/icons-material/Add';
 import Box from '@mui/material/Box';
 import Fab from '@mui/material/Fab';
+import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import type { Auth } from 'core';
 import { lazy, Suspense, useState } from 'react';
 import { FullWidthContainer } from '../../universal';
 import { Header } from '../../universal/header';
 import { SettingsPanel } from '../home-page/settings';
+import { SettingsSection } from './settings-section';
 
 const VideoUploadDialog = lazy(() =>
   import('../dialogs/upload').then((module) => ({
@@ -25,10 +27,20 @@ interface ManageScreenProps {
   sites: HeaderSites;
   user: Auth.CustomUser | null;
   onLogout: () => void;
+  standaloneMode: boolean;
+  onStandaloneModeChange: (value: boolean) => void;
+  saving?: boolean;
 }
 
 const ManageScreen = (props: ManageScreenProps) => {
-  const { sites, user, onLogout } = props;
+  const {
+    sites,
+    user,
+    onLogout,
+    standaloneMode,
+    onStandaloneModeChange,
+    saving,
+  } = props;
 
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [uploadOpen, setUploadOpen] = useState(false);
@@ -54,6 +66,13 @@ const ManageScreen = (props: ManageScreenProps) => {
             Import videos and configure your app experience.
           </Typography>
         </Box>
+        <Stack spacing={4} sx={{ pb: 8 }}>
+          <SettingsSection
+            standaloneMode={standaloneMode}
+            onChange={onStandaloneModeChange}
+            saving={saving}
+          />
+        </Stack>
       </Box>
       <Fab
         color="secondary"


### PR DESCRIPTION
PR #449's squash merge lost the route file and ManageScreen changes. ManageScreen now imports SettingsSection and accepts standalone props. Route wires useLoadUserSettings + useSaveUserSettings, clears cache on logout.

SWO-446

**Test plan**
- `pnpm typecheck` in packages/ui + apps/watch
- `pnpm lint`