### PR TITLE
[WIP] feat(extension): Telegram Web/t.me channel detector (SWO-492)

### DIFF
--- a/apps/extension/src/content-scripts/content.ts
+++ b/apps/extension/src/content-scripts/content.ts
@@ -1,11 +1,9 @@
 import type { ExtensionMessage } from 'core/universal/extension/communication/types';
-
+import { detectPageType } from './parsers/detector';
 import { isPdfPage, parsePdfDocument } from './parsers/pdf';
-import {
-  detectPageType,
-  extractYouTubeMetadata,
-  extractVimeoMetadata,
-} from './parsers/detector';
+import { extractTelegramMetadata } from './parsers/telegram';
+import { extractVimeoMetadata } from './parsers/vimeo';
+import { extractYouTubeMetadata } from './parsers/youtube';
 
 const main = async () => {
   const url = window.location.href;
@@ -49,6 +47,19 @@ const main = async () => {
       source: 'content-script',
       target: 'background',
       type: 'VIDEO_METADATA_EXTRACTED',
+      payload: metadata,
+    };
+    chrome.runtime.sendMessage(message);
+    return;
+  }
+
+  if (pageType === 'telegram') {
+    const metadata = extractTelegramMetadata();
+    if (!metadata.channelId) return;
+    const message: ExtensionMessage = {
+      source: 'content-script',
+      target: 'background',
+      type: 'TELEGRAM_CHANNEL_DETECTED',
       payload: metadata,
     };
     chrome.runtime.sendMessage(message);

--- a/apps/extension/src/content-scripts/parsers/detector.test.ts
+++ b/apps/extension/src/content-scripts/parsers/detector.test.ts
@@ -14,6 +14,16 @@ describe('detectPageType', () => {
     expect(detectPageType('https://vimeo.com/12345')).toBe('vimeo');
   });
 
+  it('should detect web.telegram.org URL', () => {
+    expect(detectPageType('https://web.telegram.org/k/#@somechannel')).toBe(
+      'telegram',
+    );
+  });
+
+  it('should detect t.me URL', () => {
+    expect(detectPageType('https://t.me/somechannel')).toBe('telegram');
+  });
+
   it('should detect PDF URL', () => {
     expect(detectPageType('https://example.com/doc.pdf')).toBe('pdf');
   });
@@ -64,6 +74,15 @@ describe('detect', () => {
     expect(result.content).not.toBeNull();
     if (result.content && 'platform' in result.content) {
       expect(result.content.platform).toBe('vimeo');
+    }
+  });
+
+  it('should return telegram type with metadata for web.telegram.org URL', () => {
+    const result = detect('https://web.telegram.org/k/#@somechannel');
+    expect(result.pageType).toBe('telegram');
+    expect(result.content).not.toBeNull();
+    if (result.content && 'url' in result.content) {
+      expect('channelId' in result.content).toBe(true);
     }
   });
 

--- a/apps/extension/src/content-scripts/parsers/detector.ts
+++ b/apps/extension/src/content-scripts/parsers/detector.ts
@@ -1,19 +1,25 @@
 import type {
   PageContent,
   PageType,
+  TelegramChannelMetadata,
   VideoMetadata,
 } from 'core/universal/extension/communication/types';
+import { extractTelegramMetadata } from './telegram';
 import { extractVimeoMetadata } from './vimeo';
 import { extractYouTubeMetadata } from './youtube';
 
 const YOUTUBE_RE = /^(https?:\/\/)?(www\.)?(youtube\.com\/watch|youtu\.be\/)/;
 const VIMEO_RE = /^(https?:\/\/)?(www\.)?vimeo\.com\//;
+// Covers both the web app (web.telegram.org) and Telegram's public sharing domain (t.me) —
+// see telegram.ts for how the channel identifier is parsed out of each.
+const TELEGRAM_RE = /^(https?:\/\/)?(web\.telegram\.org\/|(www\.)?t\.me\/)/;
 const PDF_URL_RE = /\.pdf$/i;
 
 const detectPageType = (url?: string): PageType => {
   if (!url) return 'unknown';
   if (YOUTUBE_RE.test(url)) return 'youtube';
   if (VIMEO_RE.test(url)) return 'vimeo';
+  if (TELEGRAM_RE.test(url)) return 'telegram';
   if (PDF_URL_RE.test(url)) return 'pdf';
   return 'webpage';
 };
@@ -25,7 +31,7 @@ const hasVideoElement = (): boolean => {
 
 type DetectResult = {
   pageType: PageType;
-  content: PageContent | VideoMetadata | null;
+  content: PageContent | VideoMetadata | TelegramChannelMetadata | null;
 };
 
 const detect = (url?: string): DetectResult => {
@@ -38,6 +44,11 @@ const detect = (url?: string): DetectResult => {
 
   if (pageType === 'vimeo') {
     const metadata = extractVimeoMetadata();
+    return { pageType, content: metadata };
+  }
+
+  if (pageType === 'telegram') {
+    const metadata = extractTelegramMetadata();
     return { pageType, content: metadata };
   }
 

--- a/apps/extension/src/content-scripts/parsers/telegram.test.ts
+++ b/apps/extension/src/content-scripts/parsers/telegram.test.ts
@@ -124,9 +124,7 @@ describe('extractTelegramMetadata', () => {
     const metadata = extractTelegramMetadata();
     expect(metadata.source).toBe('web-app');
     expect(metadata.channelId).toBe('@somechannel');
-    if (metadata.source === 'web-app') {
-      expect(metadata.variant).toBe('k');
-    }
+    expect(metadata.variant).toBe('k');
   });
 
   it('should extract numeric channel and variant for /a/ hash URL', () => {
@@ -137,9 +135,7 @@ describe('extractTelegramMetadata', () => {
     const metadata = extractTelegramMetadata();
     expect(metadata.source).toBe('web-app');
     expect(metadata.channelId).toBe('-582839764');
-    if (metadata.source === 'web-app') {
-      expect(metadata.variant).toBe('a');
-    }
+    expect(metadata.variant).toBe('a');
   });
 
   it('should not detect a channel for a personal chat on /a/', () => {
@@ -168,9 +164,7 @@ describe('extractTelegramMetadata', () => {
     const metadata = extractTelegramMetadata();
     expect(metadata.source).toBe('share-link');
     expect(metadata.channelId).toBe('ngocmaicutiiii');
-    if (metadata.source === 'share-link') {
-      expect(metadata.messageId).toBeUndefined();
-    }
+    expect(metadata.messageId).toBeUndefined();
   });
 
   it('should extract channel and message id for a t.me single-post link', () => {
@@ -180,8 +174,6 @@ describe('extractTelegramMetadata', () => {
     });
     const metadata = extractTelegramMetadata();
     expect(metadata.channelId).toBe('ngocmaicutiiii');
-    if (metadata.source === 'share-link') {
-      expect(metadata.messageId).toBe('3');
-    }
+    expect(metadata.messageId).toBe('3');
   });
 });

--- a/apps/extension/src/content-scripts/parsers/telegram.test.ts
+++ b/apps/extension/src/content-scripts/parsers/telegram.test.ts
@@ -42,10 +42,15 @@ describe('getChannelIdFromHash', () => {
     expect(getChannelIdFromHash('#8115119658')).toBeUndefined();
   });
 
-  it('should extract negative numeric peer id with message-id suffix', () => {
-    expect(getChannelIdFromHash('#-1001234567890_98765')).toBe(
-      '-1001234567890',
-    );
+  it('should reject a username starting with a digit', () => {
+    expect(getChannelIdFromHash('#@12345')).toBeUndefined();
+  });
+
+  it('should reject a hash with an unconfirmed message-id suffix rather than guess', () => {
+    // We don't know whether web.telegram.org appends a suffix like this for jump-to-message
+    // links, and an underscore-based suffix would be ambiguous with legitimate username
+    // characters, so this intentionally does NOT extract '-1001234567890'.
+    expect(getChannelIdFromHash('#-1001234567890_98765')).toBeUndefined();
   });
 
   it('should return undefined for empty hash (chat list)', () => {
@@ -86,8 +91,14 @@ describe('getChannelFromTmePath', () => {
     });
   });
 
-  it('should return empty object for unsupported path shapes', () => {
+  it('should return empty object for a joinchat path', () => {
     expect(getChannelFromTmePath('/joinchat/AbCdEfGh')).toEqual({});
+  });
+
+  it('should return empty object for reserved single-segment routes', () => {
+    expect(getChannelFromTmePath('/confirmphone')).toEqual({});
+    expect(getChannelFromTmePath('/giftcode')).toEqual({});
+    expect(getChannelFromTmePath('/share')).toEqual({});
   });
 
   it('should return empty object for root path', () => {
@@ -111,8 +122,11 @@ describe('extractTelegramMetadata', () => {
       writable: true,
     });
     const metadata = extractTelegramMetadata();
+    expect(metadata.source).toBe('web-app');
     expect(metadata.channelId).toBe('@somechannel');
-    expect(metadata.variant).toBe('k');
+    if (metadata.source === 'web-app') {
+      expect(metadata.variant).toBe('k');
+    }
   });
 
   it('should extract numeric channel and variant for /a/ hash URL', () => {
@@ -121,8 +135,11 @@ describe('extractTelegramMetadata', () => {
       writable: true,
     });
     const metadata = extractTelegramMetadata();
+    expect(metadata.source).toBe('web-app');
     expect(metadata.channelId).toBe('-582839764');
-    expect(metadata.variant).toBe('a');
+    if (metadata.source === 'web-app') {
+      expect(metadata.variant).toBe('a');
+    }
   });
 
   it('should not detect a channel for a personal chat on /a/', () => {
@@ -149,9 +166,11 @@ describe('extractTelegramMetadata', () => {
       writable: true,
     });
     const metadata = extractTelegramMetadata();
+    expect(metadata.source).toBe('share-link');
     expect(metadata.channelId).toBe('ngocmaicutiiii');
-    expect(metadata.messageId).toBeUndefined();
-    expect(metadata.variant).toBeUndefined();
+    if (metadata.source === 'share-link') {
+      expect(metadata.messageId).toBeUndefined();
+    }
   });
 
   it('should extract channel and message id for a t.me single-post link', () => {
@@ -161,6 +180,8 @@ describe('extractTelegramMetadata', () => {
     });
     const metadata = extractTelegramMetadata();
     expect(metadata.channelId).toBe('ngocmaicutiiii');
-    expect(metadata.messageId).toBe('3');
+    if (metadata.source === 'share-link') {
+      expect(metadata.messageId).toBe('3');
+    }
   });
 });

--- a/apps/extension/src/content-scripts/parsers/telegram.test.ts
+++ b/apps/extension/src/content-scripts/parsers/telegram.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractTelegramMetadata,
+  getChannelFromTmePath,
+  getChannelIdFromHash,
+  getVariant,
+  isTmeHostname,
+} from './telegram';
+
+describe('getVariant', () => {
+  it('should detect k variant', () => {
+    expect(getVariant('/k/')).toBe('k');
+  });
+
+  it('should detect a variant', () => {
+    expect(getVariant('/a/')).toBe('a');
+  });
+
+  it('should detect z variant', () => {
+    expect(getVariant('/z/')).toBe('z');
+  });
+
+  it('should return undefined for root path', () => {
+    expect(getVariant('/')).toBeUndefined();
+  });
+
+  it('should return undefined for unrelated path', () => {
+    expect(getVariant('/something/')).toBeUndefined();
+  });
+});
+
+describe('getChannelIdFromHash', () => {
+  it('should extract username channel from # @ username hash', () => {
+    expect(getChannelIdFromHash('#@somechannel')).toBe('@somechannel');
+  });
+
+  it('should extract negative numeric peer id (channel/group)', () => {
+    expect(getChannelIdFromHash('#-582839764')).toBe('-582839764');
+  });
+
+  it('should reject positive numeric peer id (personal/direct chat)', () => {
+    expect(getChannelIdFromHash('#8115119658')).toBeUndefined();
+  });
+
+  it('should extract negative numeric peer id with message-id suffix', () => {
+    expect(getChannelIdFromHash('#-1001234567890_98765')).toBe(
+      '-1001234567890',
+    );
+  });
+
+  it('should return undefined for empty hash (chat list)', () => {
+    expect(getChannelIdFromHash('')).toBeUndefined();
+  });
+
+  it('should return undefined for non-matching hash', () => {
+    expect(getChannelIdFromHash('#/settings')).toBeUndefined();
+  });
+});
+
+describe('isTmeHostname', () => {
+  it('should recognize t.me', () => {
+    expect(isTmeHostname('t.me')).toBe(true);
+  });
+
+  it('should recognize www.t.me', () => {
+    expect(isTmeHostname('www.t.me')).toBe(true);
+  });
+
+  it('should reject web.telegram.org', () => {
+    expect(isTmeHostname('web.telegram.org')).toBe(false);
+  });
+});
+
+describe('getChannelFromTmePath', () => {
+  it('should extract channel username from bare t.me path', () => {
+    expect(getChannelFromTmePath('/ngocmaicutiiii')).toEqual({
+      channelId: 'ngocmaicutiiii',
+      messageId: undefined,
+    });
+  });
+
+  it('should extract channel username and message id from /s/ path', () => {
+    expect(getChannelFromTmePath('/ngocmaicutiiii/s/3')).toEqual({
+      channelId: 'ngocmaicutiiii',
+      messageId: '3',
+    });
+  });
+
+  it('should return empty object for unsupported path shapes', () => {
+    expect(getChannelFromTmePath('/joinchat/AbCdEfGh')).toEqual({});
+  });
+
+  it('should return empty object for root path', () => {
+    expect(getChannelFromTmePath('/')).toEqual({});
+  });
+});
+
+describe('extractTelegramMetadata', () => {
+  const originalLocation = window.location;
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+    });
+  });
+
+  it('should extract username channel and variant for /k/ hash URL', () => {
+    Object.defineProperty(window, 'location', {
+      value: new URL('https://web.telegram.org/k/#@somechannel'),
+      writable: true,
+    });
+    const metadata = extractTelegramMetadata();
+    expect(metadata.channelId).toBe('@somechannel');
+    expect(metadata.variant).toBe('k');
+  });
+
+  it('should extract numeric channel and variant for /a/ hash URL', () => {
+    Object.defineProperty(window, 'location', {
+      value: new URL('https://web.telegram.org/a/#-582839764'),
+      writable: true,
+    });
+    const metadata = extractTelegramMetadata();
+    expect(metadata.channelId).toBe('-582839764');
+    expect(metadata.variant).toBe('a');
+  });
+
+  it('should not detect a channel for a personal chat on /a/', () => {
+    Object.defineProperty(window, 'location', {
+      value: new URL('https://web.telegram.org/a/#8115119658'),
+      writable: true,
+    });
+    const metadata = extractTelegramMetadata();
+    expect(metadata.channelId).toBeUndefined();
+  });
+
+  it('should not detect a channel for the chat list (no hash)', () => {
+    Object.defineProperty(window, 'location', {
+      value: new URL('https://web.telegram.org/k/'),
+      writable: true,
+    });
+    const metadata = extractTelegramMetadata();
+    expect(metadata.channelId).toBeUndefined();
+  });
+
+  it('should extract bare username channel for a t.me link', () => {
+    Object.defineProperty(window, 'location', {
+      value: new URL('https://t.me/ngocmaicutiiii'),
+      writable: true,
+    });
+    const metadata = extractTelegramMetadata();
+    expect(metadata.channelId).toBe('ngocmaicutiiii');
+    expect(metadata.messageId).toBeUndefined();
+    expect(metadata.variant).toBeUndefined();
+  });
+
+  it('should extract channel and message id for a t.me single-post link', () => {
+    Object.defineProperty(window, 'location', {
+      value: new URL('https://t.me/ngocmaicutiiii/s/3'),
+      writable: true,
+    });
+    const metadata = extractTelegramMetadata();
+    expect(metadata.channelId).toBe('ngocmaicutiiii');
+    expect(metadata.messageId).toBe('3');
+  });
+});

--- a/apps/extension/src/content-scripts/parsers/telegram.ts
+++ b/apps/extension/src/content-scripts/parsers/telegram.ts
@@ -1,6 +1,7 @@
 import type { TelegramChannelMetadata } from 'core/universal/extension/communication/types';
 
-// Telegram channel detection covers two distinct URL families:
+// Telegram channel detection covers two distinct URL families (see TelegramChannelMetadata
+// in packages/core for the `source`-discriminated payload shape each one produces):
 //
 // 1. `web.telegram.org` — the web app itself, with three UI variants at different path
 //    prefixes: `/k/`, `/a/`, `/z/`. All three address the open chat via a URL hash fragment
@@ -20,6 +21,13 @@ import type { TelegramChannelMetadata } from 'core/universal/extension/communica
 //    fully trusted. If either variant turns out to differ, only `getVariant`/this comment and
 //    the regexes below need updating — the dispatch logic in content.ts stays the same.
 //
+//    We intentionally do NOT try to parse a "jump to message" suffix off these hashes (e.g.
+//    a hypothetical `#-1001234567890_98765`): unlike t.me's `/s/<id>` (below), which is
+//    unambiguous because '/' can't appear in a username, an underscore-based suffix can't be
+//    reliably told apart from a legitimate username character (Telegram usernames allow
+//    underscores) or an unconfirmed numeric-hash convention. Rather than guess, we only match
+//    the exact `#@username` / `#<signedInt>` shapes.
+//
 // 2. `t.me` — Telegram's public sharing domain, confirmed by direct observation:
 //      - `https://t.me/<username>`           -> public channel link
 //      - `https://t.me/<username>/s/<msgId>` -> "single post preview" link, from a channel
@@ -30,13 +38,9 @@ import type { TelegramChannelMetadata } from 'core/universal/extension/communica
 //    accepts both '@username' and bare 'username'). Other `t.me` path shapes (`/c/...`,
 //    `/joinchat/...`, `/+invite`, `/share`, bot deep links, etc.) are intentionally NOT
 //    parsed here — out of this sub-task's scope. They safely fall through to an undetected
-//    channelId, so no message is sent for them (see content.ts).
-//
-// Convention for `channelId` (relied on by SWO-494's gateway lookup): the raw identifier as
-// it appears in the URL — sign included for numeric peer ids (e.g. '-582839764'), '@'-prefixed
-// for web.telegram.org usernames (e.g. '@somechannel'), bare for t.me usernames (e.g.
-// 'somechannel'). No normalization (no '-100' prefixing, no '@' stripping/adding) happens
-// here — that's an MTProto-resolution concern for the backend, not URL parsing.
+//    channelId, so no message is sent for them (see content.ts). A best-effort exclusion
+//    list (TME_RESERVED_PATHS) also guards against a handful of single-segment reserved t.me
+//    routes (e.g. `/confirmphone`, `/giftcode`) that would otherwise shape-match a username.
 
 const TELEGRAM_VARIANT_RE = /^\/(k|a|z)\//;
 
@@ -47,8 +51,9 @@ const getVariant = (pathname: string): TelegramVariant | undefined => {
   return match ? (match[1] as TelegramVariant) : undefined;
 };
 
-const USERNAME_HASH_RE = /^#@([a-zA-Z0-9_]{5,32})(?:[/_]\d+)?$/;
-const NUMERIC_HASH_RE = /^#(-?\d+)(?:[/_]\d+)?$/;
+// Telegram usernames: 5-32 chars, alphanumeric + underscore, starting with a letter.
+const USERNAME_HASH_RE = /^#@([A-Za-z][A-Za-z0-9_]{4,31})$/;
+const NUMERIC_HASH_RE = /^#(-?\d+)$/;
 
 const getChannelIdFromHash = (hash: string): string | undefined => {
   const usernameMatch = hash.match(USERNAME_HASH_RE);
@@ -66,11 +71,29 @@ const getChannelIdFromHash = (hash: string): string | undefined => {
   return undefined;
 };
 
-// Standard Telegram usernames are 5-32 chars, alphanumeric + underscore, starting with a
-// letter. This also happens to exclude single-segment reserved t.me keywords too short to
-// be a username (e.g. 'c'), though longer reserved words (e.g. 'joinchat', 'share') aren't
-// specifically filtered — they're expected to always appear with additional path segments
-// this regex doesn't match, so they fall through safely as an undetected channel.
+// Single-segment t.me paths reserved for Telegram's own deep-link routes (phone
+// confirmation, sticker packs, proxy/socks configs, etc.) that would otherwise shape-match
+// TME_PATH_RE as a plausible username. Not guaranteed exhaustive — see core.telegram.org/api/links.
+const TME_RESERVED_PATHS = new Set([
+  'joinchat',
+  'addstickers',
+  'addemoji',
+  'addtheme',
+  'confirmphone',
+  'login',
+  'socks',
+  'proxy',
+  'invoice',
+  'giftcode',
+  'setlanguage',
+  'addlist',
+  'boost',
+  'share',
+  'iv',
+  'bg',
+  'msg',
+]);
+
 const TME_PATH_RE = /^\/([A-Za-z][A-Za-z0-9_]{4,31})(?:\/s\/(\d+))?\/?$/;
 
 type TmeChannel = { channelId?: string; messageId?: string };
@@ -78,6 +101,7 @@ type TmeChannel = { channelId?: string; messageId?: string };
 const getChannelFromTmePath = (pathname: string): TmeChannel => {
   const match = pathname.match(TME_PATH_RE);
   if (!match) return {};
+  if (TME_RESERVED_PATHS.has(match[1].toLowerCase())) return {};
   return { channelId: match[1], messageId: match[2] };
 };
 
@@ -86,20 +110,20 @@ const isTmeHostname = (hostname: string): boolean =>
 
 const extractTelegramMetadata = (): TelegramChannelMetadata => {
   if (typeof window === 'undefined') {
-    return { url: '' };
+    return { url: '', source: 'web-app' };
   }
 
   const { hostname, pathname, hash, href } = window.location;
 
   if (isTmeHostname(hostname)) {
     const { channelId, messageId } = getChannelFromTmePath(pathname);
-    return { url: href, channelId, messageId };
+    return { url: href, source: 'share-link', channelId, messageId };
   }
 
   const variant = getVariant(pathname);
   const channelId = getChannelIdFromHash(hash);
 
-  return { url: href, channelId, variant };
+  return { url: href, source: 'web-app', channelId, variant };
 };
 
 export {

--- a/apps/extension/src/content-scripts/parsers/telegram.ts
+++ b/apps/extension/src/content-scripts/parsers/telegram.ts
@@ -1,0 +1,111 @@
+import type { TelegramChannelMetadata } from 'core/universal/extension/communication/types';
+
+// Telegram channel detection covers two distinct URL families:
+//
+// 1. `web.telegram.org` — the web app itself, with three UI variants at different path
+//    prefixes: `/k/`, `/a/`, `/z/`. All three address the open chat via a URL hash fragment
+//    rather than the pathname, in one of two shapes:
+//      - `#@username`   -> public channel/user, identified by username (we keep the '@')
+//      - `#<signedInt>` -> private channel/group/user, identified by numeric peer id
+//    The `/a/` shape is CONFIRMED by direct observation against the live site:
+//      - `https://web.telegram.org/a/#-582839764`  -> a group/channel (negative id)
+//      - `https://web.telegram.org/a/#8115119658`  -> a personal/direct chat (positive id)
+//    i.e. the sign of the numeric id is the discriminator, matching Telegram's general
+//    peer-id convention (positive = user, negative = chat/channel/supergroup).
+//
+//    TODO(SWO-492): `/k/` and `/z/` are NOT independently confirmed against the live site —
+//    they're assumed to share the same hash scheme as `/a/` based on published examples
+//    (e.g. `web.telegram.org/z/#-1782626220`) and Telegram's general peer-id convention, but
+//    this should be verified against a live web.telegram.org/k/ and /z/ channel before being
+//    fully trusted. If either variant turns out to differ, only `getVariant`/this comment and
+//    the regexes below need updating — the dispatch logic in content.ts stays the same.
+//
+// 2. `t.me` — Telegram's public sharing domain, confirmed by direct observation:
+//      - `https://t.me/<username>`           -> public channel link
+//      - `https://t.me/<username>/s/<msgId>` -> "single post preview" link, from a channel
+//        post's "Copy Post Link"/Share action, e.g. `https://t.me/ngocmaicutiiii/s/3`
+//    channelId for `t.me` links is the BARE username (no '@'), unlike the web.telegram.org
+//    hash form above — kept distinct per-source rather than normalized, since the backend
+//    (SWO-494) resolves either username form the same way (Telethon/teleproto's `getEntity`
+//    accepts both '@username' and bare 'username'). Other `t.me` path shapes (`/c/...`,
+//    `/joinchat/...`, `/+invite`, `/share`, bot deep links, etc.) are intentionally NOT
+//    parsed here — out of this sub-task's scope. They safely fall through to an undetected
+//    channelId, so no message is sent for them (see content.ts).
+//
+// Convention for `channelId` (relied on by SWO-494's gateway lookup): the raw identifier as
+// it appears in the URL — sign included for numeric peer ids (e.g. '-582839764'), '@'-prefixed
+// for web.telegram.org usernames (e.g. '@somechannel'), bare for t.me usernames (e.g.
+// 'somechannel'). No normalization (no '-100' prefixing, no '@' stripping/adding) happens
+// here — that's an MTProto-resolution concern for the backend, not URL parsing.
+
+const TELEGRAM_VARIANT_RE = /^\/(k|a|z)\//;
+
+type TelegramVariant = 'k' | 'a' | 'z';
+
+const getVariant = (pathname: string): TelegramVariant | undefined => {
+  const match = pathname.match(TELEGRAM_VARIANT_RE);
+  return match ? (match[1] as TelegramVariant) : undefined;
+};
+
+const USERNAME_HASH_RE = /^#@([a-zA-Z0-9_]{5,32})(?:[/_]\d+)?$/;
+const NUMERIC_HASH_RE = /^#(-?\d+)(?:[/_]\d+)?$/;
+
+const getChannelIdFromHash = (hash: string): string | undefined => {
+  const usernameMatch = hash.match(USERNAME_HASH_RE);
+  if (usernameMatch) return `@${usernameMatch[1]}`;
+
+  const numericMatch = hash.match(NUMERIC_HASH_RE);
+  if (numericMatch) {
+    const peerId = numericMatch[1];
+    // Positive peer ids are personal/direct chats (users) — out of scope for SWO-490,
+    // which only imports from channels. Only negative (group/channel) ids qualify.
+    if (!peerId.startsWith('-')) return undefined;
+    return peerId;
+  }
+
+  return undefined;
+};
+
+// Standard Telegram usernames are 5-32 chars, alphanumeric + underscore, starting with a
+// letter. This also happens to exclude single-segment reserved t.me keywords too short to
+// be a username (e.g. 'c'), though longer reserved words (e.g. 'joinchat', 'share') aren't
+// specifically filtered — they're expected to always appear with additional path segments
+// this regex doesn't match, so they fall through safely as an undetected channel.
+const TME_PATH_RE = /^\/([A-Za-z][A-Za-z0-9_]{4,31})(?:\/s\/(\d+))?\/?$/;
+
+type TmeChannel = { channelId?: string; messageId?: string };
+
+const getChannelFromTmePath = (pathname: string): TmeChannel => {
+  const match = pathname.match(TME_PATH_RE);
+  if (!match) return {};
+  return { channelId: match[1], messageId: match[2] };
+};
+
+const isTmeHostname = (hostname: string): boolean =>
+  hostname === 't.me' || hostname === 'www.t.me';
+
+const extractTelegramMetadata = (): TelegramChannelMetadata => {
+  if (typeof window === 'undefined') {
+    return { url: '' };
+  }
+
+  const { hostname, pathname, hash, href } = window.location;
+
+  if (isTmeHostname(hostname)) {
+    const { channelId, messageId } = getChannelFromTmePath(pathname);
+    return { url: href, channelId, messageId };
+  }
+
+  const variant = getVariant(pathname);
+  const channelId = getChannelIdFromHash(hash);
+
+  return { url: href, channelId, variant };
+};
+
+export {
+  extractTelegramMetadata,
+  getChannelFromTmePath,
+  getChannelIdFromHash,
+  getVariant,
+  isTmeHostname,
+};

--- a/packages/core/src/universal/extension/communication/types.test.ts
+++ b/packages/core/src/universal/extension/communication/types.test.ts
@@ -7,6 +7,7 @@ import type {
   PageContent,
   PageType,
   PdfMetadata,
+  TelegramChannelMetadata,
   VideoMetadata,
 } from './types';
 
@@ -16,11 +17,12 @@ describe('PageType', () => {
       'pdf',
       'youtube',
       'vimeo',
+      'telegram',
       'video-generic',
       'webpage',
       'unknown',
     ];
-    expect(types).toHaveLength(6);
+    expect(types).toHaveLength(7);
   });
 });
 
@@ -87,6 +89,38 @@ describe('VideoMetadata', () => {
       thumbnailUrl: 'https://example.com/thumb.jpg',
     };
     expect(metadata.duration).toBe(120);
+  });
+});
+
+describe('TelegramChannelMetadata', () => {
+  it('should create a valid web-app source object', () => {
+    const metadata: TelegramChannelMetadata = {
+      url: 'https://web.telegram.org/k/#@somechannel',
+      source: 'web-app',
+      channelId: '@somechannel',
+      variant: 'k',
+    };
+    expect(metadata.source).toBe('web-app');
+    expect(metadata.channelId).toBe('@somechannel');
+  });
+
+  it('should create a valid share-link source object', () => {
+    const metadata: TelegramChannelMetadata = {
+      url: 'https://t.me/somechannel/s/3',
+      source: 'share-link',
+      channelId: 'somechannel',
+      messageId: '3',
+    };
+    expect(metadata.source).toBe('share-link');
+    expect(metadata.messageId).toBe('3');
+  });
+
+  it('should allow an undetected channel', () => {
+    const metadata: TelegramChannelMetadata = {
+      url: 'https://web.telegram.org/k/',
+      source: 'web-app',
+    };
+    expect(metadata.channelId).toBeUndefined();
   });
 });
 
@@ -231,6 +265,20 @@ describe('ExtensionMessage discriminated union', () => {
       },
     };
     expect(message.type).toBe('VIDEO_METADATA_EXTRACTED');
+  });
+
+  it('should create a TELEGRAM_CHANNEL_DETECTED message', () => {
+    const message: ExtensionMessage = {
+      source: 'content-script',
+      target: 'background',
+      type: 'TELEGRAM_CHANNEL_DETECTED',
+      payload: {
+        url: 'https://t.me/somechannel',
+        source: 'share-link',
+        channelId: 'somechannel',
+      },
+    };
+    expect(message.type).toBe('TELEGRAM_CHANNEL_DETECTED');
   });
 
   it('should create a CONTENT_IMPORT_REQUEST message', () => {

--- a/packages/core/src/universal/extension/communication/types.ts
+++ b/packages/core/src/universal/extension/communication/types.ts
@@ -38,23 +38,33 @@ type ClipboardContent = {
   detectedType: 'url' | 'text' | 'isbn' | 'unknown';
 };
 
-type TelegramChannelMetadata = {
-  url: string;
-  // The raw channel identifier as it appears in the source URL — shape depends on where
-  // it was extracted from, deliberately NOT normalized to a single form:
-  //   - '@username'   from a web.telegram.org hash (e.g. '#@somechannel')
-  //   - '-1234567890' the raw numeric peer id from a web.telegram.org hash (sign kept)
-  //   - 'username'    (no '@') from a t.me/<username> link
-  // Undefined when the page doesn't identify a specific channel (e.g. the chat list,
-  // a personal/direct chat, or an unsupported t.me path like /c/, /joinchat/, /+invite).
-  channelId?: string;
-  // Message id, when the URL points at a specific post (currently only t.me's
-  // `/s/<messageId>` "single post preview" link shape). Not used by this sub-task; carried
-  // through so a later sub-issue can jump straight to that message.
-  messageId?: string;
-  // web.telegram.org client UI variant; undefined for t.me links (not applicable there).
-  variant?: 'k' | 'a' | 'z';
-};
+// Discriminated on `source` because the two URL families carry genuinely different shapes
+// of extra data (web app: which UI variant; share link: which message) — flattening them
+// into one bag of optional fields would let a consumer infer the source from which fields
+// happen to be set, which breaks the moment a third shape is added. `channelId` itself is
+// common to both, but deliberately NOT normalized to a single form across sources:
+//   - '@username'   from a web.telegram.org hash (e.g. '#@somechannel')
+//   - '-1234567890' the raw numeric peer id from a web.telegram.org hash (sign kept)
+//   - 'username'    (no '@') from a t.me/<username> link
+// Undefined when the page doesn't identify a specific channel (e.g. the chat list,
+// a personal/direct chat, or an unsupported t.me path like /c/, /joinchat/, /+invite).
+type TelegramChannelMetadata =
+  | {
+      url: string;
+      source: 'web-app';
+      channelId?: string;
+      // web.telegram.org client UI variant.
+      variant?: 'k' | 'a' | 'z';
+    }
+  | {
+      url: string;
+      source: 'share-link';
+      channelId?: string;
+      // Message id, when the URL points at a specific post (t.me's `/s/<messageId>`
+      // "single post preview" link shape). Not used by this sub-task; carried through so a
+      // later sub-issue can jump straight to that message.
+      messageId?: string;
+    };
 
 type ContentImportRequest = {
   contentId: string;

--- a/packages/core/src/universal/extension/communication/types.ts
+++ b/packages/core/src/universal/extension/communication/types.ts
@@ -38,33 +38,27 @@ type ClipboardContent = {
   detectedType: 'url' | 'text' | 'isbn' | 'unknown';
 };
 
-// Discriminated on `source` because the two URL families carry genuinely different shapes
-// of extra data (web app: which UI variant; share link: which message) — flattening them
-// into one bag of optional fields would let a consumer infer the source from which fields
-// happen to be set, which breaks the moment a third shape is added. `channelId` itself is
-// common to both, but deliberately NOT normalized to a single form across sources:
+// Flat type with a `source` tag, mirroring VideoMetadata's `platform` tag convention above
+// rather than a discriminated union — `source` tells a consumer which URL family produced
+// the payload (and therefore which of `variant`/`messageId` is meaningful) without forcing
+// a TypeScript narrow at every read site. `channelId` itself is common to both sources, but
+// deliberately NOT normalized to a single form across them:
 //   - '@username'   from a web.telegram.org hash (e.g. '#@somechannel')
 //   - '-1234567890' the raw numeric peer id from a web.telegram.org hash (sign kept)
 //   - 'username'    (no '@') from a t.me/<username> link
 // Undefined when the page doesn't identify a specific channel (e.g. the chat list,
 // a personal/direct chat, or an unsupported t.me path like /c/, /joinchat/, /+invite).
-type TelegramChannelMetadata =
-  | {
-      url: string;
-      source: 'web-app';
-      channelId?: string;
-      // web.telegram.org client UI variant.
-      variant?: 'k' | 'a' | 'z';
-    }
-  | {
-      url: string;
-      source: 'share-link';
-      channelId?: string;
-      // Message id, when the URL points at a specific post (t.me's `/s/<messageId>`
-      // "single post preview" link shape). Not used by this sub-task; carried through so a
-      // later sub-issue can jump straight to that message.
-      messageId?: string;
-    };
+type TelegramChannelMetadata = {
+  url: string;
+  source: 'web-app' | 'share-link';
+  channelId?: string;
+  // web.telegram.org client UI variant; only set when source is 'web-app'.
+  variant?: 'k' | 'a' | 'z';
+  // Message id, when the URL points at a specific post (t.me's `/s/<messageId>` "single
+  // post preview" link shape); only set when source is 'share-link'. Not used by this
+  // sub-task; carried through so a later sub-issue can jump straight to that message.
+  messageId?: string;
+};
 
 type ContentImportRequest = {
   contentId: string;

--- a/packages/core/src/universal/extension/communication/types.ts
+++ b/packages/core/src/universal/extension/communication/types.ts
@@ -2,6 +2,7 @@ type PageType =
   | 'pdf'
   | 'youtube'
   | 'vimeo'
+  | 'telegram'
   | 'video-generic'
   | 'webpage'
   | 'unknown';
@@ -35,6 +36,24 @@ type ClipboardContent = {
   text: string;
   url?: string;
   detectedType: 'url' | 'text' | 'isbn' | 'unknown';
+};
+
+type TelegramChannelMetadata = {
+  url: string;
+  // The raw channel identifier as it appears in the source URL — shape depends on where
+  // it was extracted from, deliberately NOT normalized to a single form:
+  //   - '@username'   from a web.telegram.org hash (e.g. '#@somechannel')
+  //   - '-1234567890' the raw numeric peer id from a web.telegram.org hash (sign kept)
+  //   - 'username'    (no '@') from a t.me/<username> link
+  // Undefined when the page doesn't identify a specific channel (e.g. the chat list,
+  // a personal/direct chat, or an unsupported t.me path like /c/, /joinchat/, /+invite).
+  channelId?: string;
+  // Message id, when the URL points at a specific post (currently only t.me's
+  // `/s/<messageId>` "single post preview" link shape). Not used by this sub-task; carried
+  // through so a later sub-issue can jump straight to that message.
+  messageId?: string;
+  // web.telegram.org client UI variant; undefined for t.me links (not applicable there).
+  variant?: 'k' | 'a' | 'z';
 };
 
 type ContentImportRequest = {
@@ -79,6 +98,12 @@ type ExtensionMessage =
   | {
       source: 'content-script';
       target: 'background';
+      type: 'TELEGRAM_CHANNEL_DETECTED';
+      payload: TelegramChannelMetadata;
+    }
+  | {
+      source: 'content-script';
+      target: 'background';
       type: 'CONTENT_IMPORT_REQUEST';
       payload: ContentImportRequest;
     }
@@ -119,6 +144,7 @@ export type {
   PageContent,
   PdfMetadata,
   VideoMetadata,
+  TelegramChannelMetadata,
   ClipboardContent,
   ContentImportRequest,
   ImportStatus,


### PR DESCRIPTION
## Summary
- Adds a `telegram.ts` content-script parser (mirroring `youtube.ts`/`vimeo.ts`) that detects `web.telegram.org` and `t.me` channel pages and extracts a channel identifier — `#@username` / `#<signedPeerId>` hash shapes for the web app, and `t.me/<username>` / `t.me/<username>/s/<messageId>` for share links.
- Wires the new `'telegram'` `PageType` through `detector.ts` and a new dispatch branch in `content.ts` (fixes a pre-existing broken import in `content.ts` along the way — it imported `extractYouTubeMetadata`/`extractVimeoMetadata` from `./parsers/detector`, which never exported them, breaking the extension build on `main`).
- Extends `packages/core`'s `ExtensionMessage`/`PageType` with a `TELEGRAM_CHANNEL_DETECTED` message and a `TelegramChannelMetadata` payload type (flat, `source`-tagged, mirroring `VideoMetadata`'s `platform` convention).
- Client-side detection only, per SWO-490 Wave 0 scope — no backend calls, no changes to `background.ts` (listing/import lands in SWO-494/495/496).

**Flag for verification:** the `/a/` hash format (`#-582839764` = channel, `#8115119658` = personal chat) was confirmed by direct observation against the live site. The `/k/` and `/z/` variants are assumed to share the same hash scheme based on published examples and Telegram's general peer-id convention, but are **not independently confirmed** — flagged with a `TODO(SWO-492)` comment in `telegram.ts`. Worth a quick manual check against a live `/k/` and `/z/` channel before the next sub-issue builds on it.

Refs SWO-492.

## Test plan
- [x] `pnpm --filter extension test` — 92/92 passing, including new `telegram.test.ts` and extended `detector.test.ts` (no regressions in youtube/vimeo/pdf/clipboard detection)
- [x] `pnpm --filter core test` — 36/36 passing in `communication/`, including extended `types.test.ts`
- [x] `pnpm --filter extension build` (`vite build`) succeeds
- [x] Biome lint clean on all touched files
- [x] Three rounds of `/code-review` (high effort, multi-angle) + `reviewing-pull-requests` self-review — found and fixed real bugs (ambiguous suffix parsing, missing username validation, reserved-path false positives, over-engineered discriminated union), final pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)