### PR TITLE
feat(watch): disable thumbnail URL input

### DIFF
--- a/packages/ui/src/watch/manage/video-edit-dialog.tsx
+++ b/packages/ui/src/watch/manage/video-edit-dialog.tsx
@@ -56,6 +56,8 @@ const VideoEditDialog = (props: VideoEditDialogProps) => {
             fullWidth
             value={thumbnailUrl}
             onChange={(event) => setThumbnailUrl(event.target.value)}
+            disabled
+            helperText="Thumbnail upload coming soon."
           />
         </Stack>
       </DialogContent>


### PR DESCRIPTION
## Summary

Disables the thumbnail URL field until backend re-host is implemented.

SWO-476