### PR TITLE
[WIP] feat(main): wire templates into the finance dialog

### DIFF
--- a/apps/main/src/routes/finance.lazy.tsx
+++ b/apps/main/src/routes/finance.lazy.tsx
@@ -236,6 +236,7 @@ const Content = () => {
       <AddExpenseButton
         onAddExpense={handleAddExpense}
         position="bottom-right"
+        templates={data?.templates}
       />
 
       {enabledTransactionsDialog && (


### PR DESCRIPTION
## Summary

This turns the expense templates feature on. The finance page already fetches your saved templates as part of the month query — this passes them into the Add Expense dialog, so opening it now shows a row of quick-fill chips at the top. Click one and the name, note, amount and category fill in; you still press **Add Expense** yourself and can edit anything first.

The templates table ships empty, so nothing appears on screen until rows are seeded in the database.

Last of the four steps in SWO-520. SWO-524.

## Test plan

- [x] Type check and build pass for the Main app
- [x] No new lint findings
- [ ] Seed a template row, open the finance page, hit the add button, click a chip — the form fills in and nothing saves until you press Add Expense
- [ ] With no templates seeded, the dialog looks exactly as before
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved the add-expense flow by providing available expense templates when adding a new expense.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->