### PR TITLE
docs(skills): add hasura-architecture skill

### DIFF
--- a/.claude/skills/hasura-architecture/SKILL.md
+++ b/.claude/skills/hasura-architecture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hasura-architecture
-description: Cross-cutting Hasura/database-layer principles — the single-gateway rule (nothing talks to Postgres except Hasura), when a write needs a database-level concurrency-safe pattern versus a plain read-then-write, and the three layers that validate data. Auto-triggers when designing a new mutation/Action, touching `sworld-hasura-v2` metadata, deciding how a write should be structured, or reasoning about concurrent writes or data validation. Complements `architecture` (frontend query/transformer conventions) and `backend-architecture` (the Cloud Run/Cloud Task service pipeline) — this skill owns only the database-layer decisions neither of those covers.
+description: Cross-cutting Hasura/database-layer principles — the single-gateway rule (nothing talks to Postgres except Hasura), when a write needs a database-level concurrency-safe pattern versus a plain read-then-write, and the three layers that validate data. Auto-triggers when designing a new mutation/Action, deciding how a write should be structured, or reasoning about concurrent writes or data validation. Complements `architecture` (frontend query/transformer conventions) and `backend-architecture` (the Cloud Run/Cloud Task service pipeline) — this skill owns only the database-layer decisions neither of those covers.
 user-invocable: false
 ---
 
@@ -10,11 +10,13 @@ sworld's data layer has one non-negotiable shape: **Hasura is the only thing tha
 
 ## The single-gateway rule
 
-No service, no frontend app, no script talks to Postgres directly. `sworld-backend` (Hono) reaches the database exclusively through Hasura's GraphQL API — same as the frontend. There is no direct Postgres client, no ORM, no raw connection string anywhere in application code.
+No service, no frontend app, no script talks to Postgres directly. The Hono backend reaches the database exclusively through Hasura's GraphQL API — same as the frontend. There is no direct Postgres client, no ORM, no raw connection string anywhere in application code.
 
-Human/ops access follows the same rule: **use the Hasura Console, never a direct SQL client (psql, a Neon console, etc.).** The Console is still a client of Hasura — it reaches Postgres through Hasura's own connection, not around it. The one nuance worth remembering: the Console's "Run SQL" tab executes raw SQL through Hasura's admin API, which bypasses Hasura's own permission and validation layer even though the connection itself is still Hasura-mediated. Fine for migrations; don't reach for it as a way to route around a permission or validation rule you'd otherwise have to build properly.
+Human/ops access follows the same rule: **use the Hasura Console, never a direct SQL client (psql, a database provider's console, etc.).** The Console is still a client of Hasura — it reaches Postgres through Hasura's own connection, not around it. The one nuance worth remembering: the Console's "Run SQL" tab executes raw SQL through Hasura's admin API, which bypasses Hasura's own permission and validation layer even though the connection itself is still Hasura-mediated. Fine for migrations; don't reach for it as a way to route around a permission or validation rule you'd otherwise have to build properly.
 
 **Why:** one gateway means one place that enforces permissions, one place that validates input, one schema that's ever out of sync with reality. A direct connection anywhere — even "just for this one ops task" — creates a second path that Hasura's rules don't cover.
+
+**Deployment:** we run Hasura Cloud. Metadata and migrations deploy automatically when they merge into `main` — there is no separate manual "apply" step. Treat a merge as a live schema change.
 
 ## Writes: default is fine, until two things can race
 
@@ -32,55 +34,48 @@ Classic lost-update: two clients read the same counter, each computes `current +
 mutation { update_videos(where: {...}, _inc: {view_count: 1}) { affected_rows } }
 ```
 
-Available and codegen'd for every numeric column (e.g. `videos.view_count`) — **but not actually called anywhere today**; any counter increment currently in the codebase would need auditing to confirm it isn't doing a read-then-write instead.
-
 Reach for optimistic concurrency instead — filter the mutation's `where` on a value you already read (e.g. `updated_at: {_eq: <value you saw>}`) — only when the change genuinely isn't expressible as a delta (a full-object replace where you need to detect "did anything change since I read this").
 
 ### Race 2 — two writers both try to be "the one that creates X"
 
-Two concurrent requests both check "does this task/record already exist?" and both decide to create it, because the check and the create aren't atomic together.
+Two concurrent requests both check "does this record already exist?" and both decide to create it, because the check and the create aren't atomic together.
 
 **Fix: a unique constraint plus Hasura's `on_conflict`.** `INSERT ... ON CONFLICT` is one Postgres statement — the existence check and the write happen atomically, with no gap between them for a second writer to land in.
 
-This is already shipped, not theoretical — `sworld-backend`'s task creation (`src/services/hasura/mutations/tasks/index.ts`) does exactly this:
-
 ```graphql
-mutation CreateTask($object: tasks_insert_input!) {
-  insert_tasks_one(
+mutation CreateThing($object: things_insert_input!) {
+  insert_things_one(
     object: $object
-    on_conflict: { constraint: tasks_task_id_key, update_columns: [task_id] }
+    on_conflict: { constraint: things_natural_key, update_columns: [natural_key] }
   ) {
     id
-    task_id
-    status
-    completed
   }
 }
 ```
 
-`update_columns: [task_id]` looks like a no-op — it re-sets the column to its own value — but it's deliberate: it forces Postgres onto the `DO UPDATE` path instead of `DO NOTHING`, which is the only way `returning` gives back the *existing* row (including `completed`) on conflict. `DO NOTHING` would return null instead, and the caller (`createCloudTasks`) needs that existing row to short-circuit an already-completed task instead of re-enqueuing it.
+`update_columns: [natural_key]` looks like a no-op — it re-sets the column to its own value — but it can be deliberate: it forces Postgres onto the `DO UPDATE` path instead of `DO NOTHING`, which is the only way `returning` gives back the *existing* row on conflict. `DO NOTHING` returns null instead. Use it when the caller needs the existing row (e.g. to short-circuit work that's already been done); use `DO NOTHING` when it only needs the insert to be idempotent.
 
 ### The gap this closes: Actions don't get free atomicity across their own calls
 
-A Hasura Action's Hono handler making its own query call and then its own separate mutation call is **two independent HTTP requests** — Hasura's transaction guarantee (below) does not span them. If the write in that handler needs Race 1 or Race 2 protection, the handler must use `_inc`/optimistic concurrency/`on_conflict` itself — issuing a query then a mutation does not make the pair atomic just because they're both Hasura calls.
+A Hasura Action's handler making its own query call and then its own separate mutation call is **two independent HTTP requests** — Hasura's transaction guarantee (below) does not span them. If the write in that handler needs Race 1 or Race 2 protection, the handler must use `_inc`/optimistic concurrency/`on_conflict` itself — issuing a query then a mutation does not make the pair atomic just because they're both Hasura calls.
 
 ### What Hasura's transaction guarantee actually covers
 
-Multiple **mutation fields inside one mutation request** run sequentially in a single Postgres transaction — if any fails, everything in that request rolls back. This is real and already in use: `finishVideoProcess` (`backend-architecture`) updates the `tasks` row, inserts a `notifications` row, and updates the `videos` row as one mutation — all-or-nothing.
+Multiple **mutation fields inside one mutation request** run sequentially in a single Postgres transaction — if any fails, everything in that request rolls back. So a single mutation that, say, updates a task row, inserts a notification row, and updates the target row is genuinely all-or-nothing.
 
 **The gap:** if a request mixes an **Action or Remote Schema** with direct table mutations, the rollback guarantee does not extend to the Action/Remote Schema call — only the plain table mutations are transactional together. Don't rely on "it's all in one Hasura request" to make an Action-plus-table-write combination atomic; it isn't.
 
 ### For logic too complex for any of the above
 
-A custom Postgres function (invoked as a custom mutation) that does the whole read-decide-write inside one Postgres transaction is the only way to get true atomicity for logic more complex than a delta or an upsert. `sworld-hasura-v2` has none today — reach for this only when `_inc`/`on_conflict`/optimistic concurrency genuinely can't express the logic, not as a default.
+A custom Postgres function (invoked as a custom mutation) that does the whole read-decide-write inside one Postgres transaction is the only way to get true atomicity for logic more complex than a delta or an upsert. Reach for this only when `_inc`/`on_conflict`/optimistic concurrency genuinely can't express the logic, not as a default.
 
 ## Validation: three layers, not one
 
 Authorization (row ownership — `user_id = X-Hasura-User-Id` in a permission's `check`/`filter`) is a **different concern** from data validity. Keep them separate: permissions decide *who* can touch a row; the layers below decide whether the *data* is valid regardless of who's writing it.
 
-1. **Database schema constraints** — types, `NOT NULL`, `CHECK`, foreign keys, unique constraints. The floor, always enforced, no round-trip cost. Already in use: `finance_transactions` has `CHECK (amount > 0)`.
-2. **Hasura's `validate_input`** — for plain, auto-generated CRUD mutations (insert/update/delete) that need a business rule the schema can't express. Configured per role, per operation, inside that role's permission block; routes the mutation's input to an HTTP webhook *before* the Postgres transaction starts. Available since Hasura v2.29.0 (this project runs v2.48.0) — **not used anywhere in `sworld-hasura-v2` today.** Adds webhook latency to every mutation it's attached to, so add it deliberately per table/role rather than by default.
-3. **Application-layer validation inside an Action's handler** — for writes that already go through a custom Hono handler (an Action), rather than auto-generated CRUD. The handler is already in the request path, so validation just lives in its own code.
+1. **Database schema constraints** — types, `NOT NULL`, `CHECK`, foreign keys, unique constraints. The floor, always enforced, no round-trip cost. A rule like "an amount must be positive" belongs here as a `CHECK` before anything higher up.
+2. **Hasura's `validate_input`** — for plain, auto-generated CRUD mutations (insert/update/delete) that need a business rule the schema can't express. Configured per role, per operation, inside that role's permission block; routes the mutation's input to an HTTP webhook *before* the Postgres transaction starts. Adds webhook latency to every mutation it's attached to, so add it deliberately per table/role rather than by default.
+3. **Application-layer validation inside an Action's handler** — for writes that already go through a custom handler (an Action), rather than auto-generated CRUD. The handler is already in the request path, so validation just lives in its own code.
 
 Match the layer to how the write happens: plain CRUD with a rule the schema can't express → `validate_input`. Already-custom-handler writes → validate in that handler. Everything → schema constraints as the baseline regardless.
 

--- a/.claude/skills/hasura-architecture/SKILL.md
+++ b/.claude/skills/hasura-architecture/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: hasura-architecture
+description: Cross-cutting Hasura/database-layer principles — the single-gateway rule (nothing talks to Postgres except Hasura), when a write needs a database-level concurrency-safe pattern versus a plain read-then-write, and the three layers that validate data. Auto-triggers when designing a new mutation/Action, touching `sworld-hasura-v2` metadata, deciding how a write should be structured, or reasoning about concurrent writes or data validation. Complements `architecture` (frontend query/transformer conventions) and `backend-architecture` (the Cloud Run/Cloud Task service pipeline) — this skill owns only the database-layer decisions neither of those covers.
+user-invocable: false
+---
+
+# Hasura Architecture
+
+sworld's data layer has one non-negotiable shape: **Hasura is the only thing that ever talks to Postgres.** Everything else in this skill is about using Hasura's own tools correctly once you're inside that boundary — when a write needs real concurrency-safety, and what actually validates data before it lands.
+
+## The single-gateway rule
+
+No service, no frontend app, no script talks to Postgres directly. `sworld-backend` (Hono) reaches the database exclusively through Hasura's GraphQL API — same as the frontend. There is no direct Postgres client, no ORM, no raw connection string anywhere in application code.
+
+Human/ops access follows the same rule: **use the Hasura Console, never a direct SQL client (psql, a Neon console, etc.).** The Console is still a client of Hasura — it reaches Postgres through Hasura's own connection, not around it. The one nuance worth remembering: the Console's "Run SQL" tab executes raw SQL through Hasura's admin API, which bypasses Hasura's own permission and validation layer even though the connection itself is still Hasura-mediated. Fine for migrations; don't reach for it as a way to route around a permission or validation rule you'd otherwise have to build properly.
+
+**Why:** one gateway means one place that enforces permissions, one place that validates input, one schema that's ever out of sync with reality. A direct connection anywhere — even "just for this one ops task" — creates a second path that Hasura's rules don't cover.
+
+## Writes: default is fine, until two things can race
+
+**Default pattern: one query to fetch what you need, manipulate, one mutation to persist it.** This is correct and sufficient for the overwhelming majority of writes — a user editing their own single row has no real contention to guard against.
+
+This stops being sufficient specifically when **two writers can race for the same outcome** — not because "atomic" is a box to check on every write. Two concrete race shapes come up, each with its own Hasura-native fix:
+
+### Race 1 — two writers compute the same "next value"
+
+Classic lost-update: two clients read the same counter, each computes `current + delta` locally, and whichever writes last wins — the other's change is silently gone.
+
+**Fix: send the delta, not the computed value.** Hasura's `_inc` (numeric columns) and the JSONB operators (`_append`, `_prepend`, `_delete_key`, etc.) apply the change atomically inside Postgres — there's no client-side "read the current value" step to race on at all.
+
+```graphql
+mutation { update_videos(where: {...}, _inc: {view_count: 1}) { affected_rows } }
+```
+
+Available and codegen'd for every numeric column (e.g. `videos.view_count`) — **but not actually called anywhere today**; any counter increment currently in the codebase would need auditing to confirm it isn't doing a read-then-write instead.
+
+Reach for optimistic concurrency instead — filter the mutation's `where` on a value you already read (e.g. `updated_at: {_eq: <value you saw>}`) — only when the change genuinely isn't expressible as a delta (a full-object replace where you need to detect "did anything change since I read this").
+
+### Race 2 — two writers both try to be "the one that creates X"
+
+Two concurrent requests both check "does this task/record already exist?" and both decide to create it, because the check and the create aren't atomic together.
+
+**Fix: a unique constraint plus Hasura's `on_conflict`.** `INSERT ... ON CONFLICT` is one Postgres statement — the existence check and the write happen atomically, with no gap between them for a second writer to land in.
+
+This is already shipped, not theoretical — `sworld-backend`'s task creation (`src/services/hasura/mutations/tasks/index.ts`) does exactly this:
+
+```graphql
+mutation CreateTask($object: tasks_insert_input!) {
+  insert_tasks_one(
+    object: $object
+    on_conflict: { constraint: tasks_task_id_key, update_columns: [task_id] }
+  ) {
+    id
+    task_id
+    status
+    completed
+  }
+}
+```
+
+`update_columns: [task_id]` looks like a no-op — it re-sets the column to its own value — but it's deliberate: it forces Postgres onto the `DO UPDATE` path instead of `DO NOTHING`, which is the only way `returning` gives back the *existing* row (including `completed`) on conflict. `DO NOTHING` would return null instead, and the caller (`createCloudTasks`) needs that existing row to short-circuit an already-completed task instead of re-enqueuing it.
+
+### The gap this closes: Actions don't get free atomicity across their own calls
+
+A Hasura Action's Hono handler making its own query call and then its own separate mutation call is **two independent HTTP requests** — Hasura's transaction guarantee (below) does not span them. If the write in that handler needs Race 1 or Race 2 protection, the handler must use `_inc`/optimistic concurrency/`on_conflict` itself — issuing a query then a mutation does not make the pair atomic just because they're both Hasura calls.
+
+### What Hasura's transaction guarantee actually covers
+
+Multiple **mutation fields inside one mutation request** run sequentially in a single Postgres transaction — if any fails, everything in that request rolls back. This is real and already in use: `finishVideoProcess` (`backend-architecture`) updates the `tasks` row, inserts a `notifications` row, and updates the `videos` row as one mutation — all-or-nothing.
+
+**The gap:** if a request mixes an **Action or Remote Schema** with direct table mutations, the rollback guarantee does not extend to the Action/Remote Schema call — only the plain table mutations are transactional together. Don't rely on "it's all in one Hasura request" to make an Action-plus-table-write combination atomic; it isn't.
+
+### For logic too complex for any of the above
+
+A custom Postgres function (invoked as a custom mutation) that does the whole read-decide-write inside one Postgres transaction is the only way to get true atomicity for logic more complex than a delta or an upsert. `sworld-hasura-v2` has none today — reach for this only when `_inc`/`on_conflict`/optimistic concurrency genuinely can't express the logic, not as a default.
+
+## Validation: three layers, not one
+
+Authorization (row ownership — `user_id = X-Hasura-User-Id` in a permission's `check`/`filter`) is a **different concern** from data validity. Keep them separate: permissions decide *who* can touch a row; the layers below decide whether the *data* is valid regardless of who's writing it.
+
+1. **Database schema constraints** — types, `NOT NULL`, `CHECK`, foreign keys, unique constraints. The floor, always enforced, no round-trip cost. Already in use: `finance_transactions` has `CHECK (amount > 0)`.
+2. **Hasura's `validate_input`** — for plain, auto-generated CRUD mutations (insert/update/delete) that need a business rule the schema can't express. Configured per role, per operation, inside that role's permission block; routes the mutation's input to an HTTP webhook *before* the Postgres transaction starts. Available since Hasura v2.29.0 (this project runs v2.48.0) — **not used anywhere in `sworld-hasura-v2` today.** Adds webhook latency to every mutation it's attached to, so add it deliberately per table/role rather than by default.
+3. **Application-layer validation inside an Action's handler** — for writes that already go through a custom Hono handler (an Action), rather than auto-generated CRUD. The handler is already in the request path, so validation just lives in its own code.
+
+Match the layer to how the write happens: plain CRUD with a rule the schema can't express → `validate_input`. Already-custom-handler writes → validate in that handler. Everything → schema constraints as the baseline regardless.
+
+## What this skill does NOT cover
+
+- Frontend query/transformer conventions (one page = one query = one transformer, react-query) — see `architecture`.
+- The Cloud Run service topology, Cloud Task lifecycle, Events vs Actions routing — see `backend-architecture`.
+- Frontend mutation payload-building — see `mutation-data-flow`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ When work spans the backend or schema, the change lands in those repos, not here
 - _Code:_ `code-conventions`, `react`, `mui`, `architecture`, `mutation-data-flow`, `error-handling`, `e2e-testing`, `design-principles`
 - _Workflow:_ `parallel-workflow`, `micro-prs`, `pr-descriptions`, `writing-task-specs`, `reviewing-pull-requests`, `product-planning`, `plain-english`
 - _Meta / quality:_ `grill-me`, `skill-creator`, `thermo-nuclear-code-quality-review`, `security-reviewer`, `supply-chain-security`
-- _Architecture:_ `backend-architecture`
+- _Architecture:_ `hasura-architecture`, `backend-architecture`
 - _Ops:_ `backend-ops`, `dev-environment-gotchas`
 
 **Tasks & requirements** — the source of truth for work is **Linear** (team **SWorld**, key `SWO`). A **project is an app** (Til, Watch, Listen, Game, Docs, Main — Main covers the main app's finance, journal, and library areas) — every issue belongs to one. Bugs and small features are single issues; a large feature is a **parent issue** (with sub-issues) inside the app's project, its description + a Linear document holding the spec, with blocking relations encoding the dependency waves. Status lives in the issue state (`Backlog → Todo → In Progress → In Review → Done`). See the `writing-task-specs` skill for how to author them and `parallel-workflow` for how state moves as work ships.
@@ -124,6 +124,7 @@ cd packages/ui   && pnpm storybook # Component development
 ## Common Workflows
 
 - **Before any work touching sworld-backend or sworld-hasura-v2** — load the `backend-architecture` skill. It documents the full service architecture, Cloud Task pipeline, task lifecycle, notification flow, and event vs action patterns. Do not reason about the backend without it.
+- **Before designing a new mutation/Action, or reasoning about concurrent writes or data validation** — load the `hasura-architecture` skill. It covers the single-gateway rule, when a write needs a concurrency-safe database pattern, and the three validation layers.
 - **Code exploration — always use CodeGraph first, not grep.** The CodeGraph index at the workspace root covers all three repos. Use `codegraph query` for structural questions (definitions, callers, impact). Use grep **only** for literal string/text searches, never for finding where a symbol is defined or used.
 - **Adding a feature** — identify which app(s) change; decide whether shared logic belongs in `core` or `ui`; run the relevant `dev:*` command; make changes; run `pnpm lint` and `pnpm test` before committing.
 - **Working with GraphQL** — update operations in `packages/core`, run `pnpm codegen`, use the generated types in apps.


### PR DESCRIPTION
## Summary

No user-facing changes. Adds a `hasura-architecture` skill capturing sworld's data-layer principles: Hasura as the single gateway to Postgres, when a write needs a concurrency-safe database pattern (`_inc`/JSONB ops, `on_conflict`) versus a plain read-then-write, and the three layers that validate data. Registers it in `AGENTS.md` alongside `backend-architecture`. SWO-505.

## Test plan

- [x] Skill file renders correctly and frontmatter is valid (`name`, `description`, `user-invocable: false`)
- [x] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for Hasura and database architecture, including safe concurrent-write patterns, transaction boundaries, and validation layers.
  * Documented standards for creating mutations and Actions while avoiding direct database access.
  * Updated project guidance to require reviewing the architecture documentation when designing mutations, Actions, or validation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->