### PR TITLE
[WIP] docs(skills): neutralise tracker command-carriers to reference task-tracker

### DIFF
--- a/.claude/skills/parallel-workflow/SKILL.md
+++ b/.claude/skills/parallel-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: parallel-workflow
-description: Enforces the parallel subtask workflow using Linear issues, git worktrees, and PRs. Auto-triggers when working with git, branches, worktrees, PRs, Linear issues/tasks, codegen, or CI.
+description: Enforces the parallel subtask workflow using tracker issues, git worktrees, and PRs. Auto-triggers when working with git, branches, worktrees, PRs, tracker issues/tasks, codegen, or CI.
 user-invocable: false
 ---
 
@@ -8,17 +8,17 @@ user-invocable: false
 
 ## Non-negotiable prerequisites
 
-- **The Linear issue is the source of truth.** A Linear issue (in the **SWorld** team) is REQUIRED before starting any work. NEVER start working without one — if there isn't one, create it first (see `writing-task-specs`).
+- **The tracker issue is the source of truth.** A tracker issue is REQUIRED before starting any work. NEVER start working without one — if there isn't one, create it first (see `writing-task-specs`; `task-tracker` owns the tracker itself and its commands).
 - **ALWAYS work in a dedicated worktree.** NEVER create branches or make changes in the main worktree. The main worktree must stay clean — the *only* permitted operations there advance the local `main` ref (`git pull --ff-only origin main` when it sits on `main`, `git fetch origin main:main` otherwise — see "Keep local `main` fresh" below). No branch work, no manual edits.
 
 ## Scope: all three repos
 
-This workflow applies to the whole workspace — **sworld** (frontend), **sworld-backend** (Hono), and **sworld-hasura-v2** (Hasura) — not just the frontend. Same rules everywhere: Linear issue first, dedicated worktree, commit often / push immediately, self-review loop before PR, CI loop after. Repo-specific adjustments:
+This workflow applies to the whole workspace — **sworld** (frontend), **sworld-backend** (Hono), and **sworld-hasura-v2** (Hasura) — not just the frontend. Same rules everywhere: tracker issue first, dedicated worktree, commit often / push immediately, self-review loop before PR, CI loop after. Repo-specific adjustments:
 
 - **Substitute the repo name in `gh` commands.** The CI-loop Step 3 GraphQL query below takes a `name:"<repo>"` placeholder — fill in `sworld`, `sworld-backend`, or `sworld-hasura-v2`. Querying the wrong repo silently returns nothing.
 - **Worktree setup steps 7–8 are frontend-specific** (.env copies into `apps/<app>/`, `packages/core/.env`, `pnpm install`). In a sibling repo, follow that repo's own setup instead.
 - **Trust boundaries get the deep treatment.** Hasura permissions/metadata and Hono Action/Event/webhook handlers are trust boundaries — in those repos the self-review loop (step 11) MUST also include the `security-reviewer` skill, not just the two general review skills.
-- **Hasura changes are not done when their PR is clean.** A schema change ripples into the frontend: apply the migration locally, re-run `pnpm codegen` in `packages/core` (it introspects the LOCAL Hasura), and land the regenerated types as a follow-up frontend PR — linked in Linear with a blocking relation from the Hasura issue.
+- **Hasura changes are not done when their PR is clean.** A schema change ripples into the frontend: apply the migration locally, re-run `pnpm codegen` in `packages/core` (it introspects the LOCAL Hasura), and land the regenerated types as a follow-up frontend PR — linked in the tracker with a blocking relation from the Hasura issue.
 
 ## Git fundamentals
 
@@ -49,7 +49,7 @@ Never rebase `main`; never create merge commits on it. Run it:
 
 ## Before starting
 
-1. Read the current Linear issue (`linear issue view SWO-NNN`) and confirm its `state`. All Linear operations go through the `linear` CLI via Bash — NEVER through Linear MCP tools (they authenticate as the wrong account).
+1. Read the current tracker issue (`linear issue view SWO-NNN`) and confirm its `state`. All tracker operations go through the CLI, never the tracker's MCP — see `task-tracker`.
 2. Verify an issue exists for this work — a sub-issue under a feature's parent issue, or a standalone issue. If none exists, create it first (`writing-task-specs`).
 3. Check the issue's blocking relations (`linear issue relation list SWO-NNN`); resolve those blockers first.
 4. **Analyse before you build, then start.** For any non-trivial issue — especially a large-feature parent or a reworked/reopened one — run the `analyze` skill on the ticket + its breakdown first: it re-derives requirements (via `grill-me`'s completeness sweep) and checks the breakdown is still internally consistent (stale blockers, parent drift, deploy-order encoded as real relations) before a line of code. Reconcile what it flags as fixable; raise anything that changes scope with the owner. **Let its verdict gate the advance:** if analyze concludes the breakdown needs the owner to resolve blocking findings first, stop at raising them — don't move to `In Progress` and start building against a breakdown they haven't signed off (non-gating still holds — you surface and offer, you just don't unilaterally build past an unresolved blocker). Once analyze's verdict is safe-to-build — as-is or after the reconciling edits — or the owner says go, set the issue's `state` to `In Progress` (`linear issue update SWO-NNN -s "In Progress"`) before touching code. Skip the whole pass only for a trivial single-issue change with nothing to audit.
@@ -57,7 +57,7 @@ Never rebase `main`; never create merge commits on it. Run it:
 ## Creating a worktree
 
 5. `git fetch origin main` first, then create worktree inside `.claude/worktrees/` from `origin/main`.
-6. Name worktrees after the issue's slug — the kebab-case short form of its title, optionally prefixed with the identifier (e.g. `.claude/worktrees/swo-123-sticky-progress-bar`). This keeps worktrees self-contained, gitignored, and aligned with Claude Code's official default. Including the `SWO-NNN` identifier in the branch name lets the GitHub↔Linear integration auto-link the PR to the issue.
+6. Name worktrees after the issue's slug — the kebab-case short form of its title, optionally prefixed with the identifier (e.g. `.claude/worktrees/swo-123-sticky-progress-bar`). This keeps worktrees self-contained, gitignored, and aligned with Claude Code's official default. Including the `SWO-NNN` identifier in the branch name lets the GitHub↔tracker integration auto-link the PR to the issue (see `task-tracker`).
 7. Copy `.env` files from the main worktree into the matching `apps/<app>/` directories. **Also copy `packages/core/.env`** — `pnpm codegen` reads `HASURA_GRAPHQL_URL` / `HASURA_ADMIN_SECRET` from it; without it codegen aborts with `Unable to find any GraphQL type definitions ... - undefined`.
 8. Run `pnpm install` in each worktree.
 
@@ -96,7 +96,7 @@ Once a breakdown or plan is approved, work through it without pausing to reconfi
 
 - A PR may ONLY be created after the self-review loop (step 11) has exited clean on BOTH review skills. Pushing commits needs no gate; creating the PR does.
 - Create PR with `[WIP]` prefix (not draft).
-- Reference the Linear issue in the PR description (e.g. `SWO-123`) so the integration links them.
+- Reference the tracker issue in the PR description (e.g. `SWO-123`) so the integration links them.
 - ALWAYS assign PR to the user (`--assignee "@me"`).
 - Set the issue's `state` to `In Review` (`linear issue update SWO-NNN -s "In Review"`) after the PR is created.
 - Ensure PR is independent and mergeable without other PRs.
@@ -161,7 +161,7 @@ After each iteration, report what you found and fixed. Lead with unresolved comm
 
 ## Issue state management
 
-- States follow the SWorld team lifecycle: `Backlog → Todo → In Progress → In Review → Done`.
+- States follow the tracker lifecycle — `task-tracker` owns the vocabulary.
 - A **project** is an app (Til, Watch, Listen, Game, Docs, Main) — a long-lived container, never marked `Done`. Only issues move through the lifecycle.
 - Starting work on a large feature (even planning) → set the **parent issue** to `In Progress` (`linear issue update SWO-NNN -s "In Progress"`).
 - Each sub-task **sub-issue** carries its own `state` (`Todo → In Progress → In Review → Done`), driven by the steps above.

--- a/.claude/skills/product-planning/SKILL.md
+++ b/.claude/skills/product-planning/SKILL.md
@@ -41,8 +41,8 @@ and offer**, you don't enforce.
 Don't assume where the user is. They may have planned this deeply with an agent already, or may be
 starting cold and have skipped straight to "let's build it." Find out before you start:
 
-- If they reference a Linear issue or project, pull it (`linear issue view SWO-NNN` / `linear project view` — always the `linear` CLI, never Linear MCP tools) and work from it.
-- Check whether a Linear **document** already exists for the concept in play — if it does, that's
+- If they reference a tracker issue or project, pull it (`linear issue view SWO-NNN` / `linear project view` — see `task-tracker`) and work from it.
+- Check whether a tracker **document** already exists for the concept in play — if it does, that's
   a strong signal they've already worked the concept through. If it doesn't and the work needs one,
   that's a signal it's missing.
 - If it's still unclear, just ask: *"has this been through a planning round before?"*
@@ -89,11 +89,12 @@ You can do the messy research yourself (how the concept actually works, the comp
 bring it back to pressure-test their model — exactly as you'd research anything else. The user picks
 the path.
 
-**Capture the domain/feature concept as a short Linear document if it's non-obvious** — pure concept
-truth ("what is it", "how it works", "the rules"). Use `linear document create -t "…" -f <doc.md>`: attach it (`--project`) to the app's
-**project** for a feature concept, or to the **SWorld team** for a cross-cutting domain concept. Write it
-**before** the code, not retrofitted after — defining it first is the point. Keep the feature's
-architecture and trade-offs out of it — those live in the parent issue (Step 3).
+**Capture the domain/feature concept as a short tracker document if it's non-obvious** — pure concept
+truth ("what is it", "how it works", "the rules"). Create it as a tracker document (see `task-tracker`
+for the command), attached to the app's **project** for a feature concept, or to the team for a
+cross-cutting domain concept. Write it **before** the code, not retrofitted after — defining it first
+is the point. Keep the feature's architecture and trade-offs out of it — those live in the parent
+issue (Step 3).
 
 ## Step 2 — Shape the solution
 
@@ -113,9 +114,9 @@ Now think hard about *how*, and be self-critical about it:
 ## Step 3 — Shape a high-level parent
 
 Once the thinking holds, capture it as a **high-level parent issue** with `writing-task-specs` — a
-Linear issue (in the app's project) whose description opens with the `plain-english` block and then carries the concept, the options, and the trade-offs that
+tracker issue (in the app's project) whose description opens with the `plain-english` block and then carries the concept, the options, and the trade-offs that
 *prove* the problem is understood. Keep it high-level; do **not** scope the children (sub-issues)
-yet. The concept lives in its Linear document; the parent issue supports it.
+yet. The concept lives in its tracker document; the parent issue supports it.
 
 ## The team-review decision is the user's
 
@@ -144,7 +145,7 @@ rock-solid?) and **the non-gating posture**.
 | Phase | Leans on |
 |-------|----------|
 | Interrogating the thinking | `grill-me` |
-| Nailing the concept | a short Linear document |
+| Nailing the concept | a short tracker document |
 | Parent issue + sub-issues | `writing-task-specs` |
 | Decomposition & sequencing | `micro-prs` |
 

--- a/.claude/skills/wait-for-pr-merge/SKILL.md
+++ b/.claude/skills/wait-for-pr-merge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wait-for-pr-merge
-description: Poll one or more PRs until each merges (or closes), cleaning up each PR the moment it merges — remove its worktree, delete its local branch, refresh local main, mark its Linear issue Done. Use whenever the user says "wait for PR X to merge", "wait for PRs X and Y to merge", "watch these PRs until they merge", "let me know when PR X lands", "poll PR X", or invokes /wait-for-pr-merge. This is post-READY watching only — it does NOT fix CI, conflicts, or review comments (that is "the loop"; see parallel-workflow).
+description: Poll one or more PRs until each merges (or closes), cleaning up each PR the moment it merges — remove its worktree, delete its local branch, refresh local main, mark its tracker issue Done. Use whenever the user says "wait for PR X to merge", "wait for PRs X and Y to merge", "watch these PRs until they merge", "let me know when PR X lands", "poll PR X", or invokes /wait-for-pr-merge. This is post-READY watching only — it does NOT fix CI, conflicts, or review comments (that is "the loop"; see parallel-workflow).
 user-invocable: true
 ---
 
@@ -78,7 +78,7 @@ case "$repo" in
 esac
 ```
 
-### MERGED → clean up + mark Linear issue Done
+### MERGED → clean up + mark tracker issue Done
 
 Resolve the branch and its worktree **exactly** — never substring-match, and never act on an empty branch (an empty value matches every worktree):
 
@@ -99,11 +99,11 @@ wt=$(git -C "$repo_path" worktree list --porcelain | awk -v b="refs/heads/$branc
 git -C "$repo_path" branch -D "$branch" || { echo "PR <N>: branch delete failed — aborting"; exit 1; }
 ```
 
-Then mark the linked Linear issue `Done` (the parallel-workflow CI loop's Step 1 does this when *it* observes the merge; mirror it here so the manual-merge path stays consistent). Extract `SWO-NNN` from the PR body — the branch name is **not** authoritative:
+Then mark the linked tracker issue `Done` (the parallel-workflow CI loop's Step 1 does this when *it* observes the merge; mirror it here so the manual-merge path stays consistent) — see `task-tracker` for the command. Extract `SWO-NNN` from the PR body — the branch name is **not** authoritative:
 
 ```bash
 swo=$(gh pr view <N> --repo "ShinaBR2/$repo" --json body -q .body | grep -oE 'SWO-[0-9]+' | head -n1)
-[ -n "$swo" ] && linear issue update "$swo" -s "Done" || echo "PR <N>: no SWO-NNN found in body — skipping Linear update"
+[ -n "$swo" ] && linear issue update "$swo" -s "Done" || echo "PR <N>: no SWO-NNN found in body — skipping tracker update"
 ```
 
 ### CLOSED without merge → stop watching it


### PR DESCRIPTION
## Goal

Part of **SWO-512** — with the canonical `task-tracker` skill now in place (SWO-513), neutralise the three skills that still carried live `linear …` commands and Linear-artefact nouns so they speak tracker-neutrally and defer to the owner.

## What changed

- **`parallel-workflow`** — "the tracker issue is the source of truth", "the tracker lifecycle (`task-tracker` owns the vocabulary)", the CLI-not-MCP rule and GitHub↔tracker link now point at `task-tracker`. Keeps the whole workflow (worktrees, self-review + CI loops) unchanged.
- **`product-planning`** — "tracker issue / tracker document"; the `linear document create` mechanics defer to `task-tracker`. Concept-gate methodology unchanged.
- **`wait-for-pr-merge`** — "mark its tracker issue Done" and a pointer to `task-tracker`; the merge-wait polling logic unchanged.

Literal `linear …` command examples stay as examples in every file.

## Scope / impact

Docs-only, no runtime, no behaviour change. Each skill keeps its own methodology; only the which-tracker-and-how detail moves out.

## How to test

- None of the three restates the tracker choice, CLI/MCP rule, team/key, project-is-an-app, or state lifecycle — grep for `Linear`/`SWorld` in the three files returns only literal `linear …` commands.
- Each still reads coherently and keeps its distinct ownership.

SWO-514
