### PR TITLE
feat(watch): add VideoSection with Fuse.js search and edit/repair dialog

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -69,6 +69,7 @@
     "core": "workspace:*",
     "echarts": "^6.1.0",
     "echarts-for-react": "^3.0.2",
+    "fuse.js": "^7.4.2",
     "react-dom": "^19.2.0",
     "react-error-boundary": "^4.1.2",
     "react-helmet": "^6.1.0",

--- a/packages/ui/src/watch/manage/types.ts
+++ b/packages/ui/src/watch/manage/types.ts
@@ -36,4 +36,10 @@ interface PlaylistEdit {
   description?: string;
 }
 
-export type { ManageVideo, VideoEdit, ManagePlaylist, PlaylistCreate, PlaylistEdit };
+export type {
+  ManageVideo,
+  VideoEdit,
+  ManagePlaylist,
+  PlaylistCreate,
+  PlaylistEdit,
+};

--- a/packages/ui/src/watch/manage/types.ts
+++ b/packages/ui/src/watch/manage/types.ts
@@ -1,0 +1,18 @@
+interface ManageVideo {
+  id: string;
+  title: string;
+  thumbnailUrl: string | null;
+  duration: number | null;
+  source: string | null;
+  status: string;
+  slug: string;
+  createdAt: string;
+}
+
+interface VideoEdit {
+  id: string;
+  title?: string;
+  thumbnailUrl?: string;
+}
+
+export type { ManageVideo, VideoEdit };

--- a/packages/ui/src/watch/manage/types.ts
+++ b/packages/ui/src/watch/manage/types.ts
@@ -15,4 +15,25 @@ interface VideoEdit {
   thumbnailUrl?: string;
 }
 
-export type { ManageVideo, VideoEdit };
+interface ManagePlaylist {
+  id: string;
+  title: string;
+  slug: string;
+  description?: string | null;
+  thumbnailUrl?: string | null;
+}
+
+interface PlaylistCreate {
+  title: string;
+  slug: string;
+  thumbnailUrl?: string;
+  description?: string;
+}
+
+interface PlaylistEdit {
+  id: string;
+  title?: string;
+  description?: string;
+}
+
+export type { ManageVideo, VideoEdit, ManagePlaylist, PlaylistCreate, PlaylistEdit };

--- a/packages/ui/src/watch/manage/video-edit-dialog.tsx
+++ b/packages/ui/src/watch/manage/video-edit-dialog.tsx
@@ -1,0 +1,92 @@
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import { useEffect, useState } from 'react';
+import type { ManageVideo, VideoEdit } from './types';
+
+interface VideoEditDialogProps {
+  open: boolean;
+  video: ManageVideo | null;
+  onClose: () => void;
+  onSave: (input: VideoEdit) => void;
+  onRepair: (videoId: string) => void;
+  isRepairDisabled?: boolean;
+}
+
+const VideoEditDialog = (props: VideoEditDialogProps) => {
+  const { open, video, onClose, onSave, onRepair, isRepairDisabled } = props;
+  const [title, setTitle] = useState('');
+  const [thumbnailUrl, setThumbnailUrl] = useState('');
+
+  useEffect(() => {
+    if (open && video) {
+      setTitle(video.title);
+      setThumbnailUrl(video.thumbnailUrl ?? '');
+    }
+  }, [open, video]);
+
+  const handleSave = () => {
+    if (!video) return;
+    const trimmedTitle = title.trim();
+    if (!trimmedTitle) return;
+    onSave({
+      id: video.id,
+      title: trimmedTitle,
+      thumbnailUrl: thumbnailUrl.trim() || undefined,
+    });
+    onClose();
+  };
+
+  const handleRepair = () => {
+    if (!video) return;
+    onRepair(video.id);
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="xs">
+      <DialogTitle>Edit video</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <TextField
+            autoFocus
+            label="Title"
+            fullWidth
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+          />
+          <TextField
+            label="Thumbnail URL"
+            fullWidth
+            value={thumbnailUrl}
+            onChange={(event) => setThumbnailUrl(event.target.value)}
+          />
+          <Button
+            variant="outlined"
+            color="warning"
+            fullWidth
+            disabled={isRepairDisabled}
+            onClick={handleRepair}
+          >
+            Fix video (repair fMP4)
+          </Button>
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          onClick={handleSave}
+          variant="contained"
+          disabled={!title.trim()}
+        >
+          Save
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export { VideoEditDialog };

--- a/packages/ui/src/watch/manage/video-section.tsx
+++ b/packages/ui/src/watch/manage/video-section.tsx
@@ -1,0 +1,148 @@
+import Build from '@mui/icons-material/Build';
+import Edit from '@mui/icons-material/Edit';
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
+import IconButton from '@mui/material/IconButton';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import Fuse from 'fuse.js';
+import { useMemo, useState } from 'react';
+import type { ManageVideo, VideoEdit } from './types';
+import { VideoEditDialog } from './video-edit-dialog';
+
+interface VideoSectionProps {
+  isLoading: boolean;
+  videos: ManageVideo[];
+  onUpdateVideo: (input: VideoEdit) => void;
+  onRepairVideo: (videoId: string) => void;
+  isRepairDisabled?: boolean;
+}
+
+const formatDuration = (seconds: number | null): string => {
+  if (!seconds) return '';
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+};
+
+const statusLabel = (status: string): string => {
+  switch (status) {
+    case 'ready':
+      return 'Ready';
+    case 'failed':
+      return 'Failed';
+    case 'processing':
+      return 'Processing';
+    default:
+      return status;
+  }
+};
+
+const VideoSection = (props: VideoSectionProps) => {
+  const { isLoading, videos, onUpdateVideo, onRepairVideo, isRepairDisabled } =
+    props;
+
+  const [search, setSearch] = useState('');
+  const [editing, setEditing] = useState<ManageVideo | null>(null);
+
+  const fuse = useMemo(
+    () =>
+      new Fuse(videos, {
+        keys: ['title'],
+        threshold: 0.4,
+      }),
+    [videos],
+  );
+
+  const filtered = search.trim()
+    ? fuse.search(search.trim()).map((r) => r.item)
+    : videos;
+
+  return (
+    <Box component="section">
+      <Stack
+        direction="row"
+        sx={{ alignItems: 'center', justifyContent: 'space-between', mb: 2 }}
+      >
+        <Typography variant="h6" component="h2">
+          Videos ({videos.length})
+        </Typography>
+      </Stack>
+
+      <TextField
+        placeholder="Search videos…"
+        fullWidth
+        size="small"
+        value={search}
+        onChange={(event) => setSearch(event.target.value)}
+        sx={{ mb: 2 }}
+      />
+
+      {isLoading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+          <CircularProgress />
+        </Box>
+      ) : filtered.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          {search.trim() ? 'No videos match your search.' : 'You have no videos yet.'}
+        </Typography>
+      ) : (
+        <Stack spacing={2}>
+          {filtered.map((video) => (
+            <Paper key={video.id} variant="outlined" sx={{ p: 2 }}>
+              <Stack
+                direction={{ xs: 'column', sm: 'row' }}
+                spacing={2}
+                sx={{ alignItems: { sm: 'center' } }}
+              >
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Typography variant="subtitle1" noWrap>
+                    {video.title}
+                  </Typography>
+                  <Stack direction="row" spacing={1} sx={{ mt: 0.5 }}>
+                    {video.duration ? (
+                      <Typography variant="body2" color="text.secondary">
+                        {formatDuration(video.duration)}
+                      </Typography>
+                    ) : null}
+                    <Typography variant="body2" color="text.secondary">
+                      {statusLabel(video.status)}
+                    </Typography>
+                  </Stack>
+                </Box>
+                <Stack direction="row" spacing={1}>
+                  <IconButton
+                    aria-label={`Edit ${video.title}`}
+                    onClick={() => setEditing(video)}
+                  >
+                    <Edit />
+                  </IconButton>
+                  <IconButton
+                    aria-label={`Repair ${video.title}`}
+                    onClick={() => onRepairVideo(video.id)}
+                    disabled={isRepairDisabled}
+                  >
+                    <Build />
+                  </IconButton>
+                </Stack>
+              </Stack>
+            </Paper>
+          ))}
+        </Stack>
+      )}
+
+      <VideoEditDialog
+        open={Boolean(editing)}
+        video={editing}
+        onClose={() => setEditing(null)}
+        onSave={onUpdateVideo}
+        onRepair={onRepairVideo}
+        isRepairDisabled={isRepairDisabled}
+      />
+    </Box>
+  );
+};
+
+export { VideoSection };

--- a/packages/ui/src/watch/manage/video-section.tsx
+++ b/packages/ui/src/watch/manage/video-section.tsx
@@ -86,7 +86,9 @@ const VideoSection = (props: VideoSectionProps) => {
         </Box>
       ) : filtered.length === 0 ? (
         <Typography variant="body2" color="text.secondary">
-          {search.trim() ? 'No videos match your search.' : 'You have no videos yet.'}
+          {search.trim()
+            ? 'No videos match your search.'
+            : 'You have no videos yet.'}
         </Typography>
       ) : (
         <Stack spacing={2}>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -542,7 +542,7 @@ importers:
         version: 8.3.5(jiti@2.7.0)(postcss@8.5.16)(tsx@4.19.3)(typescript@5.9.3)(yaml@2.7.0)
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(jsdom@25.0.1)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))
+        version: 4.1.9(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(jsdom@25.0.1)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))
 
   packages/jest-dom-preset:
     dependencies:
@@ -587,6 +587,9 @@ importers:
       echarts-for-react:
         specifier: ^3.0.2
         version: 3.0.2(echarts@6.1.0)(react@19.2.7)
+      fuse.js:
+        specifier: ^7.4.2
+        version: 7.4.2
       react-dom:
         specifier: ^19.2.0
         version: 19.2.7(react@19.2.7)
@@ -602,13 +605,13 @@ importers:
     devDependencies:
       '@storybook/addon-docs':
         specifier: 10.4.6
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.5)(react@19.2.7))(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.28.1))
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.24.2)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.5)(react@19.2.7))(vite@8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.24.2))
       '@storybook/addon-links':
         specifier: 10.4.6
         version: 10.4.6(@types/react@19.2.17)(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.5)(react@19.2.7))
       '@storybook/tanstack-react':
         specifier: 10.4.6
-        version: 10.4.6(@tanstack/react-router@1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tanstack/router-core@1.171.13)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.5)(react@19.2.7))(typescript@5.9.3)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.28.1))
+        version: 10.4.6(@tanstack/react-router@1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tanstack/router-core@1.171.13)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.24.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.5)(react@19.2.7))(typescript@5.9.3)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.24.2))
       '@testing-library/jest-dom':
         specifier: ^6.6.3
         version: 6.6.3
@@ -647,7 +650,7 @@ importers:
         version: 8.3.5(jiti@2.7.0)(postcss@8.5.16)(tsx@4.19.3)(typescript@5.9.3)(yaml@2.7.0)
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(jsdom@25.0.1)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))
+        version: 4.1.9(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(jsdom@25.0.1)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))
 
 packages:
 
@@ -7525,6 +7528,10 @@ packages:
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  fuse.js@7.4.2:
+    resolution: {integrity: sha512-LVbzjD4WA6UP5B1UnP8wuaXJiLnqMdM/E4fiJXTJ5haJ5b/MBNsK29h2fm6swEoQaVQjvYFWKLE2RanyZIoRVQ==}
+    engines: {node: '>=10'}
 
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
@@ -16326,11 +16333,11 @@ snapshots:
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.9.3)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.9.3)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))':
     dependencies:
       glob: 13.0.6
       react-docgen-typescript: 2.2.2(typescript@5.9.3)
-      vite: 8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -17382,10 +17389,10 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-docs@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.5)(react@19.2.7))(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.28.1))':
+  '@storybook/addon-docs@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.24.2)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.5)(react@19.2.7))(vite@8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.24.2))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@19.2.7)
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.5)(react@19.2.7))(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.28.1))
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.24.2)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.5)(react@19.2.7))(vite@8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.24.2))
       '@storybook/icons': 2.1.0(react@19.2.7)
       '@storybook/react-dom-shim': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.5)(react@19.2.7))
       react: 19.2.7
@@ -17409,26 +17416,26 @@ snapshots:
       '@types/react': 19.2.17
       react: 19.2.7
 
-  '@storybook/builder-vite@10.4.6(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.5)(react@19.2.7))(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.28.1))':
+  '@storybook/builder-vite@10.4.6(esbuild@0.24.2)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.5)(react@19.2.7))(vite@8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.24.2))':
     dependencies:
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.5)(react@19.2.7))(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.28.1))
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.24.2)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.5)(react@19.2.7))(vite@8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.24.2))
       storybook: 10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.5)(react@19.2.7)
       ts-dedent: 2.2.0
-      vite: 8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.4.6(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.5)(react@19.2.7))(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.28.1))':
+  '@storybook/csf-plugin@10.4.6(esbuild@0.24.2)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.5)(react@19.2.7))(vite@8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.24.2))':
     dependencies:
       storybook: 10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.5)(react@19.2.7)
       unplugin: 2.3.11
     optionalDependencies:
-      esbuild: 0.28.1
+      esbuild: 0.24.2
       rollup: 4.62.2
-      vite: 8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0)
-      webpack: 5.98.0(esbuild@0.28.1)
+      vite: 8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0)
+      webpack: 5.98.0(esbuild@0.24.2)
 
   '@storybook/global@5.0.0': {}
 
@@ -17445,11 +17452,11 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@storybook/react-vite@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.5)(react@19.2.7))(typescript@5.9.3)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.28.1))':
+  '@storybook/react-vite@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.24.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.5)(react@19.2.7))(typescript@5.9.3)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.24.2))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))
       '@rollup/pluginutils': 5.1.4(rollup@4.62.2)
-      '@storybook/builder-vite': 10.4.6(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.5)(react@19.2.7))(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.28.1))
+      '@storybook/builder-vite': 10.4.6(esbuild@0.24.2)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.5)(react@19.2.7))(vite@8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.24.2))
       '@storybook/react': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.5)(react@19.2.7))(typescript@5.9.3)
       empathic: 2.0.1
       magic-string: 0.30.21
@@ -17459,7 +17466,7 @@ snapshots:
       resolve: 1.22.12
       storybook: 10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.5)(react@19.2.7)
       tsconfig-paths: 4.2.0
-      vite: 8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -17485,17 +17492,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/tanstack-react@10.4.6(@tanstack/react-router@1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tanstack/router-core@1.171.13)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.5)(react@19.2.7))(typescript@5.9.3)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.28.1))':
+  '@storybook/tanstack-react@10.4.6(@tanstack/react-router@1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tanstack/router-core@1.171.13)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.24.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.5)(react@19.2.7))(typescript@5.9.3)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.24.2))':
     dependencies:
-      '@storybook/builder-vite': 10.4.6(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.5)(react@19.2.7))(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.28.1))
+      '@storybook/builder-vite': 10.4.6(esbuild@0.24.2)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.5)(react@19.2.7))(vite@8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.24.2))
       '@storybook/react': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.5)(react@19.2.7))(typescript@5.9.3)
-      '@storybook/react-vite': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.5)(react@19.2.7))(typescript@5.9.3)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.28.1))
+      '@storybook/react-vite': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.24.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.5)(react@19.2.7))(typescript@5.9.3)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(esbuild@0.24.2))
       '@tanstack/react-router': 1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/router-core': 1.171.13
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       storybook: 10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.5)(react@19.2.7)
-      vite: 8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -18340,7 +18347,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(jsdom@25.0.1)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))
+      vitest: 4.1.9(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(jsdom@25.0.1)(vite@8.1.2(@types/node@24.13.2)(esbuild@0.24.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.19.3)(yaml@2.7.0))
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -20601,6 +20608,8 @@ snapshots:
       is-document.all: 1.0.0
 
   functions-have-names@1.2.3: {}
+
+  fuse.js@7.4.2: {}
 
   generator-function@2.0.1: {}
 
@@ -25164,6 +25173,18 @@ snapshots:
 
   term-size@2.2.1: {}
 
+  terser-webpack-plugin@5.3.14(esbuild@0.24.2)(webpack@5.98.0(esbuild@0.24.2)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.0
+      serialize-javascript: 6.0.2
+      terser: 5.39.0
+      webpack: 5.98.0(esbuild@0.24.2)
+    optionalDependencies:
+      esbuild: 0.24.2
+    optional: true
+
   terser-webpack-plugin@5.3.14(esbuild@0.28.1)(webpack@5.98.0(esbuild@0.28.1)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -25978,6 +25999,37 @@ snapshots:
       - '@swc/core'
       - esbuild
       - uglify-js
+
+  webpack@5.98.0(esbuild@0.24.2):
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.9
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.14.1
+      browserslist: 4.25.3
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.18.1
+      es-module-lexer: 1.7.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.0
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 4.3.0
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.14(esbuild@0.24.2)(webpack@5.98.0(esbuild@0.24.2))
+      watchpack: 2.4.2
+      webpack-sources: 3.2.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+    optional: true
 
   webpack@5.98.0(esbuild@0.28.1):
     dependencies:


### PR DESCRIPTION
## Summary

Video list for the management dashboard with fuzzy search, edit dialog, and fMP4 repair trigger.

## What

- `VideoSection` — client-side Fuse.js search (threshold 0.4), video cards with duration + status badge
- `VideoEditDialog` — title + thumbnailUrl fields, repair fMP4 button
- Fuse.js dependency added to packages/ui (lazy-loaded in manage chunk only)

SWO-467