### PR TITLE
feat(watch): 3-dot menu with repair confirmation dialog

### DIFF
--- a/packages/ui/src/watch/manage/confirm-dialog.tsx
+++ b/packages/ui/src/watch/manage/confirm-dialog.tsx
@@ -1,0 +1,48 @@
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+const ConfirmDialog = (props: ConfirmDialogProps) => {
+  const {
+    open,
+    title,
+    message,
+    confirmLabel = 'Confirm',
+    onClose,
+    onConfirm,
+  } = props;
+
+  const handleConfirm = () => {
+    onConfirm();
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs">
+      <DialogTitle>{title}</DialogTitle>
+      <DialogContent>
+        <DialogContentText>{message}</DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button onClick={handleConfirm} color="warning" variant="contained">
+          {confirmLabel}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export { ConfirmDialog };

--- a/packages/ui/src/watch/manage/video-edit-dialog.tsx
+++ b/packages/ui/src/watch/manage/video-edit-dialog.tsx
@@ -13,12 +13,10 @@ interface VideoEditDialogProps {
   video: ManageVideo | null;
   onClose: () => void;
   onSave: (input: VideoEdit) => void;
-  onRepair: (videoId: string) => void;
-  isRepairDisabled?: boolean;
 }
 
 const VideoEditDialog = (props: VideoEditDialogProps) => {
-  const { open, video, onClose, onSave, onRepair, isRepairDisabled } = props;
+  const { open, video, onClose, onSave } = props;
   const [title, setTitle] = useState('');
   const [thumbnailUrl, setThumbnailUrl] = useState('');
 
@@ -41,11 +39,6 @@ const VideoEditDialog = (props: VideoEditDialogProps) => {
     onClose();
   };
 
-  const handleRepair = () => {
-    if (!video) return;
-    onRepair(video.id);
-  };
-
   return (
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="xs">
       <DialogTitle>Edit video</DialogTitle>
@@ -64,15 +57,6 @@ const VideoEditDialog = (props: VideoEditDialogProps) => {
             value={thumbnailUrl}
             onChange={(event) => setThumbnailUrl(event.target.value)}
           />
-          <Button
-            variant="outlined"
-            color="warning"
-            fullWidth
-            disabled={isRepairDisabled}
-            onClick={handleRepair}
-          >
-            Fix video (repair fMP4)
-          </Button>
         </Stack>
       </DialogContent>
       <DialogActions>

--- a/packages/ui/src/watch/manage/video-section.tsx
+++ b/packages/ui/src/watch/manage/video-section.tsx
@@ -10,6 +10,7 @@ import MenuItem from '@mui/material/MenuItem';
 import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
+import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import Fuse from 'fuse.js';
 import { useMemo, useState } from 'react';
@@ -152,12 +153,14 @@ const VideoSection = (props: VideoSectionProps) => {
                     </Typography>
                   </Stack>
                 </Box>
-                <IconButton
-                  aria-label={`Actions for ${video.title}`}
-                  onClick={(event) => handleMenuOpen(event, video)}
-                >
-                  <MoreVert />
-                </IconButton>
+                <Tooltip title="Actions">
+                  <IconButton
+                    aria-label={`Actions for ${video.title}`}
+                    onClick={(event) => handleMenuOpen(event, video)}
+                  >
+                    <MoreVert />
+                  </IconButton>
+                </Tooltip>
               </Stack>
             </Paper>
           ))}

--- a/packages/ui/src/watch/manage/video-section.tsx
+++ b/packages/ui/src/watch/manage/video-section.tsx
@@ -175,10 +175,7 @@ const VideoSection = (props: VideoSectionProps) => {
           </ListItemIcon>
           Edit
         </MenuItem>
-        <MenuItem
-          onClick={handleRepair}
-          disabled={isRepairDisabled}
-        >
+        <MenuItem onClick={handleRepair} disabled={isRepairDisabled}>
           <ListItemIcon>
             <Build fontSize="small" />
           </ListItemIcon>

--- a/packages/ui/src/watch/manage/video-section.tsx
+++ b/packages/ui/src/watch/manage/video-section.tsx
@@ -1,14 +1,19 @@
 import Build from '@mui/icons-material/Build';
 import Edit from '@mui/icons-material/Edit';
+import MoreVert from '@mui/icons-material/MoreVert';
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
 import IconButton from '@mui/material/IconButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
 import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import Fuse from 'fuse.js';
 import { useMemo, useState } from 'react';
+import { ConfirmDialog } from './confirm-dialog';
 import type { ManageVideo, VideoEdit } from './types';
 import { VideoEditDialog } from './video-edit-dialog';
 
@@ -46,6 +51,9 @@ const VideoSection = (props: VideoSectionProps) => {
 
   const [search, setSearch] = useState('');
   const [editing, setEditing] = useState<ManageVideo | null>(null);
+  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
+  const [menuVideo, setMenuVideo] = useState<ManageVideo | null>(null);
+  const [repairTarget, setRepairTarget] = useState<string | null>(null);
 
   const fuse = useMemo(
     () =>
@@ -59,6 +67,36 @@ const VideoSection = (props: VideoSectionProps) => {
   const filtered = search.trim()
     ? fuse.search(search.trim()).map((r) => r.item)
     : videos;
+
+  const handleMenuOpen = (
+    event: React.MouseEvent<HTMLElement>,
+    video: ManageVideo,
+  ) => {
+    setMenuAnchor(event.currentTarget);
+    setMenuVideo(video);
+  };
+
+  const handleMenuClose = () => {
+    setMenuAnchor(null);
+    setMenuVideo(null);
+  };
+
+  const handleEdit = () => {
+    if (menuVideo) setEditing(menuVideo);
+    handleMenuClose();
+  };
+
+  const handleRepair = () => {
+    if (menuVideo) setRepairTarget(menuVideo.id);
+    handleMenuClose();
+  };
+
+  const handleConfirmRepair = () => {
+    if (repairTarget) {
+      onRepairVideo(repairTarget);
+      setRepairTarget(null);
+    }
+  };
 
   return (
     <Box component="section">
@@ -114,34 +152,54 @@ const VideoSection = (props: VideoSectionProps) => {
                     </Typography>
                   </Stack>
                 </Box>
-                <Stack direction="row" spacing={1}>
-                  <IconButton
-                    aria-label={`Edit ${video.title}`}
-                    onClick={() => setEditing(video)}
-                  >
-                    <Edit />
-                  </IconButton>
-                  <IconButton
-                    aria-label={`Repair ${video.title}`}
-                    onClick={() => onRepairVideo(video.id)}
-                    disabled={isRepairDisabled}
-                  >
-                    <Build />
-                  </IconButton>
-                </Stack>
+                <IconButton
+                  aria-label={`Actions for ${video.title}`}
+                  onClick={(event) => handleMenuOpen(event, video)}
+                >
+                  <MoreVert />
+                </IconButton>
               </Stack>
             </Paper>
           ))}
         </Stack>
       )}
 
+      <Menu
+        anchorEl={menuAnchor}
+        open={Boolean(menuAnchor)}
+        onClose={handleMenuClose}
+      >
+        <MenuItem onClick={handleEdit}>
+          <ListItemIcon>
+            <Edit fontSize="small" />
+          </ListItemIcon>
+          Edit
+        </MenuItem>
+        <MenuItem
+          onClick={handleRepair}
+          disabled={isRepairDisabled}
+        >
+          <ListItemIcon>
+            <Build fontSize="small" />
+          </ListItemIcon>
+          Repair fMP4
+        </MenuItem>
+      </Menu>
+
       <VideoEditDialog
         open={Boolean(editing)}
         video={editing}
         onClose={() => setEditing(null)}
         onSave={onUpdateVideo}
-        onRepair={onRepairVideo}
-        isRepairDisabled={isRepairDisabled}
+      />
+
+      <ConfirmDialog
+        open={Boolean(repairTarget)}
+        title="Repair video"
+        message="This will remux the video from TS to fMP4 format to fix playback issues. The repair runs in the background — you will get a notification when ready."
+        confirmLabel="Start repair"
+        onClose={() => setRepairTarget(null)}
+        onConfirm={handleConfirmRepair}
       />
     </Box>
   );


### PR DESCRIPTION
## Summary

Replaces the two separate action buttons with a single 3-dot (MoreVert) menu per video card. Repair action requires confirmation.

## What

- VideoSection: 3-dot menu with Edit + Repair fMP4 items
- ConfirmDialog: new component for confirmation (reusable)
- VideoEditDialog: simplified — removed redundant repair button
- Repair confirmation: "Start repair" button with explanation before dispatching

SWO-474