### PR TITLE
fix(watch): constrain 3-dot menu button width on mobile

### DIFF
--- a/packages/ui/src/watch/manage/video-section.tsx
+++ b/packages/ui/src/watch/manage/video-section.tsx
@@ -153,14 +153,16 @@ const VideoSection = (props: VideoSectionProps) => {
                     </Typography>
                   </Stack>
                 </Box>
-                <Tooltip title="Actions">
-                  <IconButton
-                    aria-label={`Actions for ${video.title}`}
-                    onClick={(event) => handleMenuOpen(event, video)}
-                  >
-                    <MoreVert />
-                  </IconButton>
-                </Tooltip>
+                <Box sx={{ alignSelf: { xs: 'flex-end', sm: 'center' } }}>
+                  <Tooltip title="Actions">
+                    <IconButton
+                      aria-label={`Actions for ${video.title}`}
+                      onClick={(event) => handleMenuOpen(event, video)}
+                    >
+                      <MoreVert />
+                    </IconButton>
+                  </Tooltip>
+                </Box>
               </Stack>
             </Paper>
           ))}


### PR DESCRIPTION
Wraps the MoreVert button in a Box with alignSelf: flex-end on xs to prevent fullwidth stretch in column Stack.

SWO-479