### PR TITLE
docs(skills): canonical frontend-ui-architecture skill + wire references

### DIFF
--- a/.claude/skills/architecture/SKILL.md
+++ b/.claude/skills/architecture/SKILL.md
@@ -6,6 +6,8 @@ user-invocable: false
 
 # Architecture Rules
 
+This skill covers the **data path** — how server data is fetched, transformed, and consumed. For **where** frontend code lives — which package and folder new code belongs in — see `frontend-ui-architecture`. Placement is that skill's job; data flow is this one's.
+
 ## Server state management
 
 - Server state MUST always be managed by **react-query** (TanStack Query).

--- a/.claude/skills/frontend-ui-architecture/SKILL.md
+++ b/.claude/skills/frontend-ui-architecture/SKILL.md
@@ -10,7 +10,7 @@ Two rules decide **WHERE** frontend code lives. They are the most load-bearing s
 
 - `mui` — HOW a component is styled once it's in the right place (global=theme vs situational=`sx`).
 - `architecture` — the data path (one page = one query = one transformer).
-- `writing-task-specs` / `micro-prs` — a sub-task is one app/package; placement follows the rules below.
+- `writing-task-specs` — a sub-task is one app/package; placement follows the rules below.
 - `reviewing-pull-requests` — review checks code landed in the right package/folder.
 
 This skill is only about **where**. For **how** to style, see `mui`.

--- a/.claude/skills/frontend-ui-architecture/SKILL.md
+++ b/.claude/skills/frontend-ui-architecture/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: frontend-ui-architecture
+description: The load-bearing rule for WHERE frontend code lives — packages/ui is the single source of truth for all UI, and the universal-vs-site folder split governs both ui and core. Auto-triggers when creating or placing a component, deciding which package or folder new frontend code belongs in, adding app-local styles, importing from @mui/material inside an app, or reviewing where code landed.
+user-invocable: false
+---
+
+# Frontend UI Architecture
+
+Two rules decide **WHERE** frontend code lives. They are the most load-bearing structural convention in this codebase: get placement right and everything else — re-skinning, reuse, review — follows. This skill is the canonical home for the convention; other skills reference it rather than restating it:
+
+- `mui` — HOW a component is styled once it's in the right place (global=theme vs situational=`sx`).
+- `architecture` — the data path (one page = one query = one transformer).
+- `writing-task-specs` / `micro-prs` — a sub-task is one app/package; placement follows the rules below.
+- `reviewing-pull-requests` — review checks code landed in the right package/folder.
+
+This skill is only about **where**. For **how** to style, see `mui`.
+
+## Rule 1 — `packages/ui` is the single source of truth for ALL UI
+
+- All UI lives in `packages/ui` (imported as the `ui` package). MUI is an implementation detail *inside* `ui` — **apps consume UI through `ui`, never by importing `@mui/material` directly.**
+- Even raw MUI primitives are re-exported for apps through `packages/ui/src/universal/containers/generic/index.tsx` (`Alert`, `Box`, `Button`, `Container`, `Grid`, `TextField`, `Typography`, …). An app that needs a primitive imports it from `ui/universal/containers/generic`, not `@mui/material`.
+- **App-local custom CSS / `sx` is a one-time tweak, never the source of truth.** A genuine one-off is fine (that's `mui`'s situational case). But anything reusable — a shared look, a component used more than once, a repeated pattern — belongs in `ui`, not hand-rolled in the app.
+
+**Litmus test:** if "should this look/component be shared?" is *yes*, it goes in `ui`. If you're writing the same styling twice in an app, stop — it belongs in `ui`.
+
+**Why:** one place to look for any piece of UI, and re-skinning an app stays a one-line theme-provider swap (see `mui`). App-local UI that duplicates or fights `ui` quietly destroys that guarantee.
+
+## Rule 2 — `universal` vs site-specific, mirrored across `ui` AND `core`
+
+Both packages use the **same** filing system. Folder location — not per-change judgement — decides shared vs specific.
+
+| Folder | Scope | `ui` example | `core` example |
+|--------|-------|--------------|----------------|
+| `*/universal/*` | used by EVERY app | `ui/universal/header`, `ui/universal/containers/generic` | `core/universal/hooks/useRequest` |
+| `*/<site>/*` | one app only | `ui/listen/minimalism`, `ui/watch/video-detail-page` | `core/listen/query-hooks` |
+
+`<site>` ∈ `watch | listen | til | main | game | journal | finance | …` (the app / domain).
+
+**Placement decision, every time:**
+
+1. **Which package?** Presentation (components, theme, layout) → `packages/ui`. Data (queries, hooks, transformers) → `packages/core`.
+2. **Which folder?** Used across apps → `/universal`. Used by one app → that app's folder.
+
+**Why:** the split is the presentation-and-data twin of the core data doctrine (`architecture`). Deciding shared-vs-specific by folder means never re-litigating it per change, and `/universal` is the single place cross-app code accumulates.
+
+## The reality check (not an excuse)
+
+A handful of direct `@mui/material` imports and app-local `sx` exist in the apps today. They are tolerated tweaks, **not** the pattern to copy. When you touch that code or add near it, prefer moving the shared part into `ui`. New app-local UI that should be shared is a review finding, not a shortcut.

--- a/.claude/skills/mui/SKILL.md
+++ b/.claude/skills/mui/SKILL.md
@@ -6,9 +6,11 @@ user-invocable: false
 
 # MUI Rules
 
-## 1. Use MUI components directly
+These rules are about **how** to build and style a component *inside* `packages/ui`. For **where** UI lives — source of truth, which package and folder — see `frontend-ui-architecture`.
 
-- Import from `@mui/material` — no custom wrappers unless strictly required.
+## 1. Use MUI components directly (inside `packages/ui`)
+
+- Import from `@mui/material` — no custom wrappers unless strictly required. This applies **inside `packages/ui`**; how apps consume UI is `frontend-ui-architecture`'s rule.
 
 ```tsx
 // Good

--- a/.claude/skills/reviewing-pull-requests/SKILL.md
+++ b/.claude/skills/reviewing-pull-requests/SKILL.md
@@ -108,6 +108,7 @@ If the code looks AI-generated (which most of this code is), specifically check 
 
 - **Scope creep.** Did the change touch only what was asked? Files modified outside the stated scope are a red flag.
 - **Duplicated logic.** Did the AI write a new utility that already exists somewhere in `packages/core`, `packages/ui`, or one of the apps? Search for the function name and similar patterns. Reusing existing utilities is almost always better than creating a parallel one.
+- **Wrong-place code.** Did frontend code land in the right package and folder per `frontend-ui-architecture`? Shared UI hand-rolled in an app rather than `packages/ui` is a finding, not a shortcut.
 - **Weakened tests.** Were tests deleted or skipped instead of fixed? That is never the right move without explicit justification.
 - **Hallucinated APIs.** Calls to functions or properties that don't actually exist, or that exist but with different signatures.
 - **Plausible-but-wrong patterns.** Code that follows a pattern in the codebase but applies it where it doesn't fit.

--- a/.claude/skills/skill-creator/SKILL.md
+++ b/.claude/skills/skill-creator/SKILL.md
@@ -92,6 +92,12 @@ cloud-deploy/
     └── azure.md
 ```
 
+#### One canonical owner (don't duplicate across skills)
+
+A rule, law, or convention lives in exactly ONE skill — its canonical owner. Every other skill that needs it *references it by name* ("see `plain-english`", "placement per `frontend-ui-architecture`") rather than restating the content. Reference it like calling a shared function; never copy the body.
+
+Duplicated rule text drifts — two copies edited independently silently disagree, and the reader can't tell which is authoritative. When you find yourself about to restate another skill's rule, stop and point to it instead. When a rule has no home yet but several skills need it, create the canonical skill first, then wire the references (as `plain-english` did for the jargon-free law, and `frontend-ui-architecture` for UI placement).
+
 #### Principle of lack of surprise
 
 Skills must not contain malware, exploit code, or anything that could compromise security. A skill's contents shouldn't surprise the user given its stated intent. Don't create misleading skills, or skills designed to facilitate unauthorized access, data exfiltration, or other malicious activity. (Harmless things like "roleplay as an X" are fine.)

--- a/.claude/skills/writing-task-specs/SKILL.md
+++ b/.claude/skills/writing-task-specs/SKILL.md
@@ -357,7 +357,7 @@ A technically broken-down feature with sequenced sub-tasks. This is the *output*
 ### Scoping conversation steps
 
 1. **Start from the user story.** Read the user story issue. Understand the problem, the ideas explored, and the open questions.
-2. **Identify the architectural shape.** What systems are touched? Frontend app, `packages/core` hooks, the Hasura layer, the `sworld-backend` Hono service? Is there an existing pattern to follow?
+2. **Identify the architectural shape.** What systems are touched? Frontend app, `packages/core` hooks, the Hasura layer, the `sworld-backend` Hono service? Is there an existing pattern to follow? For frontend work, `frontend-ui-architecture` decides *where* each piece lands (which package and folder), which shapes how a sub-task is scoped.
 3. **Resolve the open questions.** The user story's open questions become decisions in the parent issue's description.
 4. **Write the goal & verification sub-issue first** (see below) — before naming a single code sub-task. If you can't write a concrete walkthrough and "how to know it's done" list yet, the concept isn't settled enough to scope — go back to `product-planning`, don't invent sub-tasks around a fuzzy goal.
 5. **Break into sub-tasks by one-purpose, one-app/repo scope.** Apply `micro-prs`' one-purpose test to each candidate before it becomes a sub-issue — if its `What` needs an "and", or its `Files / scope` spans two apps or two repos, split it now, at scoping time, not after the branch is built.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ When work spans the backend or schema, the change lands in those repos, not here
 - _Code:_ `code-conventions`, `react`, `mui`, `architecture`, `mutation-data-flow`, `error-handling`, `e2e-testing`, `design-principles`
 - _Workflow:_ `parallel-workflow`, `micro-prs`, `pr-descriptions`, `writing-task-specs`, `reviewing-pull-requests`, `product-planning`, `plain-english`
 - _Meta / quality:_ `grill-me`, `skill-creator`, `thermo-nuclear-code-quality-review`, `security-reviewer`, `supply-chain-security`
-- _Architecture:_ `hasura-architecture`, `backend-architecture`
+- _Architecture:_ `frontend-ui-architecture`, `hasura-architecture`, `backend-architecture`
 - _Ops:_ `backend-ops`, `dev-environment-gotchas`
 
 **Tasks & requirements** — the source of truth for work is **Linear** (team **SWorld**, key `SWO`). A **project is an app** (Til, Watch, Listen, Game, Docs, Main — Main covers the main app's finance, journal, and library areas) — every issue belongs to one. Bugs and small features are single issues; a large feature is a **parent issue** (with sub-issues) inside the app's project, its description + a Linear document holding the spec, with blocking relations encoding the dependency waves. Status lives in the issue state (`Backlog → Todo → In Progress → In Review → Done`). See the `writing-task-specs` skill for how to author them and `parallel-workflow` for how state moves as work ships.
@@ -126,9 +126,9 @@ cd packages/ui   && pnpm storybook # Component development
 - **Before any work touching sworld-backend or sworld-hasura-v2** — load the `backend-architecture` skill. It documents the full service architecture, Cloud Task pipeline, task lifecycle, notification flow, and event vs action patterns. Do not reason about the backend without it.
 - **Before designing a new mutation/Action, or reasoning about concurrent writes or data validation** — load the `hasura-architecture` skill. It covers the single-gateway rule, when a write needs a concurrency-safe database pattern, and the three validation layers.
 - **Code exploration — always use CodeGraph first, not grep.** The CodeGraph index at the workspace root covers all three repos. Use `codegraph query` for structural questions (definitions, callers, impact). Use grep **only** for literal string/text searches, never for finding where a symbol is defined or used.
-- **Adding a feature** — identify which app(s) change; decide whether shared logic belongs in `core` or `ui`; run the relevant `dev:*` command; make changes; run `pnpm lint` and `pnpm test` before committing.
+- **Adding a feature** — identify which app(s) change; decide where the code lives (`frontend-ui-architecture`); run the relevant `dev:*` command; make changes; run `pnpm lint` and `pnpm test` before committing.
 - **Working with GraphQL** — update operations in `packages/core`, run `pnpm codegen`, use the generated types in apps.
-- **Adding UI components** — create in `packages/ui`, export from `packages/ui/src/index.tsx`, build, then import in apps.
+- **Adding UI components** — all UI lives in `packages/ui` (placement per `frontend-ui-architecture`): create it there, export from `packages/ui/src/index.tsx`, build, then import in apps.
 
 ## Code style (authoritative — these win on any conflict)
 


### PR DESCRIPTION
## Summary

Adds a new canonical **`frontend-ui-architecture`** skill that states the most load-bearing frontend structural convention — currently unwritten in any skill:

1. **`packages/ui` is the single source of truth for all UI.** Apps consume UI through `ui` (even primitives via `ui/universal/containers/generic`), never `@mui/material` directly; app-local CSS is a tolerated one-off, not the source of truth.
2. **The `universal` vs `<site>` folder split, mirrored across `ui` and `core`** — folder location decides shared-vs-specific.

Other skills now **reference** it instead of restating the rule — the same canonical-owner discipline `plain-english` established in SWO-500:

- `architecture`, `mui`, `writing-task-specs`, `reviewing-pull-requests` → point to it
- `AGENTS.md` → registers the skill + two workflow bullets point to it
- `skill-creator` → new "One canonical owner (don't duplicate across skills)" subsection that writes the reference-don't-restate practice down as an authoring rule

Docs-only; no behavioural change to any other skill.

## Test plan

- [ ] `frontend-ui-architecture/SKILL.md` states both rules and cites `ui/universal/containers/generic` + the `universal`/`<site>` split in `ui` and `core`
- [ ] Each referencer names the concern and points to `frontend-ui-architecture` — no duplicated rule text
- [ ] All referenced skill names resolve; skill registered under _Architecture:_ in `AGENTS.md`
- [ ] `skill-creator` gains the "One canonical owner" subsection citing `plain-english` and `frontend-ui-architecture`

SWO-506


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added frontend architecture guidance covering UI placement, shared versus site-specific code, and styling conventions.
  - Clarified how architecture, MUI, review, and task-scoping guidance applies across the codebase.
  - Added recommendations to maintain one canonical source for shared rules and conventions.
  - Updated contributor workflows to reference the new frontend architecture guidance when deciding where code belongs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->