### PR TITLE
feat(watch): add /settings route, wire drawer, remove standalone from manage

### DIFF
--- a/apps/watch/src/components/layout/index.tsx
+++ b/apps/watch/src/components/layout/index.tsx
@@ -46,6 +46,7 @@ const Layout = (props: LayoutProps) => {
             signOut();
           },
           manage: user ? () => navigate({ to: '/manage' }) : undefined,
+          settings: user ? () => navigate({ to: '/settings' }) : undefined,
         }}
       />
       {children}

--- a/apps/watch/src/routeTree.gen.ts
+++ b/apps/watch/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as rootRouteImport } from './routes/__root'
 
 const HistoryLazyRouteImport = createFileRoute('/history')()
 const ManageLazyRouteImport = createFileRoute('/manage')()
+const SettingsLazyRouteImport = createFileRoute('/settings')()
 const IndexLazyRouteImport = createFileRoute('/')()
 const VideoSlugIdLazyRouteImport = createFileRoute('/video/$slug/$id')()
 const PlaylistSlugPlaylistIdVideoIdLazyRouteImport = createFileRoute(
@@ -30,6 +31,13 @@ const ManageLazyRoute = ManageLazyRouteImport.update({
   path: '/manage',
   getParentRoute: () => rootRouteImport,
 } as any).lazy(() => import('./routes/manage.lazy').then((d) => d.Route))
+const SettingsLazyRoute = SettingsLazyRouteImport.update({
+  id: '/settings',
+  path: '/settings',
+  getParentRoute: () => rootRouteImport,
+} as any).lazy(() =>
+  import('./routes/settings.lazy').then((d) => d.Route),
+)
 const IndexLazyRoute = IndexLazyRouteImport.update({
   id: '/',
   path: '/',
@@ -57,6 +65,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexLazyRoute
   '/history': typeof HistoryLazyRoute
   '/manage': typeof ManageLazyRoute
+  '/settings': typeof SettingsLazyRoute
   '/video/$slug/$id': typeof VideoSlugIdLazyRoute
   '/playlist/$slug/$playlistId/$videoId': typeof PlaylistSlugPlaylistIdVideoIdLazyRoute
 }
@@ -64,6 +73,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexLazyRoute
   '/history': typeof HistoryLazyRoute
   '/manage': typeof ManageLazyRoute
+  '/settings': typeof SettingsLazyRoute
   '/video/$slug/$id': typeof VideoSlugIdLazyRoute
   '/playlist/$slug/$playlistId/$videoId': typeof PlaylistSlugPlaylistIdVideoIdLazyRoute
 }
@@ -72,6 +82,7 @@ export interface FileRoutesById {
   '/': typeof IndexLazyRoute
   '/history': typeof HistoryLazyRoute
   '/manage': typeof ManageLazyRoute
+  '/settings': typeof SettingsLazyRoute
   '/video/$slug/$id': typeof VideoSlugIdLazyRoute
   '/playlist/$slug/$playlistId/$videoId': typeof PlaylistSlugPlaylistIdVideoIdLazyRoute
 }
@@ -81,6 +92,7 @@ export interface FileRouteTypes {
     | '/'
     | '/history'
     | '/manage'
+    | '/settings'
     | '/video/$slug/$id'
     | '/playlist/$slug/$playlistId/$videoId'
   fileRoutesByTo: FileRoutesByTo
@@ -88,6 +100,7 @@ export interface FileRouteTypes {
     | '/'
     | '/history'
     | '/manage'
+    | '/settings'
     | '/video/$slug/$id'
     | '/playlist/$slug/$playlistId/$videoId'
   id:
@@ -95,6 +108,7 @@ export interface FileRouteTypes {
     | '/'
     | '/history'
     | '/manage'
+    | '/settings'
     | '/video/$slug/$id'
     | '/playlist/$slug/$playlistId/$videoId'
   fileRoutesById: FileRoutesById
@@ -103,6 +117,7 @@ export interface RootRouteChildren {
   IndexLazyRoute: typeof IndexLazyRoute
   HistoryLazyRoute: typeof HistoryLazyRoute
   ManageLazyRoute: typeof ManageLazyRoute
+  SettingsLazyRoute: typeof SettingsLazyRoute
   VideoSlugIdLazyRoute: typeof VideoSlugIdLazyRoute
   PlaylistSlugPlaylistIdVideoIdLazyRoute: typeof PlaylistSlugPlaylistIdVideoIdLazyRoute
 }
@@ -121,6 +136,13 @@ declare module '@tanstack/react-router' {
       path: '/manage'
       fullPath: '/manage'
       preLoaderRoute: typeof ManageLazyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/settings': {
+      id: '/settings'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof SettingsLazyRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -151,6 +173,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexLazyRoute: IndexLazyRoute,
   HistoryLazyRoute: HistoryLazyRoute,
   ManageLazyRoute: ManageLazyRoute,
+  SettingsLazyRoute: SettingsLazyRoute,
   VideoSlugIdLazyRoute: VideoSlugIdLazyRoute,
   PlaylistSlugPlaylistIdVideoIdLazyRoute:
     PlaylistSlugPlaylistIdVideoIdLazyRoute,

--- a/apps/watch/src/routes/manage.lazy.tsx
+++ b/apps/watch/src/routes/manage.lazy.tsx
@@ -1,57 +1,25 @@
 import { createLazyFileRoute, useNavigate } from '@tanstack/react-router';
 import { useAuthContext } from 'core/providers/auth';
-import { useSaveUserSettings } from 'core/user-settings/mutation-hooks';
-import { useLoadUserSettings } from 'core/user-settings/query-hooks';
-import { useEffect, useState } from 'react';
-import { LoadingBackdrop, Notification } from 'ui/universal';
+import { useEffect } from 'react';
+import { LoadingBackdrop } from 'ui/universal';
 import { ManageScreen } from 'ui/watch/manage';
 import { appConfig } from '../config';
-import { clearStandaloneCache, writeStandaloneCache } from '../standalone-mode';
+import { clearStandaloneCache } from '../standalone-mode';
 
 const Content = () => {
-  const { user, signOut, getAccessToken } = useAuthContext();
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const { settings } = useLoadUserSettings({ getAccessToken });
-  const { saveUserSettings } = useSaveUserSettings({ getAccessToken });
-
-  const handleStandaloneModeChange = async (next: boolean) => {
-    if (!settings || saving) {
-      return;
-    }
-
-    setSaving(true);
-    try {
-      await saveUserSettings(settings, { watch: { standaloneMode: next } });
-      writeStandaloneCache(next);
-      window.location.reload();
-    } catch {
-      setSaving(false);
-      setError('Failed to save setting. Please try again.');
-    }
-  };
+  const { user, signOut } = useAuthContext();
+  const navigate = useNavigate();
 
   return (
-    <>
-      <ManageScreen
-        sites={appConfig.sites}
-        user={user}
-        onLogout={() => {
-          clearStandaloneCache();
-          signOut();
-        }}
-        standaloneMode={settings?.watch.standaloneMode ?? false}
-        onStandaloneModeChange={handleStandaloneModeChange}
-        saving={saving}
-      />
-      {error && (
-        <Notification
-          notification={{ message: error, severity: 'error' }}
-          onClose={() => setError(null)}
-        />
-      )}
-    </>
+    <ManageScreen
+      sites={appConfig.sites}
+      user={user}
+      onLogout={() => {
+        clearStandaloneCache();
+        signOut();
+      }}
+      onNavigateSettings={() => navigate({ to: '/settings' })}
+    />
   );
 };
 

--- a/apps/watch/src/routes/settings.lazy.tsx
+++ b/apps/watch/src/routes/settings.lazy.tsx
@@ -1,0 +1,74 @@
+import { createLazyFileRoute } from '@tanstack/react-router';
+import { useAuthContext } from 'core/providers/auth';
+import { useSaveUserSettings } from 'core/user-settings/mutation-hooks';
+import { useLoadUserSettings } from 'core/user-settings/query-hooks';
+import { useState } from 'react';
+import { AuthRoute } from 'ui/universal/authRoute';
+import { SettingsSection } from 'ui/watch/manage/settings-section';
+import { Notification } from 'ui/universal';
+import { Box, Typography } from '@mui/material';
+import { Layout } from '../components/layout';
+import { writeStandaloneCache } from '../standalone-mode';
+
+const Content = () => {
+  const { getAccessToken } = useAuthContext();
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const { settings } = useLoadUserSettings({ getAccessToken });
+  const { saveUserSettings } = useSaveUserSettings({ getAccessToken });
+
+  const handleStandaloneModeChange = async (next: boolean) => {
+    if (!settings || saving) {
+      return;
+    }
+
+    setSaving(true);
+    try {
+      await saveUserSettings(settings, { watch: { standaloneMode: next } });
+      writeStandaloneCache(next);
+      window.location.reload();
+    } catch {
+      setSaving(false);
+      setError('Failed to save setting. Please try again.');
+    }
+  };
+
+  return (
+    <Layout>
+      <Box sx={{ maxWidth: 'xl', mx: 'auto', width: '100%', px: 3 }}>
+        <Box sx={{ my: 4 }}>
+          <Typography variant="h4" component="h1" sx={{ mb: 1 }}>
+            Settings
+          </Typography>
+          <Typography variant="body1" color="text.secondary">
+            Configure your app experience.
+          </Typography>
+        </Box>
+        <Box sx={{ pb: 8 }}>
+          <SettingsSection
+            standaloneMode={settings?.watch.standaloneMode ?? false}
+            onChange={handleStandaloneModeChange}
+            saving={saving}
+          />
+        </Box>
+      </Box>
+      {error && (
+        <Notification
+          notification={{ message: error, severity: 'error' }}
+          onClose={() => setError(null)}
+        />
+      )}
+    </Layout>
+  );
+};
+
+export const Route = createLazyFileRoute('/settings')({
+  component: () => {
+    return (
+      <AuthRoute>
+        <Content />
+      </AuthRoute>
+    );
+  },
+});

--- a/apps/watch/src/routes/settings.lazy.tsx
+++ b/apps/watch/src/routes/settings.lazy.tsx
@@ -4,9 +4,7 @@ import { useSaveUserSettings } from 'core/user-settings/mutation-hooks';
 import { useLoadUserSettings } from 'core/user-settings/query-hooks';
 import { useState } from 'react';
 import { AuthRoute } from 'ui/universal/authRoute';
-import { SettingsSection } from 'ui/watch/manage/settings-section';
-import { Notification } from 'ui/universal';
-import { Box, Typography } from '@mui/material';
+import { SettingsScreen } from 'ui/watch/settings';
 import { Layout } from '../components/layout';
 import { writeStandaloneCache } from '../standalone-mode';
 
@@ -36,29 +34,13 @@ const Content = () => {
 
   return (
     <Layout>
-      <Box sx={{ maxWidth: 'xl', mx: 'auto', width: '100%', px: 3 }}>
-        <Box sx={{ my: 4 }}>
-          <Typography variant="h4" component="h1" sx={{ mb: 1 }}>
-            Settings
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            Configure your app experience.
-          </Typography>
-        </Box>
-        <Box sx={{ pb: 8 }}>
-          <SettingsSection
-            standaloneMode={settings?.watch.standaloneMode ?? false}
-            onChange={handleStandaloneModeChange}
-            saving={saving}
-          />
-        </Box>
-      </Box>
-      {error && (
-        <Notification
-          notification={{ message: error, severity: 'error' }}
-          onClose={() => setError(null)}
-        />
-      )}
+      <SettingsScreen
+        standaloneMode={settings?.watch.standaloneMode ?? false}
+        onChange={handleStandaloneModeChange}
+        saving={saving}
+        error={error}
+        onCloseError={() => setError(null)}
+      />
     </Layout>
   );
 };

--- a/packages/ui/src/watch/manage/index.tsx
+++ b/packages/ui/src/watch/manage/index.tsx
@@ -1,14 +1,12 @@
 import AddIcon from '@mui/icons-material/Add';
 import Box from '@mui/material/Box';
 import Fab from '@mui/material/Fab';
-import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import type { Auth } from 'core';
 import { lazy, Suspense, useState } from 'react';
 import { FullWidthContainer } from '../../universal';
 import { Header } from '../../universal/header';
 import { SettingsPanel } from '../home-page/settings';
-import { SettingsSection } from './settings-section';
 
 const VideoUploadDialog = lazy(() =>
   import('../dialogs/upload').then((module) => ({
@@ -27,9 +25,7 @@ interface ManageScreenProps {
   sites: HeaderSites;
   user: Auth.CustomUser | null;
   onLogout: () => void;
-  standaloneMode: boolean;
-  onStandaloneModeChange: (value: boolean) => void;
-  saving?: boolean;
+  onNavigateSettings?: () => void;
 }
 
 const ManageScreen = (props: ManageScreenProps) => {
@@ -37,9 +33,7 @@ const ManageScreen = (props: ManageScreenProps) => {
     sites,
     user,
     onLogout,
-    standaloneMode,
-    onStandaloneModeChange,
-    saving,
+    onNavigateSettings,
   } = props;
 
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -55,7 +49,10 @@ const ManageScreen = (props: ManageScreenProps) => {
       <SettingsPanel
         open={settingsOpen}
         toggle={setSettingsOpen}
-        actions={{ logout: onLogout }}
+        actions={{
+          logout: onLogout,
+          settings: onNavigateSettings,
+        }}
       />
       <Box sx={{ maxWidth: 'xl', mx: 'auto', width: '100%', px: 3 }}>
         <Box sx={{ my: 4 }}>
@@ -63,16 +60,9 @@ const ManageScreen = (props: ManageScreenProps) => {
             Manage library
           </Typography>
           <Typography variant="body1" color="text.secondary">
-            Import videos and configure your app experience.
+            Import videos and manage your content.
           </Typography>
         </Box>
-        <Stack spacing={4} sx={{ pb: 8 }}>
-          <SettingsSection
-            standaloneMode={standaloneMode}
-            onChange={onStandaloneModeChange}
-            saving={saving}
-          />
-        </Stack>
       </Box>
       <Fab
         color="secondary"

--- a/packages/ui/src/watch/manage/index.tsx
+++ b/packages/ui/src/watch/manage/index.tsx
@@ -29,12 +29,7 @@ interface ManageScreenProps {
 }
 
 const ManageScreen = (props: ManageScreenProps) => {
-  const {
-    sites,
-    user,
-    onLogout,
-    onNavigateSettings,
-  } = props;
+  const { sites, user, onLogout, onNavigateSettings } = props;
 
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [uploadOpen, setUploadOpen] = useState(false);

--- a/packages/ui/src/watch/settings/index.tsx
+++ b/packages/ui/src/watch/settings/index.tsx
@@ -1,0 +1,45 @@
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { Notification } from '../../universal';
+import { SettingsSection } from '../manage/settings-section';
+
+interface SettingsScreenProps {
+  standaloneMode: boolean;
+  onChange: (next: boolean) => void;
+  saving: boolean;
+  error: string | null;
+  onCloseError: () => void;
+}
+
+const SettingsScreen = (props: SettingsScreenProps) => {
+  const { standaloneMode, onChange, saving, error, onCloseError } = props;
+
+  return (
+    <Box sx={{ maxWidth: 'xl', mx: 'auto', width: '100%', px: 3 }}>
+      <Box sx={{ my: 4 }}>
+        <Typography variant="h4" component="h1" sx={{ mb: 1 }}>
+          Settings
+        </Typography>
+        <Typography variant="body1" color="text.secondary">
+          Configure your app experience.
+        </Typography>
+      </Box>
+      <Box sx={{ pb: 8 }}>
+        <SettingsSection
+          standaloneMode={standaloneMode}
+          onChange={onChange}
+          saving={saving}
+        />
+      </Box>
+      {error && (
+        <Notification
+          notification={{ message: error, severity: 'error' }}
+          onClose={onCloseError}
+        />
+      )}
+    </Box>
+  );
+};
+
+export { SettingsScreen };
+export type { SettingsScreenProps };


### PR DESCRIPTION
SWO-452

**What:** Creates a dedicated `/settings` route with the standalone mode toggle. Wires the Layout component to pass the settings navigation action to the drawer. Removes standalone mode from ManageScreen.

**Test plan:**
- Type-check passes for all changed files
- /settings route renders standalone mode toggle
- /manage page no longer has standalone mode
- Drawer shows Settings item (when SWO-450 lands)