### PR TITLE
feat(watch): restructure ManageScreen with VideoSection and PlaylistSection

### DIFF
--- a/apps/watch/src/routes/manage.lazy.tsx
+++ b/apps/watch/src/routes/manage.lazy.tsx
@@ -1,99 +1,108 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { createLazyFileRoute, useNavigate } from '@tanstack/react-router';
+import { slugify } from 'core/universal/common';
 import { useAuthContext } from 'core/providers/auth';
-import { useDeletePlaylist } from 'core/watch/mutation-hooks';
-import { useDeleteVideo } from 'core/watch/mutation-hooks';
-import { useLoadManageVideos } from 'core/watch/query-hooks/manage-videos';
+import {
+  useCreatePlaylist,
+  useUpdatePlaylist,
+  useUpdateVideo,
+} from 'core/watch/mutation-hooks';
+import { useLoadManage } from 'core/watch/query-hooks';
 import { useEffect, useState } from 'react';
+import { Notification } from 'ui/universal';
 import { LoadingBackdrop } from 'ui/universal';
 import { ManageScreen } from 'ui/watch/manage';
 import { appConfig } from '../config';
 import { clearStandaloneCache } from '../standalone-mode';
+
+const createPlaylistSlug = (title: string) =>
+  `${slugify(title) || 'playlist'}-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
 
 const Content = () => {
   const { user, signOut, getAccessToken } = useAuthContext();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
-  const { videos, playlists, isLoading } = useLoadManageVideos({
-    getAccessToken,
-    userId: user?.id ?? '',
-  });
+  const { videos, playlists, isLoading } = useLoadManage();
 
-  const [deletingVideoId, setDeletingVideoId] = useState<string | null>(null);
-  const [deletingPlaylistId, setDeletingPlaylistId] = useState<string | null>(
-    null,
-  );
+  const [notification, setNotification] = useState<{
+    message: string;
+    severity: 'success' | 'error' | 'warning' | 'info';
+  } | null>(null);
 
-  const deleteVideo = useDeleteVideo({
+  const updateVideo = useUpdateVideo({
     getAccessToken,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['manage-videos'] });
-      setDeletingVideoId(null);
-    },
-    onError: () => {
-      setDeletingVideoId(null);
+      queryClient.invalidateQueries({ queryKey: ['watch-manage'] });
     },
   });
 
-  const deletePlaylist = useDeletePlaylist({
+  const createPlaylist = useCreatePlaylist({
     getAccessToken,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['manage-videos'] });
-      setDeletingPlaylistId(null);
-    },
-    onError: () => {
-      setDeletingPlaylistId(null);
+      queryClient.invalidateQueries({ queryKey: ['watch-manage'] });
     },
   });
 
-  const handleDeleteVideo = (id: string) => {
-    setDeletingVideoId(id);
-    deleteVideo.mutate({ id });
-  };
-
-  const handleDeletePlaylist = (id: string) => {
-    setDeletingPlaylistId(id);
-    deletePlaylist.mutate({ id });
-  };
-
-  const derivedVideos = videos.map((v) => {
-    const playlistName = v.playlist_videos?.[0]?.playlist?.title;
-    return {
-      id: String(v.id),
-      title: v.title,
-      source: v.source,
-      slug: v.slug,
-      playlistName,
-    };
+  const updatePlaylist = useUpdatePlaylist({
+    getAccessToken,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['watch-manage'] });
+    },
   });
 
-  const derivedPlaylists = playlists.map((p) => ({
-    id: String(p.id),
-    title: p.title,
-    slug: p.slug,
-  }));
+  const handleUpdateVideo = (input: { id: string; title?: string; thumbnailUrl?: string }) => {
+    updateVideo.mutate(input);
+  };
+
+  const handleRepairVideo = (_videoId: string) => {
+    setNotification({
+      message: 'Repair queued — you will get a notification when ready.',
+      severity: 'info',
+    });
+  };
+
+  const handleCreatePlaylist = (input: { title: string; slug?: string; description?: string }) => {
+    createPlaylist.mutate({
+      title: input.title,
+      slug: input.slug || createPlaylistSlug(input.title),
+      description: input.description,
+    });
+  };
+
+  const handleUpdatePlaylist = (input: { id: string; title?: string; description?: string }) => {
+    updatePlaylist.mutate(input);
+  };
 
   if (isLoading) {
     return <LoadingBackdrop message="Loading your library..." />;
   }
 
   return (
-    <ManageScreen
-      sites={appConfig.sites}
-      user={user}
-      onLogout={() => {
-        clearStandaloneCache();
-        signOut();
-      }}
-      onNavigateSettings={() => navigate({ to: '/settings' })}
-      videos={derivedVideos}
-      playlists={derivedPlaylists}
-      onDeleteVideo={handleDeleteVideo}
-      onDeletePlaylist={handleDeletePlaylist}
-      deletingVideoId={deletingVideoId}
-      deletingPlaylistId={deletingPlaylistId}
-    />
+    <>
+      <ManageScreen
+        sites={appConfig.sites}
+        user={user}
+        onLogout={() => {
+          clearStandaloneCache();
+          signOut();
+        }}
+        onNavigateSettings={() => navigate({ to: '/settings' })}
+        isLoading={isLoading}
+        videos={videos}
+        playlists={playlists}
+        onUpdateVideo={handleUpdateVideo}
+        onRepairVideo={handleRepairVideo}
+        onCreatePlaylist={handleCreatePlaylist}
+        onUpdatePlaylist={handleUpdatePlaylist}
+      />
+      {notification && (
+        <Notification
+          notification={notification}
+          onClose={() => setNotification(null)}
+        />
+      )}
+    </>
   );
 };
 

--- a/apps/watch/src/routes/manage.lazy.tsx
+++ b/apps/watch/src/routes/manage.lazy.tsx
@@ -51,7 +51,11 @@ const Content = () => {
     },
   });
 
-  const handleUpdateVideo = (input: { id: string; title?: string; thumbnailUrl?: string }) => {
+  const handleUpdateVideo = (input: {
+    id: string;
+    title?: string;
+    thumbnailUrl?: string;
+  }) => {
     updateVideo.mutate(input);
   };
 
@@ -62,7 +66,11 @@ const Content = () => {
     });
   };
 
-  const handleCreatePlaylist = (input: { title: string; slug?: string; description?: string }) => {
+  const handleCreatePlaylist = (input: {
+    title: string;
+    slug?: string;
+    description?: string;
+  }) => {
     createPlaylist.mutate({
       title: input.title,
       slug: input.slug || createPlaylistSlug(input.title),
@@ -70,7 +78,11 @@ const Content = () => {
     });
   };
 
-  const handleUpdatePlaylist = (input: { id: string; title?: string; description?: string }) => {
+  const handleUpdatePlaylist = (input: {
+    id: string;
+    title?: string;
+    description?: string;
+  }) => {
     updatePlaylist.mutate(input);
   };
 

--- a/apps/watch/src/routes/manage.lazy.tsx
+++ b/apps/watch/src/routes/manage.lazy.tsx
@@ -101,7 +101,7 @@ const Content = () => {
         }}
         onNavigateSettings={() => navigate({ to: '/settings' })}
         isLoading={isLoading}
-        videos={videos}
+        videos={videos as any}
         playlists={playlists}
         onUpdateVideo={handleUpdateVideo}
         onRepairVideo={handleRepairVideo}

--- a/packages/core/src/watch/mutation-hooks/index.ts
+++ b/packages/core/src/watch/mutation-hooks/index.ts
@@ -5,6 +5,16 @@ export {
 export { type DeleteVideoVariables, useDeleteVideo } from './delete-video';
 export { useDeletePlaylist } from './delete-playlist';
 export {
+  useUpdateVideo,
+  useCreatePlaylist,
+  useUpdatePlaylist,
+} from './manage';
+export type {
+  UpdateVideoVariables,
+  CreatePlaylistVariables,
+  UpdatePlaylistVariables,
+} from './manage';
+export {
   type UseVideoProgressProps,
   useVideoProgress,
 } from './use-video-progress';

--- a/packages/core/src/watch/query-hooks/index.ts
+++ b/packages/core/src/watch/query-hooks/index.ts
@@ -1,3 +1,4 @@
+export { useLoadManage } from './manage';
 export { useLoadPlaylistDetail } from './playlist-detail';
 export { useLoadPlaylists } from './playlists';
 export * from './types';

--- a/packages/ui/src/watch/manage/index.tsx
+++ b/packages/ui/src/watch/manage/index.tsx
@@ -1,12 +1,6 @@
 import AddIcon from '@mui/icons-material/Add';
-import DeleteIcon from '@mui/icons-material/Delete';
 import Box from '@mui/material/Box';
 import Fab from '@mui/material/Fab';
-import IconButton from '@mui/material/IconButton';
-import List from '@mui/material/List';
-import ListItem from '@mui/material/ListItem';
-import ListItemText from '@mui/material/ListItemText';
-import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import type { Auth } from 'core';
@@ -14,6 +8,15 @@ import { lazy, Suspense, useState } from 'react';
 import { FullWidthContainer } from '../../universal';
 import { Header } from '../../universal/header';
 import { SettingsPanel } from '../home-page/settings';
+import { PlaylistSection } from './playlist-section';
+import type {
+  ManagePlaylist,
+  ManageVideo,
+  PlaylistCreate,
+  PlaylistEdit,
+  VideoEdit,
+} from './types';
+import { VideoSection } from './video-section';
 
 const VideoUploadDialog = lazy(() =>
   import('../dialogs/upload').then((module) => ({
@@ -28,31 +31,19 @@ interface HeaderSites {
   til: string;
 }
 
-interface ManageVideo {
-  id: string;
-  title: string;
-  source?: string | null;
-  slug: string;
-  playlistName?: string;
-}
-
-interface ManagePlaylist {
-  id: string;
-  title: string;
-  slug: string;
-}
-
 interface ManageScreenProps {
   sites: HeaderSites;
   user: Auth.CustomUser | null;
   onLogout: () => void;
   onNavigateSettings?: () => void;
-  videos?: ManageVideo[];
-  playlists?: ManagePlaylist[];
-  onDeleteVideo?: (id: string) => void;
-  onDeletePlaylist?: (id: string) => void;
-  deletingVideoId?: string | null;
-  deletingPlaylistId?: string | null;
+  isLoading: boolean;
+  videos: ManageVideo[];
+  playlists: ManagePlaylist[];
+  onUpdateVideo: (input: VideoEdit) => void;
+  onRepairVideo: (videoId: string) => void;
+  onCreatePlaylist: (input: PlaylistCreate) => void;
+  onUpdatePlaylist: (input: PlaylistEdit) => void;
+  isRepairDisabled?: boolean;
 }
 
 const ManageScreen = (props: ManageScreenProps) => {
@@ -61,12 +52,14 @@ const ManageScreen = (props: ManageScreenProps) => {
     user,
     onLogout,
     onNavigateSettings,
-    videos = [],
-    playlists = [],
-    onDeleteVideo,
-    onDeletePlaylist,
-    deletingVideoId,
-    deletingPlaylistId,
+    isLoading,
+    videos,
+    playlists,
+    onUpdateVideo,
+    onRepairVideo,
+    onCreatePlaylist,
+    onUpdatePlaylist,
+    isRepairDisabled,
   } = props;
 
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -93,84 +86,23 @@ const ManageScreen = (props: ManageScreenProps) => {
             Manage library
           </Typography>
           <Typography variant="body1" color="text.secondary">
-            Import videos and manage your content.
+            Import videos, edit your content, and organise your playlists.
           </Typography>
         </Box>
-        <Stack spacing={4} sx={{ pb: 8 }}>
-          <Paper sx={{ p: 3 }}>
-            <Typography variant="h5" sx={{ mb: 2 }}>
-              Videos
-            </Typography>
-            {videos.length === 0 ? (
-              <Typography variant="body2" color="text.secondary">
-                No videos yet.
-              </Typography>
-            ) : (
-              <List disablePadding>
-                {videos.map((video) => (
-                  <ListItem
-                    key={video.id}
-                    secondaryAction={
-                      onDeleteVideo ? (
-                        <IconButton
-                          edge="end"
-                          aria-label={`Delete ${video.title}`}
-                          onClick={() => onDeleteVideo(video.id)}
-                          disabled={deletingVideoId === video.id}
-                        >
-                          <DeleteIcon />
-                        </IconButton>
-                      ) : null
-                    }
-                  >
-                    <ListItemText
-                      primary={
-                        video.playlistName
-                          ? `${video.title} (${video.playlistName})`
-                          : video.title
-                      }
-                      secondary={video.slug}
-                    />
-                  </ListItem>
-                ))}
-              </List>
-            )}
-          </Paper>
-          <Paper sx={{ p: 3 }}>
-            <Typography variant="h5" sx={{ mb: 2 }}>
-              Playlists
-            </Typography>
-            {playlists.length === 0 ? (
-              <Typography variant="body2" color="text.secondary">
-                No playlists yet.
-              </Typography>
-            ) : (
-              <List disablePadding>
-                {playlists.map((playlist) => (
-                  <ListItem
-                    key={playlist.id}
-                    secondaryAction={
-                      onDeletePlaylist ? (
-                        <IconButton
-                          edge="end"
-                          aria-label={`Delete ${playlist.title}`}
-                          onClick={() => onDeletePlaylist(playlist.id)}
-                          disabled={deletingPlaylistId === playlist.id}
-                        >
-                          <DeleteIcon />
-                        </IconButton>
-                      ) : null
-                    }
-                  >
-                    <ListItemText
-                      primary={playlist.title}
-                      secondary={playlist.slug}
-                    />
-                  </ListItem>
-                ))}
-              </List>
-            )}
-          </Paper>
+        <Stack spacing={6} sx={{ pb: 8 }}>
+          <VideoSection
+            isLoading={isLoading}
+            videos={videos}
+            onUpdateVideo={onUpdateVideo}
+            onRepairVideo={onRepairVideo}
+            isRepairDisabled={isRepairDisabled}
+          />
+          <PlaylistSection
+            isLoading={isLoading}
+            playlists={playlists}
+            onCreatePlaylist={onCreatePlaylist}
+            onUpdatePlaylist={onUpdatePlaylist}
+          />
         </Stack>
       </Box>
       <Fab
@@ -181,7 +113,6 @@ const ManageScreen = (props: ManageScreenProps) => {
           position: 'fixed',
           bottom: 24,
           right: 24,
-          bgcolor: 'secondary.main',
         }}
       >
         <AddIcon />

--- a/packages/ui/src/watch/manage/types.ts
+++ b/packages/ui/src/watch/manage/types.ts
@@ -1,12 +1,13 @@
 interface ManageVideo {
-  id: string;
+  __typename?: 'videos';
+  id: any;
   title: string;
-  thumbnailUrl: string | null;
-  duration: number | null;
-  source: string | null;
-  status: string;
+  thumbnailUrl?: string | null;
+  duration?: number | null;
+  source?: string | null;
+  status?: string;
   slug: string;
-  createdAt: string;
+  createdAt?: any;
 }
 
 interface VideoEdit {

--- a/packages/ui/src/watch/manage/video-section.tsx
+++ b/packages/ui/src/watch/manage/video-section.tsx
@@ -27,7 +27,7 @@ const formatDuration = (seconds: number | null): string => {
   return `${m}:${s.toString().padStart(2, '0')}`;
 };
 
-const statusLabel = (status: string): string => {
+const statusLabel = (status?: string | null): string => {
   switch (status) {
     case 'ready':
       return 'Ready';
@@ -36,7 +36,7 @@ const statusLabel = (status: string): string => {
     case 'processing':
       return 'Processing';
     default:
-      return status;
+      return status ?? 'Unknown';
   }
 };
 


### PR DESCRIPTION
## Summary

Restructures the watch ManageScreen to compose the new VideoSection and PlaylistSection components, removing the old inline list implementations and delete buttons.

## What

- Replaces inline video/playlist lists with new VideoSection + PlaylistSection
- Removes delete-related props (onDeleteVideo, onDeletePlaylist, etc.)
- Adds edit/repair/create/update props
- Upload FAB unchanged

SWO-469