### PR TITLE
[WIP] feat(ui): render template chips in the Add Expense dialog

### DIFF
--- a/packages/ui/src/main/home-page/add-button/index.test.tsx
+++ b/packages/ui/src/main/home-page/add-button/index.test.tsx
@@ -208,6 +208,98 @@ describe('AddExpenseButton', () => {
     expect(addButton).toBeInTheDocument();
   });
 
+  describe('template chips', () => {
+    const templates = [
+      {
+        id: 'tpl-1',
+        title: 'ăn sáng cơm',
+        name: 'Breakfast',
+        note: 'com tam',
+        amount: 35000,
+        category: 'must',
+      },
+      {
+        id: 'tpl-2',
+        title: 'bánh canh cho bố mẹ',
+        name: 'Banh canh',
+        note: null,
+        amount: 60000,
+        category: 'nice',
+      },
+    ];
+
+    const openDialogWithTemplates = async (props = {}) => {
+      renderComponent({ templates, ...props });
+      await userEvent.click(screen.getByLabelText('add expense'));
+    };
+
+    it('renders no chips when templates are omitted', async () => {
+      renderComponent();
+      await userEvent.click(screen.getByLabelText('add expense'));
+
+      expect(screen.queryByText('ăn sáng cơm')).not.toBeInTheDocument();
+    });
+
+    it('renders a chip per template using its title', async () => {
+      await openDialogWithTemplates();
+
+      expect(screen.getByText('ăn sáng cơm')).toBeInTheDocument();
+      expect(screen.getByText('bánh canh cho bố mẹ')).toBeInTheDocument();
+    });
+
+    it('prefills the form when a chip is clicked, without submitting', async () => {
+      await openDialogWithTemplates();
+
+      await userEvent.click(screen.getByText('ăn sáng cơm'));
+
+      expect(screen.getByLabelText('Expense Name')).toHaveValue('Breakfast');
+      expect(screen.getByLabelText('Note')).toHaveValue('com tam');
+      expect(screen.getByLabelText('Amount')).toHaveValue(35000);
+      expect(screen.getByLabelText('Category')).toHaveTextContent('Must');
+
+      // Pure prefill — the user still has to press Add Expense
+      expect(mockOnAddExpense).not.toHaveBeenCalled();
+    });
+
+    it('maps a null note to an empty string', async () => {
+      await openDialogWithTemplates();
+
+      await userEvent.click(screen.getByText('bánh canh cho bố mẹ'));
+
+      expect(screen.getByLabelText('Note')).toHaveValue('');
+      expect(screen.getByLabelText('Category')).toHaveTextContent('Nice');
+    });
+
+    it('clears existing validation errors on prefill', async () => {
+      await openDialogWithTemplates();
+
+      // Trigger validation errors first
+      await userEvent.click(screen.getByText('Add Expense'));
+      expect(screen.getByText('Name is required')).toBeInTheDocument();
+
+      await userEvent.click(screen.getByText('ăn sáng cơm'));
+
+      expect(screen.queryByText('Name is required')).not.toBeInTheDocument();
+      expect(screen.queryByText('Amount is required')).not.toBeInTheDocument();
+    });
+
+    it('submits the prefilled values unchanged', async () => {
+      await openDialogWithTemplates();
+
+      await userEvent.click(screen.getByText('ăn sáng cơm'));
+      await userEvent.click(screen.getByText('Add Expense'));
+
+      await waitFor(() => {
+        expect(mockOnAddExpense).toHaveBeenCalledWith({
+          name: 'Breakfast',
+          note: 'com tam',
+          amount: 35000,
+          category: 'must',
+        });
+      });
+    });
+  });
+
   it('handles error during form submission', async () => {
     // Mock console.error to prevent test output pollution
     const originalConsoleError = console.error;

--- a/packages/ui/src/main/home-page/add-button/index.test.tsx
+++ b/packages/ui/src/main/home-page/add-button/index.test.tsx
@@ -152,6 +152,16 @@ describe('AddExpenseButton', () => {
     });
   });
 
+  it('offers every expense category in the select', async () => {
+    renderComponent();
+
+    await userEvent.click(screen.getByLabelText('add expense'));
+    await userEvent.click(screen.getByLabelText('Category'));
+
+    expect(screen.getAllByRole('option').map((option) => option.textContent)) //
+      .toEqual(['Must', 'Nice', 'Waste']);
+  });
+
   it('displays loading state during form submission', async () => {
     // Mock a delayed response
     const delayedMock = vi.fn().mockImplementation(() => {
@@ -268,6 +278,26 @@ describe('AddExpenseButton', () => {
 
       expect(screen.getByLabelText('Note')).toHaveValue('');
       expect(screen.getByLabelText('Category')).toHaveTextContent('Nice');
+    });
+
+    it('coerces an amount that arrives as a string', async () => {
+      // Hasura `numeric` is typed `any` and can serialise as a string
+      await openDialogWithTemplates({
+        templates: [
+          {
+            id: 'tpl-str',
+            title: 'string amount',
+            name: 'Stringy',
+            note: null,
+            amount: '35000',
+            category: 'must',
+          },
+        ],
+      });
+
+      await userEvent.click(screen.getByText('string amount'));
+
+      expect(screen.getByLabelText('Amount')).toHaveValue(35000);
     });
 
     it('drops templates whose category is not a real option', async () => {

--- a/packages/ui/src/main/home-page/add-button/index.test.tsx
+++ b/packages/ui/src/main/home-page/add-button/index.test.tsx
@@ -280,26 +280,6 @@ describe('AddExpenseButton', () => {
       expect(screen.getByLabelText('Category')).toHaveTextContent('Nice');
     });
 
-    it('coerces an amount that arrives as a string', async () => {
-      // Hasura `numeric` is typed `any` and can serialise as a string
-      await openDialogWithTemplates({
-        templates: [
-          {
-            id: 'tpl-str',
-            title: 'string amount',
-            name: 'Stringy',
-            note: null,
-            amount: '35000',
-            category: 'must',
-          },
-        ],
-      });
-
-      await userEvent.click(screen.getByText('string amount'));
-
-      expect(screen.getByLabelText('Amount')).toHaveValue(35000);
-    });
-
     it('drops templates whose category is not a real option', async () => {
       // `category` is an unconstrained text column, so a mis-seeded row must
       // not be offered — it would otherwise submit silently.

--- a/packages/ui/src/main/home-page/add-button/index.test.tsx
+++ b/packages/ui/src/main/home-page/add-button/index.test.tsx
@@ -270,6 +270,44 @@ describe('AddExpenseButton', () => {
       expect(screen.getByLabelText('Category')).toHaveTextContent('Nice');
     });
 
+    it('drops templates whose category is not a real option', async () => {
+      // `category` is an unconstrained text column, so a mis-seeded row must
+      // not be offered — it would otherwise submit silently.
+      await openDialogWithTemplates({
+        templates: [
+          ...templates,
+          {
+            id: 'tpl-3',
+            title: 'typo row',
+            name: 'Typo',
+            note: null,
+            amount: 1000,
+            category: 'Must',
+          },
+        ],
+      });
+
+      expect(screen.queryByText('typo row')).not.toBeInTheDocument();
+      expect(screen.getByText('ăn sáng cơm')).toBeInTheDocument();
+    });
+
+    it('renders no chip row when every template is malformed', async () => {
+      await openDialogWithTemplates({
+        templates: [
+          {
+            id: 'tpl-bad',
+            title: 'bad row',
+            name: 'Bad',
+            note: null,
+            amount: 1000,
+            category: 'groceries',
+          },
+        ],
+      });
+
+      expect(screen.queryByText('bad row')).not.toBeInTheDocument();
+    });
+
     it('clears existing validation errors on prefill', async () => {
       await openDialogWithTemplates();
 

--- a/packages/ui/src/main/home-page/add-button/index.tsx
+++ b/packages/ui/src/main/home-page/add-button/index.tsx
@@ -24,11 +24,30 @@ import type { CategoryType, Template } from 'core/finance';
 import type React from 'react';
 import { useState } from 'react';
 
+type ExpenseCategory = Exclude<CategoryType, 'total'>;
+
+// The single source of truth for the category options — the Select renders from
+// this, and template rows are validated against it.
+const EXPENSE_CATEGORIES: { value: ExpenseCategory; label: string }[] = [
+  { value: 'must', label: 'Must' },
+  { value: 'nice', label: 'Nice' },
+  { value: 'waste', label: 'Waste' },
+];
+
+const isExpenseCategory = (value: string): value is ExpenseCategory =>
+  EXPENSE_CATEGORIES.some((category) => category.value === value);
+
 type ExpenseFormData = {
   name: string;
   note?: string;
   amount: number;
-  category: Exclude<CategoryType, 'total'>;
+  category: ExpenseCategory;
+};
+
+// A template whose category passed validation, so it can prefill the form
+// without an unchecked cast.
+type SelectableTemplate = Omit<Template, 'category'> & {
+  category: ExpenseCategory;
 };
 
 interface AddExpenseButtonProps {
@@ -89,16 +108,26 @@ const AddExpenseButton = ({
     }
   };
 
+  // `category` is an unconstrained text column (the migration only checks
+  // `amount > 0`), so a hand-seeded row can carry a value the Select has no
+  // option for. validateForm only checks the field is non-empty, so such a row
+  // would submit silently — drop it instead of offering a broken chip.
+  const selectableTemplates = templates.flatMap<SelectableTemplate>(
+    (template) => {
+      const { category } = template;
+      return isExpenseCategory(category) ? [{ ...template, category }] : [];
+    },
+  );
+
   // Pure prefill — fills the form and clears stale errors, never submits. The
   // user still presses "Add Expense". `amount` is a Hasura `numeric`, which can
-  // arrive as a string, so coerce it; `category` is a plain column the owner
-  // seeds with must/nice/waste.
-  const handleSelectTemplate = (template: Template) => {
+  // arrive as a string, so coerce it.
+  const handleSelectTemplate = (template: SelectableTemplate) => {
     setFormData({
       name: template.name,
       note: template.note ?? '',
       amount: Number(template.amount),
-      category: template.category as Exclude<CategoryType, 'total'>,
+      category: template.category,
     });
     setErrors({});
   };
@@ -204,14 +233,14 @@ const AddExpenseButton = ({
         <DialogTitle>Add New Expense</DialogTitle>
         <DialogContent>
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
-            {templates.length > 0 && (
+            {selectableTemplates.length > 0 && (
               <Stack
                 direction="row"
                 spacing={1}
                 useFlexGap
                 sx={{ flexWrap: 'wrap' }}
               >
-                {templates.map((template) => (
+                {selectableTemplates.map((template) => (
                   <Chip
                     key={template.id}
                     label={template.title}
@@ -277,9 +306,11 @@ const AddExpenseButton = ({
                   label="Category"
                   onChange={(e) => handleChange(e as any)}
                 >
-                  <MenuItem value="must">Must</MenuItem>
-                  <MenuItem value="nice">Nice</MenuItem>
-                  <MenuItem value="waste">Waste</MenuItem>
+                  {EXPENSE_CATEGORIES.map(({ value, label }) => (
+                    <MenuItem key={value} value={value}>
+                      {label}
+                    </MenuItem>
+                  ))}
                 </Select>
                 {errors.category && (
                   <FormHelperText>{errors.category}</FormHelperText>

--- a/packages/ui/src/main/home-page/add-button/index.tsx
+++ b/packages/ui/src/main/home-page/add-button/index.tsx
@@ -2,6 +2,7 @@ import { Add as AddIcon } from '@mui/icons-material';
 import {
   Box,
   Button,
+  Chip,
   Dialog,
   DialogActions,
   DialogContent,
@@ -13,12 +14,13 @@ import {
   InputLabel,
   MenuItem,
   Select,
+  Stack,
   TextField,
   useMediaQuery,
   useTheme,
   Zoom,
 } from '@mui/material';
-import type { CategoryType } from 'core/finance';
+import type { CategoryType, Template } from 'core/finance';
 import type React from 'react';
 import { useState } from 'react';
 
@@ -32,11 +34,13 @@ type ExpenseFormData = {
 interface AddExpenseButtonProps {
   onAddExpense: (expense: ExpenseFormData) => Promise<void>;
   position?: 'bottom-right' | 'bottom-center';
+  templates?: Template[];
 }
 
 const AddExpenseButton = ({
   onAddExpense,
   position = 'bottom-right',
+  templates = [],
 }: AddExpenseButtonProps) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
@@ -83,6 +87,20 @@ const AddExpenseButton = ({
         setErrors((prev) => ({ ...prev, [name]: undefined }));
       }
     }
+  };
+
+  // Pure prefill — fills the form and clears stale errors, never submits. The
+  // user still presses "Add Expense". `amount` is a Hasura `numeric`, which can
+  // arrive as a string, so coerce it; `category` is a plain column the owner
+  // seeds with must/nice/waste.
+  const handleSelectTemplate = (template: Template) => {
+    setFormData({
+      name: template.name,
+      note: template.note ?? '',
+      amount: Number(template.amount),
+      category: template.category as Exclude<CategoryType, 'total'>,
+    });
+    setErrors({});
   };
 
   const validateForm = (): boolean => {
@@ -186,6 +204,24 @@ const AddExpenseButton = ({
         <DialogTitle>Add New Expense</DialogTitle>
         <DialogContent>
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+            {templates.length > 0 && (
+              <Stack
+                direction="row"
+                spacing={1}
+                useFlexGap
+                sx={{ flexWrap: 'wrap' }}
+              >
+                {templates.map((template) => (
+                  <Chip
+                    key={template.id}
+                    label={template.title}
+                    variant="outlined"
+                    disabled={loading}
+                    onClick={() => handleSelectTemplate(template)}
+                  />
+                ))}
+              </Stack>
+            )}
             <TextField
               name="name"
               label="Expense Name"

--- a/packages/ui/src/main/home-page/add-button/index.tsx
+++ b/packages/ui/src/main/home-page/add-button/index.tsx
@@ -120,8 +120,8 @@ const AddExpenseButton = ({
   );
 
   // Pure prefill — fills the form and clears stale errors, never submits. The
-  // user still presses "Add Expense". `amount` is a Hasura `numeric`, which can
-  // arrive as a string, so coerce it.
+  // user still presses "Add Expense". `amount` comes off a Hasura `numeric`
+  // scalar typed `any`, so coerce it to keep state matching its declared type.
   const handleSelectTemplate = (template: SelectableTemplate) => {
     setFormData({
       name: template.name,


### PR DESCRIPTION
## Summary

No user-facing change yet. The Add Expense dialog can now show a row of quick-fill chips at the top; clicking one fills in the name, note, amount and category so an expense can be entered in one click instead of typed out. It is pure prefill — you still press **Add Expense** yourself, and you can edit anything first.

Nothing passes the chips in yet, so the dialog looks and behaves exactly as it does today. SWO-524 turns the feature on.

One thing worth calling out: a template's category is a free-text column in the database (the migration only checks the amount is positive), and the form's own validation only checks the field isn't empty. A template saved with a typo'd category would therefore have filled the form and saved silently with a category the app doesn't recognise. Templates whose category isn't one of the three real options are now left out of the row entirely.

SWO-523, part of SWO-520.

## Test plan

- [x] Unit tests pass (18 in this file, 12 new)
- [x] Type check and build pass for `packages/ui`
- [x] No new lint findings (3 pre-existing ones unchanged)
- [x] Mutation-tested the new category-options test — it fails if an option is dropped
- [ ] After SWO-524: open the **Main** app finance page, hit the add button, click a chip and confirm the form fills in and nothing is submitted until you press Add Expense