### PR TITLE
[WIP] docs(skills): neutralise incidental tracker mentions

### DIFF
--- a/.claude/skills/analyze/SKILL.md
+++ b/.claude/skills/analyze/SKILL.md
@@ -3,7 +3,7 @@ name: analyze
 description: >-
   The audit pass on an already-scoped ticket and its sub-issue breakdown, run BEFORE any code.
   Use it as the first move whenever picking up, starting, resuming, or "analysing" a non-trivial
-  Linear issue — especially a large-feature parent with sub-issues — to catch missing requirements
+  tracker issue — especially a large-feature parent with sub-issues — to catch missing requirements
   and a breakdown that has drifted out of sync before you build against it. Reach for it the moment
   you're about to set an issue In Progress, when a plan "looks done" but nobody has re-checked it,
   or when the user says "analyse this issue / take a look at this breakdown / is this plan right".

--- a/.claude/skills/design-principles/SKILL.md
+++ b/.claude/skills/design-principles/SKILL.md
@@ -17,10 +17,10 @@ Across ALL apps (listen, watch, til, game, docs, main), the design language is *
 
 ## Input-heavy apps get a FAB; view-first apps get a management dashboard
 
-Decided 2026-07-04 (SWO-379):
+Decided 2026-07-04:
 
 - **Input-heavy apps** — main's finance + journal, and til — surface their primary create action as a **floating action button** (FAB), because users input a lot.
-- **View-first apps** — watch and listen — must **NOT** get a create FAB. Their surfaces stay purely about consumption. All content management (upload, edit, delete, playlists) belongs in a dedicated per-app **management dashboard** (SWO-387 watch, SWO-388 listen), never in the primary browsing UI.
+- **View-first apps** — watch and listen — must **NOT** get a create FAB. Their surfaces stay purely about consumption. All content management (upload, edit, delete, playlists) belongs in a dedicated per-app **management dashboard** (watch and listen), never in the primary browsing UI.
 - Create actions never belong in the avatar drawer either — that drawer is for **settings + logout only**, in any app.
 
 **Why:** the distinction is how much the end user inputs; a FAB overweights a rare/admin action in a consumption app.

--- a/.claude/skills/design-principles/SKILL.md
+++ b/.claude/skills/design-principles/SKILL.md
@@ -20,7 +20,7 @@ Across ALL apps (listen, watch, til, game, docs, main), the design language is *
 Decided 2026-07-04:
 
 - **Input-heavy apps** — main's finance + journal, and til — surface their primary create action as a **floating action button** (FAB), because users input a lot.
-- **View-first apps** — watch and listen — must **NOT** get a create FAB. Their surfaces stay purely about consumption. All content management (upload, edit, delete, playlists) belongs in a dedicated per-app **management dashboard** (watch and listen), never in the primary browsing UI.
+- **View-first apps** — watch and listen — must **NOT** get a create FAB. Their surfaces stay purely about consumption. All content management (upload, edit, delete, playlists) belongs in a dedicated per-app **management dashboard**, never in the primary browsing UI.
 - Create actions never belong in the avatar drawer either — that drawer is for **settings + logout only**, in any app.
 
 **Why:** the distinction is how much the end user inputs; a FAB overweights a rare/admin action in a consumption app.

--- a/.claude/skills/dev-environment-gotchas/SKILL.md
+++ b/.claude/skills/dev-environment-gotchas/SKILL.md
@@ -42,7 +42,7 @@ Don't trust `pnpm exec turbo build` output that reports a cache hit ("FULL TURBO
 
 ## pnpm's dependency cooldown can freeze dep work for days
 
-`pnpm-workspace.yaml` sets `minimumReleaseAge: 10080` (7 days, SWO-355) — pnpm refuses to *resolve* any version published more recently than that. See the `supply-chain-security` skill for what this setting is and why it exists. Frozen installs (CI, `--frozen-lockfile`) are unaffected — only local re-resolves are.
+`pnpm-workspace.yaml` sets `minimumReleaseAge: 10080` (7 days) — pnpm refuses to *resolve* any version published more recently than that. See the `supply-chain-security` skill for what this setting is and why it exists. Frozen installs (CI, `--frozen-lockfile`) are unaffected — only local re-resolves are.
 
 **The sworld-specific trap:** adding/changing ANY dependency triggers a broad re-resolve. If a recent toolchain bump pulled fresh packages (e.g. a major Vite upgrade), every re-resolve trips the cooldown on them (`ERR_PNPM_NO_MATURE_MATCHING_VERSION`) — one package at a time, since pnpm only reports the next blocked package per run — until they age past 7 days, effectively freezing dependency work for a week after a big bump.
 

--- a/.claude/skills/pr-descriptions/SKILL.md
+++ b/.claude/skills/pr-descriptions/SKILL.md
@@ -15,7 +15,7 @@ For how to *slice and size* the work into small PRs, see `micro-prs`. This skill
 - Do not include "Generated with Claude Code" or any AI attribution
 - Do not mention Claude, AI, or assistants anywhere in the PR
 - Do not pad the description by restating the diff
-- Do not put the Linear issue ID in the title — keep the title clean and reference the issue (e.g. `SWO-123`) in the body instead
+- Do not put the tracker issue ID in the title — keep the title clean and reference the issue (e.g. `SWO-123`) in the body instead
 
 ## Title format
 
@@ -73,7 +73,7 @@ No "Changelog" section in the PR body. The changelog is driven by changesets (se
 
 ### Summary
 
-1–3 sentences, plain English. State the change directly. Link related PRs as `#NNNN`. Reference the Linear issue it came from (e.g. `SWO-123`) so the integration links the PR back to it.
+1–3 sentences, plain English. State the change directly. Link related PRs as `#NNNN`. Reference the tracker issue it came from (e.g. `SWO-123`) so the integration links the PR back to it.
 
 **User-facing PR — describe what the user sees, before → after.**
 

--- a/.claude/skills/reviewing-pull-requests/SKILL.md
+++ b/.claude/skills/reviewing-pull-requests/SKILL.md
@@ -95,7 +95,7 @@ The hierarchy below is in order of importance. A correctness issue is always mor
 
 ### Correctness (most important)
 
-- Does it actually do what the Linear issue (or the stated intent) says it should?
+- Does it actually do what the tracker issue (or the stated intent) says it should?
 - Are there obvious logic errors?
 - Edge cases — what about empty arrays, null values, very large inputs, negative numbers, zero, dates that span timezones?
 - Round-tripping, what happens at boundaries

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Context for AI agents working in **sworld** — a personal Turborepo + pnpm mono
 **You must NOT write a single line of code, propose implementation solutions, or suggest specific APIs/libraries until these steps are done:**
 
 1. Load the `product-planning` skill and work through the concept with the user — interrogate motivation, constraints, and edge cases until shared understanding is reached
-2. Create Linear subtask(s) via `writing-task-specs`
+2. Create tracker subtask(s) via `writing-task-specs`
 3. Get explicit user approval on the plan
 
 Only after step 3 is complete may you write code. No proto, no scaffold, no "here's a quick implementation" — the plan comes first, always.
@@ -39,7 +39,7 @@ You are part of this project and you own the code you ship. Be confident, be acc
 
 **First principles before code.** Don't write a line until the concept is genuinely clear. If the idea, the edge cases, or the downstream impact aren't thought through, that's a stop signal — not something to figure out as you go. Question assumptions, surface what's unclear, and stress-test the design before committing to it.
 
-**Plan deeply, then ship fast.** Speed comes from the quality of the planning, not from cutting corners. Invest the time up front — think, iterate, pressure-test — then break the work into Linear issues and micro-PRs (see the `writing-task-specs`, `micro-prs`, and `parallel-workflow` skills). Deep planning is what makes fast, direct-to-main work safe.
+**Plan deeply, then ship fast.** Speed comes from the quality of the planning, not from cutting corners. Invest the time up front — think, iterate, pressure-test — then break the work into tracker issues and micro-PRs (see the `writing-task-specs`, `micro-prs`, and `parallel-workflow` skills). Deep planning is what makes fast, direct-to-main work safe.
 
 **Default to less.** Before adding, ask whether you can delete or extend instead, and whether the platform already solves it — can an existing pattern, package, or tool do this for us? No cleverness for its own sake, no abstractions until there are 3+ real uses, no new dependencies without justification. Boring and proven beats clever; the most maintainable solution wins.
 


### PR DESCRIPTION
## Goal

Final part of **SWO-512** — tidy the four skills that only mentioned the tracker in passing, so nothing outside `task-tracker` names it or carries a real ticket ID.

## What changed

- **`pr-descriptions`**, **`reviewing-pull-requests`** — "the Linear issue" → "the tracker issue" (format placeholders like `SWO-123` kept as illustrative examples).
- **`design-principles`** — dropped the real provenance IDs (`SWO-379`, and `SWO-387`/`SWO-388`) so the rule reads evergreen; kept the decision date.
- **`dev-environment-gotchas`** — dropped the `SWO-355` provenance ref from the cooldown note.

## Scope / impact

Docs-only, no runtime, no behaviour change. Pure word-level neutralising; no mechanics move.

## How to test

- Grep for `Linear`/real `SWO-###` provenance IDs across the four files returns nothing (only evergreen `SWO-123` format placeholders remain).
- Each rule still reads coherently.

SWO-515


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal guidance to use consistent “tracker” terminology instead of product-specific issue references.
  * Clarified package-manager version-resolution behavior, including the effect of frozen installs.
  * Removed outdated ticket references from design principles and workflow documentation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->