### PR TITLE
feat(watch): add PlaylistSection with create/edit dialog

### DIFF
--- a/packages/ui/src/watch/manage/playlist-edit-dialog.tsx
+++ b/packages/ui/src/watch/manage/playlist-edit-dialog.tsx
@@ -1,0 +1,79 @@
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import { useEffect, useState } from 'react';
+import type { ManagePlaylist } from './types';
+
+interface PlaylistFormValues {
+  title: string;
+  description: string;
+}
+
+interface PlaylistEditDialogProps {
+  open: boolean;
+  playlist: ManagePlaylist | null;
+  onClose: () => void;
+  onSubmit: (values: PlaylistFormValues) => void;
+}
+
+const PlaylistEditDialog = (props: PlaylistEditDialogProps) => {
+  const { open, playlist, onClose, onSubmit } = props;
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+
+  useEffect(() => {
+    if (open) {
+      setTitle(playlist?.title ?? '');
+      setDescription(playlist?.description ?? '');
+    }
+  }, [open, playlist]);
+
+  const handleSubmit = () => {
+    const trimmed = title.trim();
+    if (!trimmed) return;
+    onSubmit({ title: trimmed, description: description.trim() });
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="xs">
+      <DialogTitle>{playlist ? 'Edit playlist' : 'New playlist'}</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <TextField
+            autoFocus
+            label="Title"
+            fullWidth
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+          />
+          <TextField
+            label="Description"
+            fullWidth
+            multiline
+            minRows={2}
+            value={description}
+            onChange={(event) => setDescription(event.target.value)}
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          onClick={handleSubmit}
+          variant="contained"
+          disabled={!title.trim()}
+        >
+          {playlist ? 'Save' : 'Create'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export { PlaylistEditDialog };
+export type { PlaylistFormValues };

--- a/packages/ui/src/watch/manage/playlist-section.tsx
+++ b/packages/ui/src/watch/manage/playlist-section.tsx
@@ -1,0 +1,111 @@
+import Add from '@mui/icons-material/Add';
+import Edit from '@mui/icons-material/Edit';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import IconButton from '@mui/material/IconButton';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { useState } from 'react';
+import {
+  PlaylistEditDialog,
+  type PlaylistFormValues,
+} from './playlist-edit-dialog';
+import type { ManagePlaylist, PlaylistCreate, PlaylistEdit } from './types';
+
+interface PlaylistSectionProps {
+  isLoading: boolean;
+  playlists: ManagePlaylist[];
+  onCreatePlaylist: (input: PlaylistCreate) => void;
+  onUpdatePlaylist: (input: PlaylistEdit) => void;
+}
+
+const PlaylistSection = (props: PlaylistSectionProps) => {
+  const { isLoading, playlists, onCreatePlaylist, onUpdatePlaylist } = props;
+
+  const [formOpen, setFormOpen] = useState(false);
+  const [editing, setEditing] = useState<ManagePlaylist | null>(null);
+
+  const openCreate = () => {
+    setEditing(null);
+    setFormOpen(true);
+  };
+
+  const openEdit = (playlist: ManagePlaylist) => {
+    setEditing(playlist);
+    setFormOpen(true);
+  };
+
+  const handleSubmit = (values: PlaylistFormValues) => {
+    if (editing) {
+      onUpdatePlaylist({ id: editing.id, ...values });
+    } else {
+      onCreatePlaylist(values as PlaylistCreate);
+    }
+  };
+
+  return (
+    <Box component="section">
+      <Stack
+        direction="row"
+        sx={{ alignItems: 'center', justifyContent: 'space-between', mb: 2 }}
+      >
+        <Typography variant="h6" component="h2">
+          Playlists ({playlists.length})
+        </Typography>
+        <Button variant="contained" startIcon={<Add />} onClick={openCreate}>
+          New playlist
+        </Button>
+      </Stack>
+
+      {isLoading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+          <CircularProgress />
+        </Box>
+      ) : playlists.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          You have no playlists yet.
+        </Typography>
+      ) : (
+        <Stack spacing={2}>
+          {playlists.map((playlist) => (
+            <Paper key={playlist.id} variant="outlined" sx={{ p: 2 }}>
+              <Stack
+                direction={{ xs: 'column', sm: 'row' }}
+                spacing={2}
+                sx={{ alignItems: { sm: 'center' } }}
+              >
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Typography variant="subtitle1">{playlist.title}</Typography>
+                  {playlist.description ? (
+                    <Typography variant="body2" color="text.secondary" noWrap>
+                      {playlist.description}
+                    </Typography>
+                  ) : null}
+                </Box>
+                <Stack direction="row" spacing={1}>
+                  <IconButton
+                    aria-label={`Edit ${playlist.title}`}
+                    onClick={() => openEdit(playlist)}
+                  >
+                    <Edit />
+                  </IconButton>
+                </Stack>
+              </Stack>
+            </Paper>
+          ))}
+        </Stack>
+      )}
+
+      <PlaylistEditDialog
+        open={formOpen}
+        playlist={editing}
+        onClose={() => setFormOpen(false)}
+        onSubmit={handleSubmit}
+      />
+    </Box>
+  );
+};
+
+export { PlaylistSection };

--- a/packages/ui/src/watch/manage/types.ts
+++ b/packages/ui/src/watch/manage/types.ts
@@ -36,4 +36,10 @@ interface PlaylistEdit {
   description?: string;
 }
 
-export type { ManageVideo, VideoEdit, ManagePlaylist, PlaylistCreate, PlaylistEdit };
+export type {
+  ManageVideo,
+  VideoEdit,
+  ManagePlaylist,
+  PlaylistCreate,
+  PlaylistEdit,
+};

--- a/packages/ui/src/watch/manage/types.ts
+++ b/packages/ui/src/watch/manage/types.ts
@@ -1,0 +1,22 @@
+interface ManagePlaylist {
+  id: string;
+  title: string;
+  slug: string;
+  description?: string | null;
+  thumbnailUrl?: string | null;
+}
+
+interface PlaylistCreate {
+  title: string;
+  slug: string;
+  thumbnailUrl?: string;
+  description?: string;
+}
+
+interface PlaylistEdit {
+  id: string;
+  title?: string;
+  description?: string;
+}
+
+export type { ManagePlaylist, PlaylistCreate, PlaylistEdit };

--- a/packages/ui/src/watch/manage/types.ts
+++ b/packages/ui/src/watch/manage/types.ts
@@ -1,3 +1,20 @@
+interface ManageVideo {
+  id: string;
+  title: string;
+  thumbnailUrl: string | null;
+  duration: number | null;
+  source: string | null;
+  status: string;
+  slug: string;
+  createdAt: string;
+}
+
+interface VideoEdit {
+  id: string;
+  title?: string;
+  thumbnailUrl?: string;
+}
+
 interface ManagePlaylist {
   id: string;
   title: string;
@@ -19,4 +36,4 @@ interface PlaylistEdit {
   description?: string;
 }
 
-export type { ManagePlaylist, PlaylistCreate, PlaylistEdit };
+export type { ManageVideo, VideoEdit, ManagePlaylist, PlaylistCreate, PlaylistEdit };


### PR DESCRIPTION
## Summary

Playlist management section for the watch dashboard with dual-mode create/edit dialog. No delete.

## What

- `PlaylistSection` — playlist list with edit button, new playlist button
- `PlaylistEditDialog` — dual-mode: create when no playlist selected, edit when selected
- Follows listen PlaylistSection pattern

SWO-468