### PR TITLE
[WIP] docs(skills): plain-English summaries, goal sub-issue, one-purpose sub-tasks

### DIFF
--- a/.claude/skills/micro-prs/SKILL.md
+++ b/.claude/skills/micro-prs/SKILL.md
@@ -10,32 +10,60 @@ Ship features like LEGO blocks: break every feature into the smallest increments
 
 This isn't process hygiene for its own sake — it's velocity. Small PRs review fast, merge fast, and when something breaks you revert one block instead of unpicking a monolith. Big PRs stall in review and kill momentum.
 
-## Size guide
+## The two governing rules
 
-Lines changed is a rough proxy, not a hard rule — use judgement (a 200-line pure rename is fine; a 60-line tangle of logic may not be).
+Apply these mechanically, before anything else — when breaking a ticket into sub-tasks, when opening a PR, and when reviewing one.
+
+### 1. One PR solves exactly ONE problem
+
+Not "mostly one". One. If describing the PR needs an "and", it's two PRs.
+
+### 2. ONE repo, and within it ONE app or ONE shared package — never combine
+
+sworld spans three physically separate repos (frontend `sworld`, `sworld-backend`, `sworld-hasura-v2`), so a PR can never span repos by construction — but the same discipline has to be applied deliberately *within* the frontend repo, where nothing stops you combining things that shouldn't be combined:
+
+- A single frontend PR touches **at most one** of: one `apps/<app>` directory, or `packages/core`, or `packages/ui`.
+- Touching two apps in one PR is wrong. An app plus `packages/core` in one PR is wrong. `packages/core` plus `packages/ui` in one PR is wrong.
+- Each layer carries different review and verification concerns — an app PR is checked by running that app; a `packages/core` PR is checked by its unit tests and `pnpm codegen`; a `packages/ui` PR is checked in Storybook. A PR mixing them can't be reviewed properly or reverted cleanly.
+- Across repos, the same rule shows up as sequencing instead of a single-PR constraint: a Hasura migration is its own PR in `sworld-hasura-v2`, and the frontend's regenerated types are a separate follow-up PR in `sworld` (see `parallel-workflow`) — never squashed into one change just because they're related.
+
+## Blockers land first, as their own PRs
+
+- **Database/schema.** Anything Hasura migration + metadata (permissions, relationships) is ONE dedicated PR in `sworld-hasura-v2`. It lands first; the frontend codegen follow-up is blocked-by it.
+- **Codegen never lands bundled with app logic.** It rides with the schema-change PR above when the schema changed, or — for a read-only phase with no migration — is its own tiny PR, blocked by nothing.
+- **`packages/core`.** Its own PR, even for a one-line change. Never bundled into an app PR that consumes it.
+- **Constants.** Their own independent PR, first, when a later PR needs them.
+- **Foundation/scaffolding.** A foundation-only PR containing nothing but the scaffolding, cut from `main` — never `blockedBy` the feature that surfaced the need. Foundation comes first; the feature builds on it.
+
+## Sequencing — parallel by default, waves only when earned
+
+**Independent pieces of work are parallel by default.** Don't invent a dependency graph between two sub-tasks just because they belong to the same feature. Within one app or package, break by **layer, not by feature** — each layer below is an independent top-blocker that can be built in parallel; only wiring waits:
+
+1. Types/interfaces (no implementation) — independent, top blocker.
+2. Core logic (behind a flag if it's user-visible) — independent, pure, unit-tested.
+3. API/endpoint — a stub returning a placeholder is enough; nothing calls it until wiring, so nothing breaks.
+4. GraphQL query + codegen — independent, unless a schema change blocks it (see above).
+5. Wiring — **always last.** This assembles the pieces: endpoint → core logic, hook → query → UI.
+6. Remove old code — its own PR, after the replacement is live.
+
+Before writing any "blocked by", ask: does this genuinely need the other to exist first (it won't compile, or it consumes the other's output), or do they just touch related code? The second case is a file-ownership note to resolve at review, not a blocker.
+
+Common shapes:
+
+- **Database change:** table schema → migration → GraphQL schema update (all one PR, per "Blockers land first" above) → frontend codegen follow-up (separate PR, separate repo).
+- **New API:** endpoint stub (returns empty) → core logic → validation & error handling.
+- **Frontend feature:** component skeleton → basic functionality → styling/interactions → wire to backend.
+
+## Scope is the limit — size is only a hint
+
+**Decide splits by scope first** (the two governing rules above) — a PR that spans two apps or does two jobs is wrong **even at 10 lines**. Once the scope is right, lines changed is a rough sanity check, not a hard rule — use judgement (a 200-line pure rename is fine; a 60-line tangle of logic may not be):
 
 - **0–50 lines** — perfect, ship immediately.
 - **51–150 lines** — good for a cohesive change.
 - **151–300 lines** — needs justification: why can't this be smaller?
-- **300+ lines** — decompose further.
+- **300+ lines** — almost certainly more than one job. Re-check the scope.
 
 See `parallel-workflow` for the file-count view ("the 3-files limit is soft") and the good-PR criteria — same idea from the other axis.
-
-## How to decompose
-
-Break a large change by layer, each layer its own PR:
-
-1. Add new types/interfaces (no implementation).
-2. Implement core logic (behind a flag if it's user-visible).
-3. Update API/endpoints — one at a time.
-4. Migrate frontend components — one by one.
-5. Remove the old code (separate PR).
-
-Common shapes:
-
-- **Database change:** table schema → migration → GraphQL schema update.
-- **New API:** endpoint stub (returns empty) → core logic → validation & error handling.
-- **Frontend feature:** component skeleton → basic functionality → styling/interactions → wire to backend.
 
 ## Ship incomplete work safely with flags
 
@@ -48,15 +76,17 @@ if (featureFlags.bulkImportCosts) {
 return <LegacyImportPanel />;
 ```
 
-This is what makes step 2 above possible — land the logic before the UI is ready.
+This is what makes the core-logic layer above land safely ahead of the UI — behind a flag, before it's ready.
 
 ## What a good micro-PR looks like
 
 - Reviewable in a few minutes.
 - Safely revertible on its own.
 - Delivers value, or a foundation for the next step.
-- Single responsibility — does one thing.
+- Single responsibility — does one thing, in one app/package/repo.
 - Independently deployable (behind a flag if needed).
+
+Before opening any PR, ask: **what ONE problem, in ONE app/package/repo, does this solve?** If the answer names two, split it — database/schema and constants land first as blockers, app logic on top.
 
 Once a slice is scoped, see `pr-descriptions` for writing the title and body.
 

--- a/.claude/skills/plain-english/SKILL.md
+++ b/.claude/skills/plain-english/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: plain-english
+description: The jargon-free "plain words" writing rule and the block templates that apply it — the mandatory opening summary a reader with zero context can understand in ten seconds, with no code, file paths, symbol names, or unexplained acronyms. Referenced by `writing-task-specs` (ticket "In plain words" / "Why this matters" blocks) and `pr-descriptions` (PR summary and user-facing test plan) rather than duplicated in each. Auto-triggers whenever drafting any of those, or any other doc that needs to read cleanly for a non-technical reader.
+---
+
+# Plain English
+
+One law, reused everywhere a document needs to be readable by someone with zero context. It used to get restated slightly differently every time a skill needed it — this is the single canonical version; `writing-task-specs` and `pr-descriptions` both apply it instead of each keeping their own copy.
+
+## The law
+
+- No code, no file paths, no function or symbol names.
+- No bare acronym or internal term (a protocol name, an internal field name, "the singleton", a three-letter domain code) — if the reader has to already know the term to parse the sentence, rewrite the sentence.
+- Round numbers when a figure matters ("$120k", not "$119,847.32").
+- Describe what a user sees or experiences, not how the system does it internally.
+- A reader with zero context gets the gist in ten seconds, unaided.
+
+## The test before publishing a sentence
+
+Read it back as someone who has never seen this codebase, this domain, or this feature before. If any single word would send them off to look something up before the sentence makes sense, rewrite it.
+
+## Applying it by context
+
+The law doesn't change — only the header and length it sits under, which belongs to the consuming skill:
+
+| Context | Header | Length | Owned by |
+|---|---|---|---|
+| Bug / small feature / large-feature-parent ticket | `**In plain words**` | 2–4 sentences | `writing-task-specs` |
+| Sub-issue (child of a large feature) | `**Why this matters**` | one sentence | `writing-task-specs` |
+| User story | no separate header — its opening section already is the plain-words block | 2–4 paragraphs | `writing-task-specs` |
+| PR summary | the description's opening sentences | 1–3 sentences | `pr-descriptions` |
+| PR test plan (user-facing change) | Test plan steps | click-by-click | `pr-descriptions` |
+
+## Before / after
+
+Bad — jargon leaks into the reader-facing sentence:
+
+> The client factory now resolves credentials per-request from the user's own record instead of a shared process-wide singleton, fixing cross-user session leakage.
+
+Good:
+
+> Right now, one part of the app could accidentally use someone else's login instead of your own. This fixes it so every action always uses your own account, never someone else's.
+
+## Why this is its own skill, not copy-pasted text
+
+The rule already has two independent, real consumers — `writing-task-specs`'s four ticket shapes and `pr-descriptions`'s summary/test-plan — not a hypothetical future one. Duplicating prose risks drift: one copy gets refined during a review and the other quietly falls behind. Whenever this law changes, it changes once, here, and both consumers pick it up.

--- a/.claude/skills/pr-descriptions/SKILL.md
+++ b/.claude/skills/pr-descriptions/SKILL.md
@@ -44,7 +44,7 @@ Bad titles:
 
 ## Who reads this PR
 
-Default assumption: **the description and test plan are read by a non-technical end user.** Write what *they see and do* in the product — plain English, real numbers, click-by-click. Apply the `plain-english` skill's law (no file names, no function names, no jargon) to both the Summary and the Test plan below.
+Default assumption: **the description and test plan are read by a non-technical end user.** Apply the `plain-english` skill's law to both the Summary and the Test plan below.
 
 There is exactly one exception: a PR with **no user-facing change at all** (pure refactor, tech-debt, internal cleanup, build/CI). For those:
 
@@ -103,7 +103,7 @@ Doesn't flag that there's no user impact, and leans on insider shorthand a new d
 
 ### Test plan
 
-**User-facing PR — steps a non-technical person can actually follow.** Each step names the exact page (click by click to get there), the exact thing to look at, and what pass vs. fail looks like in plain terms. No file names, no function names, no jargon. Before publishing a step, make sure the thing is genuinely visible on that page and that it actually changes in the example given.
+**User-facing PR — steps a non-technical person can actually follow.** Each step names the exact page (click by click to get there), the exact thing to look at, and what pass vs. fail looks like in plain terms — apply the `plain-english` law. Before publishing a step, make sure the thing is genuinely visible on that page and that it actually changes in the example given.
 
 Good:
 

--- a/.claude/skills/pr-descriptions/SKILL.md
+++ b/.claude/skills/pr-descriptions/SKILL.md
@@ -44,7 +44,7 @@ Bad titles:
 
 ## Who reads this PR
 
-Default assumption: **the description and test plan are read by a non-technical end user.** Write what *they see and do* in the product — plain English, real numbers, click-by-click. No file names, no function names, no jargon.
+Default assumption: **the description and test plan are read by a non-technical end user.** Write what *they see and do* in the product — plain English, real numbers, click-by-click. Apply the `plain-english` skill's law (no file names, no function names, no jargon) to both the Summary and the Test plan below.
 
 There is exactly one exception: a PR with **no user-facing change at all** (pure refactor, tech-debt, internal cleanup, build/CI). For those:
 

--- a/.claude/skills/product-planning/SKILL.md
+++ b/.claude/skills/product-planning/SKILL.md
@@ -127,8 +127,9 @@ decide a change doesn't need team sign-off, and that's their call. Don't hold th
 
 Only once the user (and, where they chose to, the team) is aligned: break the parent into children.
 Write the **goal & verification sub-issue first** (`writing-task-specs`) — the plain-English walkthrough and
-"how to know it's done" checklist. If that can't be written concretely yet, the shape isn't agreed
-enough for this step; go back to Steps 1–3 rather than inventing sub-issues around a fuzzy goal.
+"how to know it's done" checklist. If that can't be written concretely yet, say so and suggest
+going back to Steps 1–3 rather than inventing sub-issues around a fuzzy goal — same non-gating
+posture as above: raise the concern, then follow the user's call if they want to proceed anyway.
 Then break the rest into sub-issues, applying `micro-prs`' one-purpose test and one-app/repo scope to each,
 sequencing them (flat by default, waves only where a real dependency exists — see `writing-task-specs`),
 and respecting the deployment model (small, independently mergeable, revertible). This is deliberately

--- a/.claude/skills/product-planning/SKILL.md
+++ b/.claude/skills/product-planning/SKILL.md
@@ -113,7 +113,7 @@ Now think hard about *how*, and be self-critical about it:
 ## Step 3 — Shape a high-level parent
 
 Once the thinking holds, capture it as a **high-level parent issue** with `writing-task-specs` — a
-Linear issue (in the app's project) whose description carries the concept, the options, and the trade-offs that
+Linear issue (in the app's project) whose description opens with the `plain-english` block and then carries the concept, the options, and the trade-offs that
 *prove* the problem is understood. Keep it high-level; do **not** scope the children (sub-issues)
 yet. The concept lives in its Linear document; the parent issue supports it.
 
@@ -125,11 +125,14 @@ decide a change doesn't need team sign-off, and that's their call. Don't hold th
 
 ## Step 4 — Detailed scoping (a separate, later pass)
 
-Only once the user (and, where they chose to, the team) is aligned: break the parent into children —
-the sub-issues, their order (waves encoded by `blockedBy` relations), and the dependency chain
-that delivers the feature most efficiently. Use `writing-task-specs` (large-feature shape) and `micro-prs`,
-respecting the deployment model (small, independently mergeable, revertible). This is deliberately *separate* from Steps 1–3 —
-don't race ahead into it before the shape is agreed.
+Only once the user (and, where they chose to, the team) is aligned: break the parent into children.
+Write the **goal & verification sub-issue first** (`writing-task-specs`) — the plain-English walkthrough and
+"how to know it's done" checklist. If that can't be written concretely yet, the shape isn't agreed
+enough for this step; go back to Steps 1–3 rather than inventing sub-issues around a fuzzy goal.
+Then break the rest into sub-issues, applying `micro-prs`' one-purpose test and one-app/repo scope to each,
+sequencing them (flat by default, waves only where a real dependency exists — see `writing-task-specs`),
+and respecting the deployment model (small, independently mergeable, revertible). This is deliberately
+*separate* from Steps 1–3 — don't race ahead into it before the shape is agreed.
 
 ## You are the conductor
 

--- a/.claude/skills/reviewing-pull-requests/SKILL.md
+++ b/.claude/skills/reviewing-pull-requests/SKILL.md
@@ -41,7 +41,7 @@ Before reviewing the code itself, make a fast judgment about whether this diff i
 
 Look at:
 
-- **Scope.** Does this change do one thing, or is it touching too many unrelated concerns?
+- **Scope.** Same test as `micro-prs`' one-purpose rule, applied after the fact: does this change do one thing, in one app/package/repo, or is it touching too many unrelated concerns?
 - **Surface area.** How many files? How many distinct changes?
 - **Risk profile.** Auth, data access, database migrations, shared logic in `packages/core` or `packages/ui` that many apps depend on? Or buttons, copy, styling, internal renames?
 - **Coherence.** Is it easy to hold the change in your head, or does it sprawl across the codebase in ways that are hard to reason about?

--- a/.claude/skills/writing-task-specs/SKILL.md
+++ b/.claude/skills/writing-task-specs/SKILL.md
@@ -110,9 +110,9 @@ For a specific, reproducible issue. Direct, short, focused on getting the fix ri
 ### Description structure
 
 ```markdown
-**In plain words**  _(no code, no jargon — anyone can read this)_
+**In plain words**  _(see `plain-english`)_
 
-[2–4 sentences. What a user sees going wrong and why it matters. Round numbers if a figure is off. No file paths, no symbol names, no bare acronyms.]
+[2–4 sentences: what a user sees going wrong and why it matters.]
 
 **Problem**
 
@@ -180,9 +180,9 @@ For a single focused change that maps to one PR. Short spec, no sub-tasks. A sin
 ### Description structure
 
 ```markdown
-**In plain words**  _(no code, no jargon — anyone can read this)_
+**In plain words**  _(see `plain-english`)_
 
-[2–4 sentences. What the user can't do easily today and what they'll be able to do after. Why it's worth building. No file paths, no symbol names, no bare acronyms.]
+[2–4 sentences: what the user can't do easily today, what they'll be able to do after, and why it's worth building.]
 
 **Problem**
 
@@ -371,9 +371,9 @@ A technically broken-down feature with sequenced sub-tasks. This is the *output*
 The parent issue holds the technical scope. It is not worked on directly — its sub-issues do the work. Set this as the parent issue `description` (and, for a heavy domain concept, also create a Linear **document** attached to the app's project — see `product-planning`).
 
 ```markdown
-**In plain words**  _(no code, no jargon — anyone can read this)_
+**In plain words**  _(see `plain-english`)_
 
-[2–4 sentences. What this feature lets a user do that they can't today, and why it matters. The whole thing in plain language before any architecture appears. No file paths, no symbol names, no bare acronyms.]
+[2–4 sentences: what this feature lets a user do that they can't today, and why it matters — before any architecture appears.]
 
 **Context**
 

--- a/.claude/skills/writing-task-specs/SKILL.md
+++ b/.claude/skills/writing-task-specs/SKILL.md
@@ -32,8 +32,25 @@ The fields that an in-repo tracker would keep in frontmatter are native Linear f
 - Match the spec shape to the work — do not force a bug template onto a feature, or vice versa
 - For large features, do the scoping work in conversation with the user before creating the parent issue and sub-issues — do not invent sub-tasks without confirming the breakdown
 - Sub-tasks must respect the deployment model: each one is small, independently mergeable, and revertible
+- **Every sub-task solves exactly one problem** — see `micro-prs`' one-purpose test. If a sub-task's `What` needs an "and", it's two sub-tasks.
+- **Every large feature's first sub-issue is the goal & verification sub-issue** — see below. Write it before any code sub-issue.
 - Always create in the **SWorld** team; attach every issue to the matching app **project** (Til, Watch, Listen, Game, Docs, Main) — a large feature is a parent issue *inside* its app's project, not a project of its own
 - Before starting work on an issue, set its `state` to `In Progress` (see the `parallel-workflow` skill)
+- **Every ticket opens in plain words** — see below. No exceptions.
+
+## Every ticket opens in plain words
+
+Whatever the shape, the **first thing in the description** is a plain-English orientation block — the ticket's five-second answer to "what is this about?" Anyone who opens it — a non-technical tester, a first-week dev, the owner skimming Linear on their phone — must understand what is wrong (or wanted) and why it matters *before* a single file path, symbol name, or domain acronym appears.
+
+The jargon-free law itself (what counts as plain, the ten-second test, worked before/after examples) lives in the `plain-english` skill — load it before writing this block. This skill only owns *where* the block sits and its header per shape:
+
+```markdown
+**In plain words**  _(no code, no jargon — anyone can read this)_
+
+[2–4 sentences. What a user actually experiences going wrong, or wants — and why it matters. If a number is wrong, show it with round numbers. A non-technical reader gets the gist in ten seconds.]
+```
+
+This block is mandatory on the Bug, Small feature, and Large-feature-parent shapes. The **User story** already opens this way — its `**The user's problem**` section *is* the plain-words block, no separate header needed. A **sub-issue** (the small child of a large feature) opens with a one-line `**Why this matters**` instead — same law, just one sentence: what part of the user-facing feature this piece contributes to, so whoever picks it up knows the point without decoding the title or re-reading the parent.
 
 ## The four spec shapes
 
@@ -93,6 +110,10 @@ For a specific, reproducible issue. Direct, short, focused on getting the fix ri
 ### Description structure
 
 ```markdown
+**In plain words**  _(no code, no jargon — anyone can read this)_
+
+[2–4 sentences. What a user sees going wrong and why it matters. Round numbers if a figure is off. No file paths, no symbol names, no bare acronyms.]
+
 **Problem**
 
 [1–3 sentences. What is broken, where, who reported it. Be specific enough that the reader can picture the bug without seeing it.]
@@ -155,6 +176,10 @@ For a single focused change that maps to one PR. Short spec, no sub-tasks. A sin
 ### Description structure
 
 ```markdown
+**In plain words**  _(no code, no jargon — anyone can read this)_
+
+[2–4 sentences. What the user can't do easily today and what they'll be able to do after. Why it's worth building. No file paths, no symbol names, no bare acronyms.]
+
 **Problem**
 
 [What user need or friction this addresses. 1–2 sentences.]
@@ -326,16 +351,22 @@ A technically broken-down feature with sequenced sub-tasks. This is the *output*
 1. **Start from the user story.** Read the user story issue. Understand the problem, the ideas explored, and the open questions.
 2. **Identify the architectural shape.** What systems are touched? Frontend app, `packages/core` hooks, the Hasura layer, the `sworld-backend` Hono service? Is there an existing pattern to follow?
 3. **Resolve the open questions.** The user story's open questions become decisions in the parent issue's description.
-4. **Identify dependencies.** What blocks what? Where can work happen in parallel?
-5. **Map to the deployment model.** Each sub-task must be small, independently mergeable, and revertible. Anything user-facing sits behind a feature flag until ready.
-6. **Group into waves.** A wave is a set of sub-tasks that can be done in parallel — encode it with **blocking relations** (each wave's sub-issues are `blockedBy` the previous wave's). Subsequent waves depend on previous waves landing.
-7. **Confirm with the user** before creating the parent issue and sub-issues. Show the proposed wave structure and dependency graph. Adjust until it's right.
+4. **Write the goal & verification sub-issue first** (see below) — before naming a single code sub-task. If you can't write a concrete walkthrough and "how to know it's done" list yet, the concept isn't settled enough to scope — go back to `product-planning`, don't invent sub-tasks around a fuzzy goal.
+5. **Break into sub-tasks by one-purpose, one-app/repo scope.** Apply `micro-prs`' one-purpose test to each candidate before it becomes a sub-issue — if its `What` needs an "and", or its `Files / scope` spans two apps or two repos, split it now, at scoping time, not after the branch is built.
+6. **Identify real dependencies only.** The default is a flat list of sub-tasks, all startable now — independent work is parallel by default. Only add a `blockedBy` where one sub-task genuinely cannot exist or compile without another's output (a schema/migration change the query layer needs, a shared helper its consumers import, wiring that assembles already-finished pieces). Do not invent an ordering to make the breakdown feel more structured — two sub-tasks that just happen to touch related code are not blocked on each other.
+7. **Group into waves only where step 6 found a real blocker.** A wave is a barrier: everything in wave N must land before wave N+1 starts, which is a real cost — impose it only where earned. If everything is parallel, say so and skip waves and the dependency graph entirely.
+8. **Map to the deployment model.** Each sub-task must be small, independently mergeable, and revertible. Anything user-facing sits behind a feature flag until ready.
+9. **Confirm with the user** before creating the parent issue and sub-issues. Show the proposed breakdown (flat list, or waves if any are real). Adjust until it's right.
 
 ### Parent issue description structure
 
 The parent issue holds the technical scope. It is not worked on directly — its sub-issues do the work. Set this as the parent issue `description` (and, for a heavy domain concept, also create a Linear **document** attached to the app's project — see `product-planning`).
 
 ```markdown
+**In plain words**  _(no code, no jargon — anyone can read this)_
+
+[2–4 sentences. What this feature lets a user do that they can't today, and why it matters. The whole thing in plain language before any architecture appears. No file paths, no symbol names, no bare acronyms.]
+
 **Context**
 
 [Link to the user story issue (SWO-NNN). 1–2 sentences summarising the user need this delivers on. Do not repeat the full user story — link to it.]
@@ -397,13 +428,17 @@ For features involving data models or complex logic, include sections like:
 Each sub-task is one sub-issue under the parent, and a small focused PR. It inherits context from the parent issue — do not repeat the architecture or rationale. Create with `linear issue create --team SWO --project "<app>" --parent SWO-NNN -s "Todo" --estimate N …`, then `linear issue relation add SWO-<new> blocked-by SWO-<dep>` for each dependency.
 
 ```markdown
+**Why this matters**  _(one plain-language line — see `plain-english`)_
+
+[One sentence, no jargon: what part of the user-facing feature this piece contributes to.]
+
 **What**
 
 [1–2 sentences describing the specific change.]
 
 **Files / scope**
 
-[Files or modules touched. Be specific.]
+[Files or modules touched, in this ONE repo/app only — see `micro-prs`. If the list spans two apps or two repos, split the sub-task before creating it.]
 
 **Acceptance criteria**
 
@@ -411,6 +446,48 @@ Each sub-task is one sub-issue under the parent, and a small focused PR. It inhe
 * [Tests pass]
 * [No regression on dependent code]
 ```
+
+**Before creating it, run the one-purpose test** (`micro-prs`): can `What` be said without an "and"? Does `Files / scope` stay inside one app (or one repo, for `sworld-backend`/`sworld-hasura-v2` work)? If either fails, it's two sub-tasks, not one. A common failure shape: a sub-task titled around one piece of work (e.g. "client factory") that quietly also adds an unrelated data-access module, unrelated constants, and a cleanup deletion — each of those is independently nameable in one sentence, which is the tell it should have been three or four sub-tasks instead of one.
+
+### The goal & verification sub-issue — every large feature's first sub-issue
+
+Before any code sub-issue is created, write one sub-issue whose entire job is answering: **"how does anyone — with zero context — know the whole feature works when every sub-issue is done?"** Each sub-issue's own acceptance criteria only proves its own slice; nobody's acceptance criteria proves the assembled feature actually delivers the user story. This sub-issue is that missing check, written before the breakdown so it also doubles as a sanity check on the breakdown itself — if you can't write a concrete verification step, the shape probably isn't settled yet either.
+
+Create it with `linear issue create --team SWO --project "<app>" --parent SWO-NNN -s "Todo" -t "Goal & verification — <feature>" --no-interactive`, first among the sub-issues (no `blockedBy` — nothing needs to finish before this is written, and every other sub-issue may link back to it):
+
+```markdown
+**Why this matters**
+
+This is the checklist for the whole feature, not one slice of it — read it before touching any of the other sub-issues, and use it to confirm the parent is actually done once they've all landed.
+
+**Goal — what "done" looks like**
+
+[Plain-English walkthrough of the feature end-to-end, written as if explaining to someone who has never seen this app. What can a user now do that they couldn't before? No jargon, no file paths — see `plain-english`.]
+
+**User stories**
+
+* As a <who>, I can <what>, so that <why>.
+* [one per distinct user-facing capability the feature delivers]
+
+**Full walkthrough — a fresh dev or non-technical tester can follow this with no other context**
+
+1. [Concrete, click-by-click step]
+2. [Concrete, click-by-click step]
+3. ...
+N. [The observable result that proves it worked]
+
+**How to know the whole feature is done**
+
+* [Observable outcome — something you can see, click, or check, not an implementation detail]
+* [Observable outcome]
+* ...
+
+**Explicitly out of scope**
+
+[What this feature deliberately does NOT do, so review doesn't drift into scope creep]
+```
+
+Mark it `Done` once the user confirms the walkthrough matches their intent — its own deliverable is the spec being right, not code. It then sits as the reference every other sub-issue links back to, and is the actual acceptance test for the parent issue once every sub-issue merges.
 
 ### Sub-task titles
 
@@ -423,9 +500,19 @@ The parent issue gives the context, so the sub-task title can be short:
 
 Do not prefix with `[domain]` or other tags — the parent issue already scopes the work.
 
-### Wave and dependency example
+### Sequencing examples — flat by default, waves only when earned
 
-A worked dependency graph for an `Import notes` parent issue (waves are encoded by `blockedBy` relations between sub-issues):
+Most breakdowns are a flat list — nothing here has a real dependency, so nothing gets a `blockedBy`:
+
+```
+No waves — all startable now:
+  types-only             — new interfaces in packages/core, no implementation
+  ui-shell               — empty dialog + button in apps/til, no wiring yet
+  parser-helper          — pure text→notes parser in packages/core, unit-tested alone
+  hasura-permissions     — read permission for the new table (sworld-hasura-v2, separate repo/PR)
+```
+
+A worked dependency graph for an `Import notes` parent issue where a real blocker exists (waves are encoded by `blockedBy` relations between sub-issues — only imposed because `preview-table` genuinely cannot exist without `parser-helper`'s output shape):
 
 ```
 Wave 0 — Foundations (no blockers):
@@ -439,7 +526,7 @@ Wave 2 — Save:
   save-wiring            — blockedBy: [preview-table]
 ```
 
-Each issue's `blockedBy` lists the issues above it. A sub-task can be *developed* in parallel even when blocked — it just can't merge until its blockers are `Done`.
+Each issue's `blockedBy` lists the issues above it. A sub-task can be *developed* in parallel even when blocked — it just can't merge until its blockers are `Done`. Before writing any `blockedBy`, ask: does this genuinely need the other to exist first, or do they just touch related code? The latter is a file-ownership note to resolve at review, not a blocker.
 
 ## Process
 
@@ -447,9 +534,9 @@ When Claude has been working with the developer and a spec is needed:
 
 1. **Identify the shape** — bug, small feature, user story, or large feature. Ask if unsure.
 2. **For user stories** — focus on capturing the user's problem and ideas in plain language, as an issue in `Backlog`. Do not jump to technical scoping.
-3. **For large features** — run the scoping conversation before creating anything. Confirm the breakdown with the user. If there's an existing user story, start from it.
-4. **Draft the spec** matching the shape's structure. Use the developer's existing context, do not re-investigate things already discussed.
-5. **Create in Linear** — `linear issue create` for a bug / small feature / user story; for a large feature: `linear issue create` for the parent (attached to the app `--project`), then `linear issue create` per sub-task with `--parent`, `--project`, and `--estimate` set, plus `linear issue relation add … blocked-by …` for dependencies. For a heavy domain concept, add a `linear document create --project "<app>" -t "…" -f <doc.md>`.
+3. **For large features** — run the scoping conversation before creating anything, including the goal & verification sub-issue's content. Confirm the breakdown with the user. If there's an existing user story, start from it.
+4. **Draft the spec** matching the shape's structure, applying `plain-english` to its opening block. Use the developer's existing context, do not re-investigate things already discussed.
+5. **Create in Linear** — `linear issue create` for a bug / small feature / user story; for a large feature: `linear issue create` for the parent (attached to the app `--project`), then the goal & verification sub-issue first, then `linear issue create` per code sub-task with `--parent`, `--project`, and `--estimate` set, plus `linear issue relation add … blocked-by …` only where step 6 of the scoping conversation found a real dependency. For a heavy domain concept, add a `linear document create --project "<app>" -t "…" -f <doc.md>`.
 6. **Confirm to the user** what was created, with the issue identifiers and URLs.
 
 ## Validation checklist
@@ -460,11 +547,12 @@ Before creating a spec:
 - Created in the **SWorld** team and attached to the right app **project**
 - Shape matches the work (bug / small feature / user story / large feature)
 - Detail level matches the shape — not over-documented, not under-documented
+- Opens with the `plain-english` block (`**In plain words**`, `**Why this matters**`, or the user story's own opening section) — no exceptions
 - Linear fields set: `--state`, plus `--estimate` / `--label` / `--parent` / blocked-by relations where relevant
 - For bugs: `bug` label; problem, root cause (or note that it's unknown), solution (if known), acceptance criteria
 - For small features: problem, proposed solution, acceptance criteria
 - For user stories: `state: Backlog`, user problem front and centre, ideas explored but no technical spec, open questions listed honestly
-- For large features: scoping conversation done, parent issue description has architecture + wave breakdown, sub-issues are small and revertible, `blockedBy` wiring matches the dependency graph and encodes the waves, links back to the user story issue if one exists
+- For large features: scoping conversation done, goal & verification sub-issue created first, every code sub-task passes the one-purpose test (`micro-prs`) and stays inside one app/repo, `blockedBy` wiring reflects only real dependencies (flat list is the default, not a gap), links back to the user story issue if one exists
 - UK English throughout
 - No AI attribution
 

--- a/.claude/skills/writing-task-specs/SKILL.md
+++ b/.claude/skills/writing-task-specs/SKILL.md
@@ -138,6 +138,10 @@ For a specific, reproducible issue. Direct, short, focused on getting the fix ri
 Created with `linear issue create --team SWO --project "Main" -l bug -s "Todo" --estimate 1 -t "Library reading progress bar loses its label on long books" --description-file <spec.md> --no-interactive` (library is a feature area of the main app), where the description file holds:
 
 ```markdown
+**In plain words**
+
+In the Main app's library, reading a long book loses the progress bar partway through — once you scroll past the first few chapters, the bar that shows your current chapter and how far through the book you are just disappears. You can keep reading, but you lose track of where you are.
+
 **Problem**
 
 When a book in the library app has many chapters, scrolling down to the chapters at the bottom of the reader loses the sticky progress bar that shows current chapter and percentage. The reader can't tell how far through the book they are, making it hard to resume.
@@ -199,6 +203,10 @@ For a single focused change that maps to one PR. Short spec, no sub-tasks. A sin
 `linear issue create --team SWO --project "Listen" -s "Todo" --estimate 4 -t "Add bulk import for listen playlist tracks" --description-file <spec.md> --no-interactive`, description:
 
 ```markdown
+**In plain words**
+
+Building a playlist in the Listen app means adding tracks one at a time, even if you already have a list of 15+ songs written down somewhere. This adds a way to paste that whole list in at once instead of typing each track by hand.
+
 **Problem**
 
 Users building a playlist in the listen app have to add each track individually, which is slow when working from a tracklist they already have written down (15+ tracks).
@@ -389,7 +397,15 @@ For features involving data models or complex logic, include sections like:
 | Sequential total | Xh |
 | Parallel total (critical path) | Xh |
 
-**Waves & sub-tasks (N total)**
+**Sub-tasks (N total)**
+
+Flat by default — one table, no waves, when nothing has a real dependency (the common case, see "Sequencing examples" below):
+
+| Sub-task | Work | Est |
+|----------|------|-----|
+| <title> | <description> | Xh |
+
+Only when a real dependency exists, group into waves instead and add a **Dependency graph** section (a text diagram of what blocks what — see "Sequencing examples" below):
 
 **Wave 0 — [Wave name]**
 
@@ -400,10 +416,6 @@ For features involving data models or complex logic, include sections like:
 **Wave 1 — [Wave name]**
 
 [... same table format, blocked-by references earlier sub-tasks]
-
-**Dependency graph**
-
-[Text-based diagram showing what blocks what]
 
 **Verification**
 
@@ -504,7 +516,7 @@ Do not prefix with `[domain]` or other tags — the parent issue already scopes 
 
 Most breakdowns are a flat list — nothing here has a real dependency, so nothing gets a `blockedBy`:
 
-```
+```text
 No waves — all startable now:
   types-only             — new interfaces in packages/core, no implementation
   ui-shell               — empty dialog + button in apps/til, no wiring yet
@@ -514,7 +526,7 @@ No waves — all startable now:
 
 A worked dependency graph for an `Import notes` parent issue where a real blocker exists (waves are encoded by `blockedBy` relations between sub-issues — only imposed because `preview-table` genuinely cannot exist without `parser-helper`'s output shape):
 
-```
+```text
 Wave 0 — Foundations (no blockers):
   parser-helper          — pure text→notes parser in packages/core
   import-dialog-shell    — empty dialog + button in apps/til

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ When work spans the backend or schema, the change lands in those repos, not here
 **Skills** (`.claude/skills/`) — task-triggered conventions. They fire automatically, but reach for them deliberately too:
 
 - _Code:_ `code-conventions`, `react`, `mui`, `architecture`, `mutation-data-flow`, `error-handling`, `e2e-testing`, `design-principles`
-- _Workflow:_ `parallel-workflow`, `micro-prs`, `pr-descriptions`, `writing-task-specs`, `reviewing-pull-requests`, `product-planning`
+- _Workflow:_ `parallel-workflow`, `micro-prs`, `pr-descriptions`, `writing-task-specs`, `reviewing-pull-requests`, `product-planning`, `plain-english`
 - _Meta / quality:_ `grill-me`, `skill-creator`, `thermo-nuclear-code-quality-review`, `security-reviewer`, `supply-chain-security`
 - _Architecture:_ `backend-architecture`
 - _Ops:_ `backend-ops`, `dev-environment-gotchas`


### PR DESCRIPTION
## Summary

No user-facing changes. Tightens the task-breakdown skills so every ticket opens with a jargon-free summary, every large feature gets a dedicated goal/verification sub-issue written before any code sub-task, and every sub-task passes a one-purpose, one-app/repo test. Extracts the jargon-free writing rule into a new `plain-english` skill (referenced by `writing-task-specs` and `pr-descriptions` instead of each keeping its own copy) and points `reviewing-pull-requests`' scope check at `micro-prs`' one-purpose rule instead of restating it. SWO-500.

## Test plan

- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved guidance for writing clear, reader-friendly project descriptions, task specifications, pull request summaries, and test plans.
  - Added consistent plain-language openings that explain the value and expected outcome without technical jargon.
  - Clarified how to split work into focused, independently deliverable tasks.
  - Added stronger guidance for sequencing work, identifying true blockers, and verifying goals early.
  - Updated review and planning guidance to reinforce focused scope, clear acceptance criteria, and straightforward explanations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->