### PR TITLE
[WIP] docs(skills): add completeness sweep to grill-me

### DIFF
--- a/.claude/skills/grill-me/SKILL.md
+++ b/.claude/skills/grill-me/SKILL.md
@@ -12,15 +12,26 @@ Interview the user relentlessly about every aspect of their plan until you reach
 When this skill is invoked, switch into interviewer mode:
 
 1. **Read the plan** — understand what the user has described so far.
-2. **Identify the decision tree** — map out every branch: architecture, data model, UX, edge cases, deployment, dependencies.
+2. **Identify the decision tree** — map out every branch: architecture, data model, UX, edge cases, deployment, dependencies. Run **the completeness sweep** (below) so the map covers every actor and scenario, not only the branches that came to mind first.
 3. **Grill one branch at a time** — ask focused questions, starting from the highest-impact unknowns. Don't move on until the branch is resolved.
 4. **Surface dependencies** — when one decision blocks or constrains another, name it explicitly before continuing.
 5. **Summarize as you go** — after each resolved branch, restate the decision so the user can confirm or correct.
-6. **Stop when aligned** — once all branches are resolved, present the complete shared understanding as a structured summary.
+6. **Stop when aligned** — once all branches are resolved *and the completeness sweep is fully covered*, present the complete shared understanding as a structured summary.
+
+## The completeness sweep
+
+A decision tree only covers the branches you thought to draw — the real failure is a whole actor or scenario nobody mapped, so it never gets grilled and surfaces later as a missing requirement. Before calling a branch (or the whole plan) resolved, walk these three axes out loud and confirm each is either handled or *explicitly* ruled out of scope. Silence is not coverage.
+
+- **Actors / roles** — enumerate *every* kind of person or system that touches this: a signed-out visitor, the signed-in owner, another user's shared or public data, an admin. For each, is there a story — or a deliberate "not this one"? In this product, permission turns on role (owner vs vip vs anonymous vs admin), so a role nobody mapped is usually a requirement nobody wrote.
+- **States & scale** — empty (nothing created yet), one, many, and the extreme (hundreds of items, the longest, the largest). Where does behaviour change as the count grows?
+- **Failure & timing** — the request fails or the user is offline, permission is denied, two actions happen at once (concurrent edits), something is left half-finished, and first-run versus returning.
+
+Any cell that isn't clearly handled is an open branch — grill it like any other. Name the ones the user rules out, so "out of scope" is a decision on the record rather than an omission nobody noticed.
 
 ## Rules
 
 - **Never assume.** If something is ambiguous, ask.
+- **Sweep before resolving.** Don't trust the branches you happened to think of — run the completeness sweep (actors, states, failure) before calling anything resolved.
 - **One topic at a time.** Don't bundle unrelated questions.
 - **Push back.** If a decision seems risky or contradictory, say so.
 - **No implementation.** This skill is for planning only. Don't write code.


### PR DESCRIPTION
## Summary

Closes the SWO-501 audit gap. The `grill-me` skill named "edge cases" as one branch of the decision tree but gave no systematic way to enumerate them — so a whole actor or scenario could go unmapped, never get grilled, and surface later as a missing requirement.

This adds a **completeness sweep** to `grill-me` (the skill already tasked with surfacing every assumption and edge case): three axes — actors/roles, states & scale, failure & timing — walked before any branch is called resolved, with each cell either handled or explicitly ruled out of scope. Wired into the tree-mapping step, the stop-condition, and the rules list.

Audit conclusion: the three skills (`product-planning`, `grill-me`, `writing-task-specs`) are cleanly separated with single ownership; the only real gap was this missing enumeration method. It's closed by strengthening `grill-me` rather than adding a new skill. `product-planning` already delegates to `grill-me`, so it inherits this automatically — no duplication added to the other skills.

SWO-501

## Test plan

- Docs-only change to one skill file (`.claude/skills/grill-me/SKILL.md`); no runtime code.
- Verify the sweep reads cleanly and its three internal references (step 2, step 6, the new rule) all resolve to the new section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
