### PR TITLE
[WIP] chore(claude): block writes to the main worktree via PreToolUse hook

### DIFF
--- a/.claude/hooks/blockMainWorktreeWrites.sh
+++ b/.claude/hooks/blockMainWorktreeWrites.sh
@@ -25,21 +25,21 @@ file_path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // .tool_input.n
 target=$file_path
 hops=0
 while [ -L "$target" ] && [ "$hops" -lt 40 ]; do
-  link=$(readlink "$target")
+  link=$(readlink -- "$target")
   case "$link" in
     /*) target=$link ;;
-    *) target=$(dirname "$target")/$link ;;
+    *) target=$(dirname -- "$target")/$link ;;
   esac
   hops=$((hops + 1))
 done
 
 # The file may not exist yet, so resolve from its nearest existing ancestor,
 # and resolve that physically so a symlinked directory can't disguise it either.
-dir=$(dirname "$target")
+dir=$(dirname -- "$target")
 while [ ! -d "$dir" ] && [ "$dir" != "/" ] && [ "$dir" != "." ]; do
-  dir=$(dirname "$dir")
+  dir=$(dirname -- "$dir")
 done
-dir=$(cd "$dir" 2>/dev/null && pwd -P) || exit 0
+dir=$(cd -- "$dir" 2>/dev/null && pwd -P) || exit 0
 
 # Outside a git repo (scratchpad, ~/.claude, /tmp) — allow.
 git_dir=$(git -C "$dir" rev-parse --absolute-git-dir 2>/dev/null) || exit 0

--- a/.claude/hooks/blockMainWorktreeWrites.sh
+++ b/.claude/hooks/blockMainWorktreeWrites.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Blocks file writes to a repo's main worktree, unconditionally — the main
+# worktree of every repo in this workspace must only ever hold `main`, never
+# feature work (see .claude/skills/parallel-workflow: "NEVER create branches or
+# make changes in the main worktree"). Unlike the branch-aware variants elsewhere,
+# there is no "a branch is deliberately checked out here" exception: any write to
+# a main worktree is the accident this guards against.
+#
+# A linked worktree's git dir (.git/worktrees/<name>) differs from its common dir
+# (.git); in the main worktree the two are identical. That is the whole worktree
+# test, so no machine-specific paths are needed. Paths outside any repo are left
+# alone — this is portable across all three repos and any clone.
+
+set -uo pipefail
+
+input=$(cat)
+# Edit/Write use file_path; NotebookEdit uses notebook_path.
+file_path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // .tool_input.notebook_path // empty')
+
+# No path to check (or not a file tool) — nothing to gate.
+[ -n "$file_path" ] || exit 0
+
+# Follow symlinks before classifying: a symlink inside a linked worktree can
+# point at a file in the main worktree, and the editing tool writes through it.
+target=$file_path
+hops=0
+while [ -L "$target" ] && [ "$hops" -lt 40 ]; do
+  link=$(readlink "$target")
+  case "$link" in
+    /*) target=$link ;;
+    *) target=$(dirname "$target")/$link ;;
+  esac
+  hops=$((hops + 1))
+done
+
+# The file may not exist yet, so resolve from its nearest existing ancestor,
+# and resolve that physically so a symlinked directory can't disguise it either.
+dir=$(dirname "$target")
+while [ ! -d "$dir" ] && [ "$dir" != "/" ] && [ "$dir" != "." ]; do
+  dir=$(dirname "$dir")
+done
+dir=$(cd "$dir" 2>/dev/null && pwd -P) || exit 0
+
+# Outside a git repo (scratchpad, ~/.claude, /tmp) — allow.
+git_dir=$(git -C "$dir" rev-parse --absolute-git-dir 2>/dev/null) || exit 0
+common_dir=$(git -C "$dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || exit 0
+
+# Linked worktree (git dir differs from common dir) — this is where work belongs,
+# so allow. Anything else is a main worktree and is blocked below.
+[ "$git_dir" = "$common_dir" ] || exit 0
+
+toplevel=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null)
+
+resolved_note=""
+[ "$target" = "$file_path" ] || resolved_note="
+  (via symlink, resolves to $target)"
+
+cat >&2 <<EOF
+Blocked: this writes to the main worktree ($toplevel), which must only ever hold main.
+
+  $file_path$resolved_note
+
+All work happens in a linked worktree — the main worktree is never edited, whatever
+branch it currently sits on. To do this work, use a worktree (see the
+parallel-workflow skill):
+  1. Make sure a Linear issue exists for this work.
+  2. git -C $toplevel fetch origin main
+  3. git -C $toplevel worktree add -b swo-NNN-<slug> .claude/worktrees/swo-NNN-<slug> origin/main
+  4. Re-run this edit against the path inside that worktree.
+
+This hook gates the Edit, Write and NotebookEdit tools. Reading the main worktree
+is fine, as is advancing it with: git -C $toplevel pull --ff-only origin main
+EOF
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/blockMainWorktreeWrites.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Makes the "never make changes in the main worktree" rule (from the `parallel-workflow` skill) mechanical instead of advisory. Adds a checked-in `PreToolUse(Edit|Write|NotebookEdit)` hook that blocks any file write resolving to a repo's **main worktree**, and wires it in `.claude/settings.json`.

- **Unconditional** — the main worktree must only ever hold `main`, so there's no branch-based exception (unlike branch-aware variants elsewhere). Any write to a main worktree is the accident this guards against.
- Detection is pure git (`main worktree = git dir equals common dir`), so the single script guards this repo with no machine-specific paths and works from any clone.
- **Reads and `git pull --ff-only` on the main worktree are untouched** — only Edit/Write/NotebookEdit are gated.

Part of SWO-504 (companion PRs add the identical hook to the other two repos). Note: this checked-in `settings.json` fires when a session is started **inside this repo**; the daily multi-repo workspace session is covered by a separate machine-local wiring (the workspace root isn't a git repo, so that piece can't be checked in).

SWO-504

## Test plan

Verified by piping simulated tool inputs to the hook:

- Write to a path in the **main worktree** → blocked (exit 2) with a guidance message, regardless of the branch checked out there.
- Write to a path in a **linked worktree** (`.claude/worktrees/...`) → allowed.
- `NotebookEdit` path key → same handling.
- Symlink inside a linked worktree pointing at a main-worktree file → blocked (follows the symlink).
- Path outside any git repo (scratchpad) / empty input → allowed.
- `settings.json` is valid JSON and Biome-compliant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safeguards that prevent edits to a repository’s main worktree.
  * Edits remain available in linked worktrees and non-repository locations.
  * Applies protection to file, notebook, and other write operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->