### PR TITLE
[WIP] feat: add opencode workflow gate plugin

### DIFF
--- a/.opencode/plugins/workflow-gate.ts
+++ b/.opencode/plugins/workflow-gate.ts
@@ -1,0 +1,58 @@
+const isGatedTool = (tool: string) => tool === 'edit' || tool === 'write';
+
+const isInWorktree = (cwd: string) => cwd.includes('/.claude/worktrees/');
+
+const getBranch = async ($: any) => {
+  const result = await $`git branch --show-current`.text();
+  return result.trim();
+};
+
+const getMergeBase = async ($: any) => {
+  const result =
+    await $`git merge-base --is-ancestor origin/main HEAD && echo "ancestor" || echo "not-ancestor"`.text();
+  return result.trim() === 'ancestor';
+};
+
+const getTicketFromBranch = (branch: string) => {
+  const match = branch.match(/^(swo-\d+)/i);
+  return match ? match[1].toUpperCase() : null;
+};
+
+const isTicketInProgress = async ($: any, ticket: string) => {
+  try {
+    const result = await $`linear issue view ${ticket} --json state`.text();
+    const json = JSON.parse(result.trim());
+    return json?.state?.type === 'started';
+  } catch {
+    return false;
+  }
+};
+
+// biome-ignore lint/suspicious/noExplicitAny: BunShell type from opencode runtime
+export default async ({ $, directory }: any) => {
+  return {
+    'permission.ask': async (_input: any, output: any) => {
+      if (!isGatedTool(_input.tool)) return;
+
+      if (!isInWorktree(directory)) return;
+
+      const branch = await getBranch($);
+      if (!branch) return;
+
+      const ticket = getTicketFromBranch(branch);
+      if (!ticket) {
+        output.status = 'deny';
+        return;
+      }
+
+      if (!(await isTicketInProgress($, ticket))) {
+        output.status = 'deny';
+        return;
+      }
+
+      if (!(await getMergeBase($))) {
+        output.status = 'deny';
+      }
+    },
+  };
+};

--- a/.opencode/plugins/workflow-gate.ts
+++ b/.opencode/plugins/workflow-gate.ts
@@ -2,14 +2,16 @@ const isGatedTool = (tool: string) => tool === 'edit' || tool === 'write';
 
 const isInWorktree = (cwd: string) => cwd.includes('/.claude/worktrees/');
 
-const getBranch = async ($: any) => {
-  const result = await $`git branch --show-current`.text();
+const getBranch = async ($: any, cwd: string) => {
+  const result = await $`git branch --show-current`.cwd(cwd).text();
   return result.trim();
 };
 
-const getMergeBase = async ($: any) => {
+const getMergeBase = async ($: any, cwd: string) => {
   const result =
-    await $`git merge-base --is-ancestor origin/main HEAD && echo "ancestor" || echo "not-ancestor"`.text();
+    await $`git merge-base --is-ancestor origin/main HEAD && echo "ancestor" || echo "not-ancestor"`
+      .cwd(cwd)
+      .text();
   return result.trim() === 'ancestor';
 };
 
@@ -36,8 +38,17 @@ export default async ({ $, directory }: any) => {
 
       if (!isInWorktree(directory)) return;
 
-      const branch = await getBranch($);
-      if (!branch) return;
+      let branch: string;
+      try {
+        branch = await getBranch($, directory);
+      } catch {
+        output.status = 'deny';
+        return;
+      }
+      if (!branch) {
+        output.status = 'deny';
+        return;
+      }
 
       const ticket = getTicketFromBranch(branch);
       if (!ticket) {
@@ -50,7 +61,7 @@ export default async ({ $, directory }: any) => {
         return;
       }
 
-      if (!(await getMergeBase($))) {
+      if (!(await getMergeBase($, directory))) {
         output.status = 'deny';
       }
     },


### PR DESCRIPTION
Blocks Edit/Write in worktrees unless: SWO-NNN branch, Linear issue In Progress, branch from origin/main.

SWO-447

**Test plan**
- Plugin auto-discovered from `.opencode/plugins/`
- Restart opencode after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workflow safeguards for editing and writing files in designated worktree environments.
  * Changes are permitted only when the associated ticket is actively in progress and the branch is based on the latest mainline history.
  * Requests that do not meet these conditions are automatically denied, helping prevent work from proceeding in an invalid workflow state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->