### PR TITLE
feat(watch): add Settings item to drawer with divider above logout

### DIFF
--- a/packages/ui/src/watch/home-page/settings/index.test.tsx
+++ b/packages/ui/src/watch/home-page/settings/index.test.tsx
@@ -65,4 +65,26 @@ describe('SettingsPanel', () => {
 
     expect(defaultProps.toggle).toHaveBeenCalledWith(false);
   });
+
+  it('renders settings button when settings action is provided', () => {
+    const settings = vi.fn();
+    render(
+      <SettingsPanel
+        {...defaultProps}
+        actions={{ logout: vi.fn(), settings }}
+      />,
+    );
+
+    const settingsButton = screen.getByText('Settings');
+    expect(settingsButton).toBeInTheDocument();
+
+    fireEvent.click(settingsButton);
+    expect(settings).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render settings button when settings action is omitted', () => {
+    render(<SettingsPanel {...defaultProps} />);
+
+    expect(screen.queryByText('Settings')).not.toBeInTheDocument();
+  });
 });

--- a/packages/ui/src/watch/home-page/settings/index.tsx
+++ b/packages/ui/src/watch/home-page/settings/index.tsx
@@ -1,4 +1,5 @@
 import Logout from '@mui/icons-material/Logout';
+import Settings from '@mui/icons-material/Settings';
 import VideoLibrary from '@mui/icons-material/VideoLibrary';
 import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
@@ -14,17 +15,19 @@ interface SettingsPanelProps {
   actions: {
     logout: () => void;
     manage?: () => void;
+    settings?: () => void;
   };
 }
 
 const texts = {
   logout: 'Logout',
   manage: 'Manage library',
+  settings: 'Settings',
 };
 
 const SettingsPanel = (props: SettingsPanelProps) => {
   const { open, toggle, actions } = props;
-  const { logout, manage } = actions;
+  const { logout, manage, settings } = actions;
 
   return (
     <Drawer anchor="right" open={open} onClose={() => toggle(false)}>
@@ -48,6 +51,17 @@ const SettingsPanel = (props: SettingsPanelProps) => {
         </List>
         <Divider />
         <List>
+          {settings ? (
+            <>
+              <ListItemButton onClick={settings}>
+                <ListItemIcon>
+                  <Settings />
+                </ListItemIcon>
+                <ListItemText primary={texts.settings} />
+              </ListItemButton>
+              <Divider />
+            </>
+          ) : null}
           <ListItemButton onClick={logout}>
             <ListItemIcon>
               <Logout />


### PR DESCRIPTION
SWO-450

**What:** Add optional `settings` action to SettingsPanel drawer. When provided, renders a Settings item with a horizontal divider above Logout.

**Test plan:**
- 8 SettingsPanel tests pass (including 2 new tests for settings action)
- All 578 package tests pass