### PR TITLE
[WIP] docs(skills): extract status-moment model into task-tracker (SWO-517)

### DIFF
--- a/.claude/skills/analyze/SKILL.md
+++ b/.claude/skills/analyze/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   Use it as the first move whenever picking up, starting, resuming, or "analysing" a non-trivial
   tracker issue — especially a large-feature parent with sub-issues — to catch missing requirements
   and a breakdown that has drifted out of sync before you build against it. Reach for it the moment
-  you're about to set an issue In Progress, when a plan "looks done" but nobody has re-checked it,
+  you're about to start an issue, when a plan "looks done" but nobody has re-checked it,
   or when the user says "analyse this issue / take a look at this breakdown / is this plan right".
   This is the backward/audit direction on a *spec* — distinct from `product-planning`/`grill-me`
   (forward, idea → breakdown) and `reviewing-pull-requests` (analysing *code*). Not needed for a
@@ -33,13 +33,13 @@ a breakdown is still internally consistent with itself.
 
 ## When to run it
 
-The first move on picking up any non-trivial issue — before setting it `In Progress`, before a line of
+The first move on picking up any non-trivial issue — before you start it, before a line of
 code. Highest value on a large-feature **parent with sub-issues**, on any issue that was scoped a while
 ago, and on anything reopened or reworked (where the plan and the sub-issues drift apart most). Skip it
 for a trivial single-issue bug with no breakdown to audit — there's nothing to reconcile.
 
-Pull the issue and its relations first (`linear issue view SWO-NNN`, `linear issue relation list SWO-NNN`,
-and the sub-issues) so you're auditing what's actually there, not memory.
+Pull the issue, its relations, and the sub-issues first (see `task-tracker`) so you're auditing what's
+actually there, not memory.
 
 ## The three passes
 

--- a/.claude/skills/parallel-workflow/SKILL.md
+++ b/.claude/skills/parallel-workflow/SKILL.md
@@ -49,15 +49,15 @@ Never rebase `main`; never create merge commits on it. Run it:
 
 ## Before starting
 
-1. Read the current tracker issue (`linear issue view SWO-NNN`) and confirm its `state`. All tracker operations go through the CLI, never the tracker's MCP — see `task-tracker`.
+1. Read the current tracker issue and confirm its `state` (see `task-tracker`).
 2. Verify an issue exists for this work — a sub-issue under a feature's parent issue, or a standalone issue. If none exists, create it first (`writing-task-specs`).
-3. Check the issue's blocking relations (`linear issue relation list SWO-NNN`); resolve those blockers first.
-4. **Analyse before you build, then start.** For any non-trivial issue — especially a large-feature parent or a reworked/reopened one — run the `analyze` skill on the ticket + its breakdown first: it re-derives requirements (via `grill-me`'s completeness sweep) and checks the breakdown is still internally consistent (stale blockers, parent drift, deploy-order encoded as real relations) before a line of code. Reconcile what it flags as fixable; raise anything that changes scope with the owner. **Let its verdict gate the advance:** if analyze concludes the breakdown needs the owner to resolve blocking findings first, stop at raising them — don't move to `In Progress` and start building against a breakdown they haven't signed off (non-gating still holds — you surface and offer, you just don't unilaterally build past an unresolved blocker). Once analyze's verdict is safe-to-build — as-is or after the reconciling edits — or the owner says go, set the issue's `state` to `In Progress` (`linear issue update SWO-NNN -s "In Progress"`) before touching code. Skip the whole pass only for a trivial single-issue change with nothing to audit.
+3. Check the issue's blocking relations (see `task-tracker`); resolve those blockers first.
+4. **Analyse before you build, then start.** For any non-trivial issue — especially a large-feature parent or a reworked/reopened one — run the `analyze` skill on the ticket + its breakdown first: it re-derives requirements (via `grill-me`'s completeness sweep) and checks the breakdown is still internally consistent (stale blockers, parent drift, deploy-order encoded as real relations) before a line of code. Reconcile what it flags as fixable; raise anything that changes scope with the owner. **Let its verdict gate the advance:** if analyze concludes the breakdown needs the owner to resolve blocking findings first, stop at raising them — don't start building against a breakdown they haven't signed off (non-gating still holds — you surface and offer, you just don't unilaterally build past an unresolved blocker). Once analyze's verdict is safe-to-build — as-is or after the reconciling edits — or the owner says go, start the issue in the tracker (see `task-tracker`) before touching code. Skip the whole pass only for a trivial single-issue change with nothing to audit.
 
 ## Creating a worktree
 
 5. `git fetch origin main` first, then create worktree inside `.claude/worktrees/` from `origin/main`.
-6. Name worktrees after the issue's slug — the kebab-case short form of its title, optionally prefixed with the identifier (e.g. `.claude/worktrees/swo-123-sticky-progress-bar`). This keeps worktrees self-contained, gitignored, and aligned with Claude Code's official default. Including the `SWO-NNN` identifier in the branch name lets the GitHub↔tracker integration auto-link the PR to the issue (see `task-tracker`).
+6. Create the worktree under `.claude/worktrees/` — self-contained, gitignored, and aligned with Claude Code's official default — named for the issue per `task-tracker`'s branch convention.
 7. Copy `.env` files from the main worktree into the matching `apps/<app>/` directories. **Also copy `packages/core/.env`** — `pnpm codegen` reads `HASURA_GRAPHQL_URL` / `HASURA_ADMIN_SECRET` from it; without it codegen aborts with `Unable to find any GraphQL type definitions ... - undefined`.
 8. Run `pnpm install` in each worktree.
 
@@ -96,9 +96,8 @@ Once a breakdown or plan is approved, work through it without pausing to reconfi
 
 - A PR may ONLY be created after the self-review loop (step 11) has exited clean on BOTH review skills. Pushing commits needs no gate; creating the PR does.
 - Create PR with `[WIP]` prefix (not draft).
-- Reference the tracker issue in the PR description (e.g. `SWO-123`) so the integration links them.
+- Reference the tracker issue in the PR description (see `task-tracker`).
 - ALWAYS assign PR to the user (`--assignee "@me"`).
-- Set the issue's `state` to `In Review` (`linear issue update SWO-NNN -s "In Review"`) after the PR is created.
 - Ensure PR is independent and mergeable without other PRs.
 - Run the CI loop after pushing.
 
@@ -111,7 +110,7 @@ Before entering the gates, push any unpushed local commits so the remote PR refl
 ### Step 1: Check merge status
 
 - Run `gh pr view <number> --json state` as the **ONLY** command. Do NOT batch it with anything else.
-- If `MERGED` → set the issue's `state` to `Done` (`linear issue update SWO-NNN -s "Done"`), clean up worktree + delete local branch. Loop is done.
+- If `MERGED` → clean up worktree + delete local branch. (This is the "done" moment — issue status is the tracker's, see `task-tracker`.) Loop is done.
 - If `CLOSED` → stop the loop. Report to user that the PR was closed without merging.
 - If `OPEN` → proceed to Step 2.
 
@@ -140,7 +139,7 @@ Before entering the gates, push any unpushed local commits so the remote PR refl
 - If all green AND no unresolved comments → PR is ready. Report to user.
 - **Flaky E2E**: if an E2E job failed at an infra/setup step (Playwright OS deps, Node.js setup, cache, runner allocation) and the PR doesn't touch test code, treat it as green — don't trigger reruns or block readiness on it. Reruns are only appropriate when the failure is in a step that executes changed code.
 - **Known non-blocking checks** — confirm the specific failure mode before waving these through, then gate on `test` + CodeRabbit instead:
-  - **Argos visual-regression** (`argos/Listen E2E`) does a pixel-perfect diff against the anonymous home, which is data-driven (real Firebase preview + prod Hasura, no mocking) — it reports "changed" whenever the underlying data changes, not just on real UI regressions. Root-cause fix tracked in SWO-310 (mask the data-driven pixels). If the diff is plausibly a genuine intended UI change, say so — it needs approving in Argos, not dismissing.
+  - **Argos visual-regression** (`argos/Listen E2E`) does a pixel-perfect diff against the anonymous home, which is data-driven (real Firebase preview + prod Hasura, no mocking) — it reports "changed" whenever the underlying data changes, not just on real UI regressions. Root-cause fix tracked separately (mask the data-driven pixels). If the diff is plausibly a genuine intended UI change, say so — it needs approving in Argos, not dismissing.
   - **`prod_deploy` / Deploy Preview 429** (`RESOURCE_EXHAUSTED: channel quota reached`) — Firebase Hosting preview channels are per-app-per-PR with a 7-day TTL; a burst of PRs exhausts a site's quota, and it can fire on an app the PR doesn't even touch. Confirm by grepping the failed job log for `429`/`RESOURCE_EXHAUSTED` — a different `prod_deploy` failure still needs investigating.
 
 ### Merging — never automatic
@@ -161,11 +160,7 @@ After each iteration, report what you found and fixed. Lead with unresolved comm
 
 ## Issue state management
 
-- States follow the tracker lifecycle — `task-tracker` owns the vocabulary.
-- A **project** is an app (Til, Watch, Listen, Game, Docs, Main) — a long-lived container, never marked `Done`. Only issues move through the lifecycle.
-- Starting work on a large feature (even planning) → set the **parent issue** to `In Progress` (`linear issue update SWO-NNN -s "In Progress"`).
-- Each sub-task **sub-issue** carries its own `state` (`Todo → In Progress → In Review → Done`), driven by the steps above.
-- Last sub-issue of a parent done → set the **parent issue** to `Done`.
+An issue's status changes at exactly three moments — you **start** it, it's **ready for review**, it's **done**. Those moments are the workflow's; what each one requires — a manual step or nothing at all — is the tracker's. At every moment, do what `task-tracker` says. Starting a large-feature parent (even just to plan it) is a "start" moment too.
 
 ## Good PR criteria
 

--- a/.claude/skills/pr-descriptions/SKILL.md
+++ b/.claude/skills/pr-descriptions/SKILL.md
@@ -15,7 +15,7 @@ For how to *slice and size* the work into small PRs, see `micro-prs`. This skill
 - Do not include "Generated with Claude Code" or any AI attribution
 - Do not mention Claude, AI, or assistants anywhere in the PR
 - Do not pad the description by restating the diff
-- Do not put the tracker issue ID in the title — keep the title clean and reference the issue (e.g. `SWO-123`) in the body instead
+- Do not put the tracker issue ID in the title — keep the title clean and reference the issue in the body instead (see `task-tracker`)
 
 ## Title format
 
@@ -73,7 +73,7 @@ No "Changelog" section in the PR body. The changelog is driven by changesets (se
 
 ### Summary
 
-1–3 sentences, plain English. State the change directly. Link related PRs as `#NNNN`. Reference the tracker issue it came from (e.g. `SWO-123`) so the integration links the PR back to it.
+1–3 sentences, plain English. State the change directly. Link related PRs as `#NNNN`. Reference the tracker issue it came from (see `task-tracker`).
 
 **User-facing PR — describe what the user sees, before → after.**
 

--- a/.claude/skills/product-planning/SKILL.md
+++ b/.claude/skills/product-planning/SKILL.md
@@ -41,7 +41,7 @@ and offer**, you don't enforce.
 Don't assume where the user is. They may have planned this deeply with an agent already, or may be
 starting cold and have skipped straight to "let's build it." Find out before you start:
 
-- If they reference a tracker issue or project, pull it (`linear issue view SWO-NNN` / `linear project view` — see `task-tracker`) and work from it.
+- If they reference a tracker issue or project, pull it (see `task-tracker`) and work from it.
 - Check whether a tracker **document** already exists for the concept in play — if it does, that's
   a strong signal they've already worked the concept through. If it doesn't and the work needs one,
   that's a signal it's missing.

--- a/.claude/skills/task-tracker/SKILL.md
+++ b/.claude/skills/task-tracker/SKILL.md
@@ -64,21 +64,21 @@ Only *issues* move through this lifecycle; a *project* (an app) never does. `par
 owns *when* each transition happens as work ships — this skill owns the vocabulary and the command
 that performs a transition (`linear issue update SWO-NNN -s "<state>"`).
 
-### What the GitHub↔Linear integration automates — and the one gap you must cover by hand
+### Status changes: three moments, and what each needs today
 
-Two transitions happen **automatically** via the integration, so you never set them yourself:
+An issue's status only ever changes at **three moments** in the work — *start working on it*,
+*it's ready for review*, *it's done*. That's fixed no matter the tooling; consumers just recognise
+the moment and defer here. What each moment does in our current GitHub↔Linear setup:
 
-- **Merged PR → the linked issue goes `Done`.** Triggered by the `SWO-NNN` reference in the branch
-  name / PR body (see *The GitHub link* below). The manual `-s "Done"` that `parallel-workflow`'s CI
-  loop and `wait-for-pr-merge` still run is a deliberate safety net over this — harmless if the
-  automation already fired, and it catches the case where a PR body carried no `SWO-NNN`.
-- **Last child sub-issue `Done` → the parent issue closes** too, so you don't hand-close a parent
-  once its final sub-issue lands.
+1. **You start working on something** → set the issue to `In Progress`, **by hand** — the integration
+   doesn't cover this one: `linear issue update SWO-NNN -s "In Progress"`. This is the **only** status
+   change you ever make yourself.
+2. **It's ready for review** → opening the PR auto-moves the issue to `In Review` (the integration,
+   keyed off the `SWO-NNN` in the branch / PR body — see *The GitHub link* below). Nothing to do.
+3. **It's done** → merging auto-moves the issue to `Done`, and a parent auto-closes once its last
+   child is `Done`. Nothing to do.
 
-The **gap**: nothing automates **`Todo → In Progress`**. No event moves an issue into `In Progress`
-when you pick it up — so you **must set it yourself, by hand, as the first action before touching any
-code** (`linear issue update SWO-NNN -s "In Progress"`). `parallel-workflow` makes this its
-start-of-work step; this automation gap is *why* that step can't be skipped — nothing else will do it.
+So in practice you touch status exactly once — at the start; moments 2 and 3 happen on their own.
 
 ## Command mechanics
 
@@ -125,6 +125,9 @@ What an in-repo tracker would keep in a file's frontmatter, Linear keeps as nati
 
 ## The GitHub link
 
-Putting the `SWO-NNN` identifier in a PR's branch name lets the GitHub↔Linear integration auto-link
-the PR to the issue — so name branches with the issue slug (see `parallel-workflow`). Referencing
-`SWO-NNN` in the PR description links it too.
+The issue identifier (`SWO-NNN`) is what ties an issue to its code, so it drives the branch/worktree
+name: a kebab-case slug **prefixed with the identifier**, e.g. `swo-123-sticky-progress-bar`. That
+prefix is what lets the GitHub↔Linear integration auto-link the PR to the issue — and, once linked,
+fire the automatic status transitions above (PR opened → `In Review`, merged → `Done`). Referencing
+`SWO-NNN` in the PR description links it too. Consumers (`parallel-workflow`, `pr-descriptions`, …)
+just follow this convention and point here; they carry none of these specifics.

--- a/.claude/skills/wait-for-pr-merge/SKILL.md
+++ b/.claude/skills/wait-for-pr-merge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wait-for-pr-merge
-description: Poll one or more PRs until each merges (or closes), cleaning up each PR the moment it merges — remove its worktree, delete its local branch, refresh local main, mark its tracker issue Done. Use whenever the user says "wait for PR X to merge", "wait for PRs X and Y to merge", "watch these PRs until they merge", "let me know when PR X lands", "poll PR X", or invokes /wait-for-pr-merge. This is post-READY watching only — it does NOT fix CI, conflicts, or review comments (that is "the loop"; see parallel-workflow).
+description: Poll one or more PRs until each merges (or closes), cleaning up each PR the moment it merges — remove its worktree, delete its local branch, refresh local main (issue status is the tracker's — see `task-tracker`). Use whenever the user says "wait for PR X to merge", "wait for PRs X and Y to merge", "watch these PRs until they merge", "let me know when PR X lands", "poll PR X", or invokes /wait-for-pr-merge. This is post-READY watching only — it does NOT fix CI, conflicts, or review comments (that is "the loop"; see parallel-workflow).
 user-invocable: true
 ---
 
@@ -78,7 +78,7 @@ case "$repo" in
 esac
 ```
 
-### MERGED → clean up + mark tracker issue Done
+### MERGED → clean up
 
 Resolve the branch and its worktree **exactly** — never substring-match, and never act on an empty branch (an empty value matches every worktree):
 
@@ -99,12 +99,7 @@ wt=$(git -C "$repo_path" worktree list --porcelain | awk -v b="refs/heads/$branc
 git -C "$repo_path" branch -D "$branch" || { echo "PR <N>: branch delete failed — aborting"; exit 1; }
 ```
 
-Then mark the linked tracker issue `Done` (the parallel-workflow CI loop's Step 1 does this when *it* observes the merge; mirror it here so the manual-merge path stays consistent) — see `task-tracker` for the command. Extract `SWO-NNN` from the PR body — the branch name is **not** authoritative:
-
-```bash
-swo=$(gh pr view <N> --repo "ShinaBR2/$repo" --json body -q .body | grep -oE 'SWO-[0-9]+' | head -n1)
-[ -n "$swo" ] && linear issue update "$swo" -s "Done" || echo "PR <N>: no SWO-NNN found in body — skipping tracker update"
-```
+Issue status is the tracker's to manage — see `task-tracker`. This path only cleans up.
 
 ### CLOSED without merge → stop watching it
 
@@ -131,5 +126,5 @@ Report that the PR could not be polled and drop it from the pending set so the u
     *)    git -C "$repo_path" fetch origin main:main || { echo "$repo: main refresh failed — stop"; exit 1; } ;;
   esac
   ```
-- Report per PR: cleaned-up+moved-to-Done (merged), closed-without-merge, or unreachable.
+- Report per PR: cleaned-up (merged), closed-without-merge, or unreachable.
 - If PRs remain pending, re-launch the poll (step 1) for just those. When the pending set is empty, report the final tally and stop.

--- a/.claude/skills/writing-task-specs/SKILL.md
+++ b/.claude/skills/writing-task-specs/SKILL.md
@@ -7,7 +7,7 @@ description: This skill should be used whenever the user asks to "create a ticke
 
 Produce clear, consistent task specs in the task tracker that match the shape of the work. A great spec lets a developer (or AI agent) pick it up and start without asking questions.
 
-This skill owns the **shapes** of a good spec; the `task-tracker` skill owns the tracker itself — which tool it is, the team, the project-is-an-app model, the state lifecycle, and every `linear …` command form. Read `task-tracker` for how to create and wire what this skill describes; the short version of the model:
+This skill owns the **shapes** of a good spec; the `task-tracker` skill owns the tracker itself — which tool it is, the team, the project-is-an-app model, the state lifecycle, and every command form. Read `task-tracker` for how to create and wire what this skill describes; the short version of the model:
 
 Every issue belongs to an **app's project** (see `task-tracker` for the project-is-an-app model). A large feature is a **parent issue** *inside* its app's project — not a project of its own.
 
@@ -23,7 +23,7 @@ Every issue belongs to an **app's project** (see `task-tracker` for the project-
 - **Every sub-task solves exactly one problem** — see `micro-prs`' one-purpose test. If a sub-task's `What` needs an "and", it's two sub-tasks.
 - **Every large feature's first sub-issue is the goal & verification sub-issue** — see below. Write it before any code sub-issue.
 - Attach every issue to the matching app **project** (Til, Watch, Listen, Game, Docs, Main; see `task-tracker`) — a large feature is a parent issue *inside* its app's project, not a project of its own
-- Before starting work on an issue, set its `state` to `In Progress` (see the `parallel-workflow` skill)
+- Before starting work on an issue, start it in the tracker (see `task-tracker`)
 - **Every ticket opens in plain words** — see below. No exceptions.
 
 ## Every ticket opens in plain words
@@ -69,7 +69,7 @@ Not every user story becomes a large feature — sometimes scoping reveals it's 
 
 ## Title and slug conventions
 
-The issue/project **title** should be specific enough that a developer knows what they're looking at before opening it. The tracker assigns the identifier (e.g. `SWO-123`); you don't pick one (see `task-tracker`).
+The issue/project **title** should be specific enough that a developer knows what they're looking at before opening it. The tracker assigns the identifier; you don't pick one (see `task-tracker`).
 
 - Active voice or noun phrase, no gerunds in active titles ("Fix" not "Fixing")
 - Reference the app or domain when relevant (library, listen, watch, til, finance, journal)
@@ -93,7 +93,7 @@ Bad:
 
 ## Shape 1 — Bug
 
-For a specific, reproducible issue. Direct, short, focused on getting the fix right. Create a single issue with the `bug` label, `state: Todo`, and an `estimate`. The body below is the issue **description** (tracker descriptions are Markdown).
+For a specific, reproducible issue. Direct, short, focused on getting the fix right. Create a single issue with the `bug` label, ready to pick up, and an `estimate`. The body below is the issue **description** (tracker descriptions are Markdown).
 
 ### Description structure
 
@@ -123,7 +123,7 @@ For a specific, reproducible issue. Direct, short, focused on getting the fix ri
 
 ### Example — the library progress bug
 
-Created as a `bug`-labelled issue in the **Main** app's project, `state: Todo`, estimate 1 (library is a feature area of the main app; see `task-tracker` for the create command), where the description file holds:
+Created as a `bug`-labelled issue in the **Main** app's project, ready to pick up, estimate 1 (library is a feature area of the main app; see `task-tracker` for the create command), where the description file holds:
 
 ```markdown
 **In plain words**
@@ -163,7 +163,7 @@ Key files:
 
 ## Shape 2 — Small feature / improvement
 
-For a single focused change that maps to one PR. Short spec, no sub-tasks. A single issue (`state: Todo`, an `estimate`, attached to the relevant `project`).
+For a single focused change that maps to one PR. Short spec, no sub-tasks. A single issue (ready to pick up, an `estimate`, attached to the relevant `project`).
 
 ### Description structure
 
@@ -188,7 +188,7 @@ For a single focused change that maps to one PR. Short spec, no sub-tasks. A sin
 
 ### Example
 
-A **Listen**-project issue, `state: Todo`, estimate 4 (see `task-tracker` for the create command), description:
+A **Listen**-project issue, ready to pick up, estimate 4 (see `task-tracker` for the create command), description:
 
 ```markdown
 **In plain words**
@@ -365,7 +365,7 @@ The parent issue holds the technical scope. It is not worked on directly — its
 
 **Context**
 
-[Link to the user story issue (SWO-NNN). 1–2 sentences summarising the user need this delivers on. Do not repeat the full user story — link to it.]
+[Link to the user story issue. 1–2 sentences summarising the user need this delivers on. Do not repeat the full user story — link to it.]
 
 **Technical approach**
 
@@ -419,13 +419,13 @@ Only when a real dependency exists, group into waves instead and add a **Depende
 
 **Related**
 
-* SWO-NNN — user story
+* [link to the user story issue] — user story
 * [Tracker document or external doc] — relevant patterns
 ```
 
 ### Sub-task issue structure
 
-Each sub-task is one sub-issue under the parent, and a small focused PR. It inherits context from the parent issue — do not repeat the architecture or rationale. Create each as a sub-issue under the parent, `state: Todo`, with an estimate, then add a `blocked-by` relation for each dependency (see `task-tracker` for the commands).
+Each sub-task is one sub-issue under the parent, and a small focused PR. It inherits context from the parent issue — do not repeat the architecture or rationale. Create each as a sub-issue under the parent, ready to pick up, with an estimate, then add a `blocked-by` relation for each dependency (see `task-tracker` for the commands).
 
 ```markdown
 **Why this matters**  _(one plain-language line — see `plain-english`)_
@@ -453,7 +453,7 @@ Each sub-task is one sub-issue under the parent, and a small focused PR. It inhe
 
 Before any code sub-issue is created, write one sub-issue whose entire job is answering: **"how does anyone — with zero context — know the whole feature works when every sub-issue is done?"** Each sub-issue's own acceptance criteria only proves its own slice; nobody's acceptance criteria proves the assembled feature actually delivers the user story. This sub-issue is that missing check, written before the breakdown so it also doubles as a sanity check on the breakdown itself — if you can't write a concrete verification step, the shape probably isn't settled yet either.
 
-Create it as the **first** sub-issue under the parent, `state: Todo`, titled `Goal & verification — <feature>` (no `blockedBy` — nothing needs to finish before this is written, and every other sub-issue may link back to it). See `task-tracker` for the command:
+Create it as the **first** sub-issue under the parent, ready to pick up, titled `Goal & verification — <feature>` (no `blockedBy` — nothing needs to finish before this is written, and every other sub-issue may link back to it). See `task-tracker` for the command:
 
 ```markdown
 **Why this matters**


### PR DESCRIPTION
## Summary

Finishes the tracker-extraction started in SWO-512 (SWO-513→516). Those PRs swapped the word "Linear" for "tracker" but left the *mechanics* — CLI commands, the `SWO-NNN` identifier, state names, the GitHub-integration behaviour, and a redundant manual "mark it Done" — scattered across the workflow skills. This lifts all of it into the one owner skill, `task-tracker`, using a clean two-layer split:

- **Mental model (never changes, any tool):** a task's status changes at exactly **three moments** — you *start* it, it's *ready for review*, it's *done*. Consumers name the moment and defer.
- **Tooling layer (lives ONLY in `task-tracker`):** maps each moment to our current GitHub↔Linear setup — start = set `In Progress` by hand (the integration doesn't do it); ready-for-review = PR-open auto-sets `In Review`, nothing to do; done = merge auto-sets `Done` and auto-closes the parent, nothing to do.

After this, swapping trackers touches only `task-tracker`; every consumer keeps working unedited.

### What changed

- **`task-tracker`** (owner) — reframed its status section as *three moments → current mapping*; now also owns the `SWO-NNN` → branch/worktree naming + PR-linking convention.
- **`parallel-workflow`, `wait-for-pr-merge`, `product-planning`, `analyze`, `pr-descriptions`, `writing-task-specs`** — removed every `linear …` command, `SWO-NNN`, state name (`In Progress`/`In Review`/`Done`/`Todo`), and integration clause; each now names the moment/intent and points to `task-tracker`.
- Dropped the **redundant manual transitions**: no consumer sets `Done`/`In Review` by hand (automated), and the manual parent-close is gone (last child auto-closes).
- `Backlog`/`Todo` reframed as the pre-work **readiness** concept ("ready to pick up"); the state names stay in `task-tracker`.

Docs-only. Verified with `git grep`: zero tracker specifics remain in any consumer skill.

## Test plan

- [ ] `git grep` for `linear `/`SWO-NNN`/`In Progress`/`In Review`/`Todo`/`GitHub↔` across `.claude/skills` excluding `task-tracker` returns nothing.
- [ ] `task-tracker` reads as the single source: three-moment mapping + the ID/branch/PR-linking convention.
- [ ] Each consumer reads coherently and points to `task-tracker` at every status/tracker touchpoint.

Part of SWO-512 (parent). Reference: SWO-517.
