### PR TITLE
feat(watch): implement useRepairFmp4 mutation hook and wire to repair button

### DIFF
--- a/apps/watch/src/routes/manage.lazy.tsx
+++ b/apps/watch/src/routes/manage.lazy.tsx
@@ -3,6 +3,7 @@ import { slugify } from 'core/universal/common';
 import { useAuthContext } from 'core/providers/auth';
 import {
   useCreatePlaylist,
+  useRepairFmp4,
   useReorderPlaylistVideos,
   useUpdatePlaylist,
   useUpdateVideo,
@@ -45,6 +46,10 @@ const Content = () => {
     getAccessToken,
   });
 
+  const repairFmp4 = useRepairFmp4({
+    getAccessToken,
+  });
+
   const handleUpdateVideo = (input: {
     id: string;
     title?: string;
@@ -53,11 +58,29 @@ const Content = () => {
     updateVideo.mutate(input);
   };
 
-  const handleRepairVideo = (_videoId: string) => {
-    setNotification({
-      message: 'Repair queued — you will get a notification when ready.',
-      severity: 'info',
-    });
+  const handleRepairVideo = (videoId: string) => {
+    repairFmp4.mutate(
+      { input: { videoId } },
+      {
+        onSuccess: (data: any) => {
+          setNotification({
+            message:
+              data?.repairFmp4?.message ||
+              'Repair queued — you will get a notification when ready.',
+            severity: 'success',
+          });
+        },
+        onError: (error: unknown) => {
+          setNotification({
+            message:
+              error instanceof Error
+                ? error.message
+                : 'Repair failed. Please try again.',
+            severity: 'error',
+          });
+        },
+      },
+    );
   };
 
   const handleCreatePlaylist = (input: {

--- a/packages/core/schema.graphql
+++ b/packages/core/schema.graphql
@@ -98,6 +98,20 @@ input Int_comparison_exp {
   _nin: [Int!]
 }
 
+input RepairFmp4Input {
+  videoId: String!
+}
+
+type RepairFmp4Output {
+  success: Boolean!
+}
+
+type RepairFmp4Response {
+  dataObject: RepairFmp4Output
+  message: String!
+  success: Boolean!
+}
+
 input SetVideoThumbnailAtTimeInput {
   atSeconds: Float!
   videoId: String!
@@ -4201,6 +4215,10 @@ type mutation_root {
     on_conflict: videos_on_conflict
   ): videos
   """
+  Remux a stored TS video into fMP4/CMAF to fix the hls.js MPEG-TS AAC-demux noise bug. Ownership enforced server-side.
+  """
+  repairFmp4(input: RepairFmp4Input!): RepairFmp4Response!
+  """
   Capture the frame at a given timestamp and persist it as the video's thumbnail; ownership enforced server-side against the session user.
   """
   setVideoThumbnailAtTime(input: SetVideoThumbnailAtTimeInput!): SetVideoThumbnailAtTimeResponse!
@@ -6843,7 +6861,7 @@ type posts {
   brief: String!
   created_at: timestamptz!
   """Hashnode public id"""
-  hId: String
+  hId: String!
   id: uuid!
   markdownContent: String!
   pinned: Boolean!
@@ -8727,8 +8745,8 @@ type shared_video_recipients {
   recipientId: uuid
   updatedAt: timestamptz!
   """An object relationship"""
-  video: videos
-  videoId: uuid
+  video: videos!
+  videoId: uuid!
   viewed: Boolean!
 }
 
@@ -11323,7 +11341,7 @@ input timestamptz_comparison_exp {
 }
 
 """
-Per-user, per-app UI preferences. The `data` blob is site-scoped ({ watch: { standaloneMode }, ... }); its structure and defaults live in the frontend core package, not the DB.
+columns and relationships of "user_settings"
 """
 type user_settings {
   data(

--- a/packages/core/src/graphql/gql.ts
+++ b/packages/core/src/graphql/gql.ts
@@ -64,6 +64,7 @@ type Documents = {
     "\n  mutation CreatePlaylistManage(\n    $title: String!\n    $slug: String!\n    $thumbnailUrl: String\n    $description: String\n  ) {\n    insert_playlist_one(\n      object: {\n        title: $title\n        slug: $slug\n        thumbnailUrl: $thumbnailUrl\n        description: $description\n        site: \"watch\"\n      }\n    ) {\n      id\n    }\n  }\n": typeof types.CreatePlaylistManageDocument,
     "\n  mutation UpdatePlaylistManage($id: uuid!, $title: String, $description: String) {\n    update_playlist_by_pk(\n      pk_columns: { id: $id }\n      _set: { title: $title, description: $description }\n    ) {\n      id\n    }\n  }\n": typeof types.UpdatePlaylistManageDocument,
     "\n  mutation ReorderPlaylistVideos($updates: [playlist_videos_updates!]!) {\n    update_playlist_videos_many(updates: $updates) {\n      returning {\n        position\n      }\n    }\n  }\n": typeof types.ReorderPlaylistVideosDocument,
+    "\n  mutation RepairFmp4($input: RepairFmp4Input!) {\n    repairFmp4(input: $input) {\n      success\n      message\n    }\n  }\n": typeof types.RepairFmp4Document,
     "\n  mutation SaveSubtitle($id: uuid!, $object: subtitles_set_input!) {\n    update_subtitles_by_pk(pk_columns: { id: $id }, _set: $object) {\n      id\n    }\n  }\n": typeof types.SaveSubtitleDocument,
     "\n  mutation SetVideoThumbnailAtTime($input: SetVideoThumbnailAtTimeInput!) {\n    setVideoThumbnailAtTime(input: $input) {\n      success\n      message\n      dataObject {\n        thumbnailUrl\n      }\n    }\n  }\n": typeof types.SetVideoThumbnailAtTimeDocument,
     "\n  mutation sharePlaylist($id: uuid!, $emails: jsonb) {\n    update_playlist_by_pk(pk_columns: { id: $id }, _set: { sharedRecipientsInput: $emails }) {\n      id\n    }\n  }\n": typeof types.SharePlaylistDocument,
@@ -131,6 +132,7 @@ const documents: Documents = {
     "\n  mutation CreatePlaylistManage(\n    $title: String!\n    $slug: String!\n    $thumbnailUrl: String\n    $description: String\n  ) {\n    insert_playlist_one(\n      object: {\n        title: $title\n        slug: $slug\n        thumbnailUrl: $thumbnailUrl\n        description: $description\n        site: \"watch\"\n      }\n    ) {\n      id\n    }\n  }\n": types.CreatePlaylistManageDocument,
     "\n  mutation UpdatePlaylistManage($id: uuid!, $title: String, $description: String) {\n    update_playlist_by_pk(\n      pk_columns: { id: $id }\n      _set: { title: $title, description: $description }\n    ) {\n      id\n    }\n  }\n": types.UpdatePlaylistManageDocument,
     "\n  mutation ReorderPlaylistVideos($updates: [playlist_videos_updates!]!) {\n    update_playlist_videos_many(updates: $updates) {\n      returning {\n        position\n      }\n    }\n  }\n": types.ReorderPlaylistVideosDocument,
+    "\n  mutation RepairFmp4($input: RepairFmp4Input!) {\n    repairFmp4(input: $input) {\n      success\n      message\n    }\n  }\n": types.RepairFmp4Document,
     "\n  mutation SaveSubtitle($id: uuid!, $object: subtitles_set_input!) {\n    update_subtitles_by_pk(pk_columns: { id: $id }, _set: $object) {\n      id\n    }\n  }\n": types.SaveSubtitleDocument,
     "\n  mutation SetVideoThumbnailAtTime($input: SetVideoThumbnailAtTimeInput!) {\n    setVideoThumbnailAtTime(input: $input) {\n      success\n      message\n      dataObject {\n        thumbnailUrl\n      }\n    }\n  }\n": types.SetVideoThumbnailAtTimeDocument,
     "\n  mutation sharePlaylist($id: uuid!, $emails: jsonb) {\n    update_playlist_by_pk(pk_columns: { id: $id }, _set: { sharedRecipientsInput: $emails }) {\n      id\n    }\n  }\n": types.SharePlaylistDocument,
@@ -345,6 +347,10 @@ export function graphql(source: "\n  mutation UpdatePlaylistManage($id: uuid!, $
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(source: "\n  mutation ReorderPlaylistVideos($updates: [playlist_videos_updates!]!) {\n    update_playlist_videos_many(updates: $updates) {\n      returning {\n        position\n      }\n    }\n  }\n"): typeof import('./graphql').ReorderPlaylistVideosDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n  mutation RepairFmp4($input: RepairFmp4Input!) {\n    repairFmp4(input: $input) {\n      success\n      message\n    }\n  }\n"): typeof import('./graphql').RepairFmp4Document;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/packages/core/src/graphql/graphql.ts
+++ b/packages/core/src/graphql/graphql.ts
@@ -111,6 +111,22 @@ export type Int_Comparison_Exp = {
   _nin?: InputMaybe<Array<Scalars['Int']['input']>>;
 };
 
+export type RepairFmp4Input = {
+  videoId: Scalars['String']['input'];
+};
+
+export type RepairFmp4Output = {
+  __typename?: 'RepairFmp4Output';
+  success: Scalars['Boolean']['output'];
+};
+
+export type RepairFmp4Response = {
+  __typename?: 'RepairFmp4Response';
+  dataObject?: Maybe<RepairFmp4Output>;
+  message: Scalars['String']['output'];
+  success: Scalars['Boolean']['output'];
+};
+
 export type SetVideoThumbnailAtTimeInput = {
   atSeconds: Scalars['Float']['input'];
   videoId: Scalars['String']['input'];
@@ -3354,6 +3370,8 @@ export type Mutation_Root = {
   insert_videos?: Maybe<Videos_Mutation_Response>;
   /** insert a single row into the table: "videos" */
   insert_videos_one?: Maybe<Videos>;
+  /** Remux a stored TS video into fMP4/CMAF to fix the hls.js MPEG-TS AAC-demux noise bug. Ownership enforced server-side. */
+  repairFmp4: RepairFmp4Response;
   /** Capture the frame at a given timestamp and persist it as the video's thumbnail; ownership enforced server-side against the session user. */
   setVideoThumbnailAtTime: SetVideoThumbnailAtTimeResponse;
   /** update data of the table: "audio_tags" */
@@ -4248,6 +4266,12 @@ export type Mutation_RootInsert_VideosArgs = {
 export type Mutation_RootInsert_Videos_OneArgs = {
   object: Videos_Insert_Input;
   on_conflict?: InputMaybe<Videos_On_Conflict>;
+};
+
+
+/** mutation root */
+export type Mutation_RootRepairFmp4Args = {
+  input: RepairFmp4Input;
 };
 
 
@@ -6443,7 +6467,7 @@ export type Posts = {
   brief: Scalars['String']['output'];
   created_at: Scalars['timestamptz']['output'];
   /** Hashnode public id */
-  hId?: Maybe<Scalars['String']['output']>;
+  hId: Scalars['String']['output'];
   id: Scalars['uuid']['output'];
   markdownContent: Scalars['String']['output'];
   pinned: Scalars['Boolean']['output'];
@@ -8248,8 +8272,8 @@ export type Shared_Video_Recipients = {
   recipientId?: Maybe<Scalars['uuid']['output']>;
   updatedAt: Scalars['timestamptz']['output'];
   /** An object relationship */
-  video?: Maybe<Videos>;
-  videoId?: Maybe<Scalars['uuid']['output']>;
+  video: Videos;
+  videoId: Scalars['uuid']['output'];
   viewed: Scalars['Boolean']['output'];
 };
 
@@ -10676,7 +10700,7 @@ export type Timestamptz_Comparison_Exp = {
   _nin?: InputMaybe<Array<Scalars['timestamptz']['input']>>;
 };
 
-/** Per-user, per-app UI preferences. The `data` blob is site-scoped ({ watch: { standaloneMode }, ... }); its structure and defaults live in the frontend core package, not the DB. */
+/** columns and relationships of "user_settings" */
 export type User_Settings = {
   __typename?: 'user_settings';
   data: Scalars['jsonb']['output'];
@@ -10686,7 +10710,7 @@ export type User_Settings = {
 };
 
 
-/** Per-user, per-app UI preferences. The `data` blob is site-scoped ({ watch: { standaloneMode }, ... }); its structure and defaults live in the frontend core package, not the DB. */
+/** columns and relationships of "user_settings" */
 export type User_SettingsDataArgs = {
   path?: InputMaybe<Scalars['String']['input']>;
 };
@@ -13540,6 +13564,13 @@ export type ReorderPlaylistVideosMutationVariables = Exact<{
 
 export type ReorderPlaylistVideosMutation = { __typename?: 'mutation_root', update_playlist_videos_many?: Array<{ __typename?: 'playlist_videos_mutation_response', returning: Array<{ __typename?: 'playlist_videos', position: number }> } | null> | null };
 
+export type RepairFmp4MutationVariables = Exact<{
+  input: RepairFmp4Input;
+}>;
+
+
+export type RepairFmp4Mutation = { __typename?: 'mutation_root', repairFmp4: { __typename?: 'RepairFmp4Response', success: boolean, message: string } };
+
 export type SaveSubtitleMutationVariables = Exact<{
   id: Scalars['uuid']['input'];
   object: Subtitles_Set_Input;
@@ -14530,6 +14561,14 @@ export const ReorderPlaylistVideosDocument = new TypedDocumentString(`
   }
 }
     `) as unknown as TypedDocumentString<ReorderPlaylistVideosMutation, ReorderPlaylistVideosMutationVariables>;
+export const RepairFmp4Document = new TypedDocumentString(`
+    mutation RepairFmp4($input: RepairFmp4Input!) {
+  repairFmp4(input: $input) {
+    success
+    message
+  }
+}
+    `) as unknown as TypedDocumentString<RepairFmp4Mutation, RepairFmp4MutationVariables>;
 export const SaveSubtitleDocument = new TypedDocumentString(`
     mutation SaveSubtitle($id: uuid!, $object: subtitles_set_input!) {
   update_subtitles_by_pk(pk_columns: {id: $id}, _set: $object) {

--- a/packages/core/src/watch/mutation-hooks/index.ts
+++ b/packages/core/src/watch/mutation-hooks/index.ts
@@ -9,6 +9,7 @@ export {
   useCreatePlaylist,
   useUpdatePlaylist,
   useReorderPlaylistVideos,
+  useRepairFmp4,
 } from './manage';
 export type {
   UpdateVideoVariables,
@@ -16,6 +17,7 @@ export type {
   UpdatePlaylistVariables,
   ReorderPlaylistVideosVariables,
   ReorderItem,
+  RepairFmp4Variables,
 } from './manage';
 export {
   type UseVideoProgressProps,

--- a/packages/core/src/watch/mutation-hooks/manage.ts
+++ b/packages/core/src/watch/mutation-hooks/manage.ts
@@ -262,11 +262,36 @@ const useReorderPlaylistVideos = (props: UseMutationProps) => {
   return { ...mutation, mutate };
 };
 
+// ─── useRepairFmp4 ───
+
+const repairFmp4Mutation = graphql(/* GraphQL */ `
+  mutation RepairFmp4($input: RepairFmp4Input!) {
+    repairFmp4(input: $input) {
+      success
+      message
+    }
+  }
+`);
+
+interface RepairFmp4Variables {
+  videoId: string;
+}
+
+const useRepairFmp4 = (props: UseMutationProps) => {
+  const { getAccessToken } = props;
+
+  return useMutationRequest({
+    document: repairFmp4Mutation,
+    getAccessToken,
+  });
+};
+
 export {
   useUpdateVideo,
   useCreatePlaylist,
   useUpdatePlaylist,
   useReorderPlaylistVideos,
+  useRepairFmp4,
 };
 export type {
   UpdateVideoVariables,
@@ -274,4 +299,5 @@ export type {
   UpdatePlaylistVariables,
   ReorderPlaylistVideosVariables,
   ReorderItem,
+  RepairFmp4Variables,
 };


### PR DESCRIPTION
Replaces the no-op toast placeholder with the actual `repairFmp4` Hasura Action call.

SWO-489

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to repair FMP4 videos from the manage screen.
  * Repair requests now report clear success or failure notifications.
  * Success messages include server-provided details when available.

* **Bug Fixes**
  * Replaced the previous immediate “queued” notification with status updates based on the actual repair request outcome.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->