### PR TITLE
[WIP] fix(ui): move template chips below the Add Expense form fields

### DIFF
--- a/packages/ui/src/main/home-page/add-button/index.test.tsx
+++ b/packages/ui/src/main/home-page/add-button/index.test.tsx
@@ -257,6 +257,19 @@ describe('AddExpenseButton', () => {
       expect(screen.getByText('bánh canh cho bố mẹ')).toBeInTheDocument();
     });
 
+    it('renders the chips below the form fields', async () => {
+      await openDialogWithTemplates();
+
+      const categoryField = screen.getByLabelText('Category');
+      const chip = screen.getByText('ăn sáng cơm');
+
+      // Chips are a shortcut, so they sit after every field in document order
+      expect(
+        categoryField.compareDocumentPosition(chip) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+    });
+
     it('prefills the form when a chip is clicked, without submitting', async () => {
       await openDialogWithTemplates();
 

--- a/packages/ui/src/main/home-page/add-button/index.tsx
+++ b/packages/ui/src/main/home-page/add-button/index.tsx
@@ -233,24 +233,6 @@ const AddExpenseButton = ({
         <DialogTitle>Add New Expense</DialogTitle>
         <DialogContent>
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
-            {selectableTemplates.length > 0 && (
-              <Stack
-                direction="row"
-                spacing={1}
-                useFlexGap
-                sx={{ flexWrap: 'wrap' }}
-              >
-                {selectableTemplates.map((template) => (
-                  <Chip
-                    key={template.id}
-                    label={template.title}
-                    variant="outlined"
-                    disabled={loading}
-                    onClick={() => handleSelectTemplate(template)}
-                  />
-                ))}
-              </Stack>
-            )}
             <TextField
               name="name"
               label="Expense Name"
@@ -317,6 +299,29 @@ const AddExpenseButton = ({
                 )}
               </FormControl>
             </Box>
+
+            {/* Below the fields on purpose: the chips are a shortcut, not the
+                primary input, and templates arrive asynchronously — sitting
+                last means a late arrival can't shove the fields down while
+                the user is already typing. */}
+            {selectableTemplates.length > 0 && (
+              <Stack
+                direction="row"
+                spacing={1}
+                useFlexGap
+                sx={{ flexWrap: 'wrap' }}
+              >
+                {selectableTemplates.map((template) => (
+                  <Chip
+                    key={template.id}
+                    label={template.title}
+                    variant="outlined"
+                    disabled={loading}
+                    onClick={() => handleSelectTemplate(template)}
+                  />
+                ))}
+              </Stack>
+            )}
           </Box>
         </DialogContent>
         <DialogActions sx={{ px: 3, pb: 3 }}>


### PR DESCRIPTION
## Summary

The quick-fill chips sat at the top of the Add Expense dialog, above the Name field. They now sit below the fields instead, just above the Cancel / Add Expense buttons.

Two reasons. The fields are the main thing in the dialog — the chips are a shortcut, so they shouldn't take the first position. And it removes a jump: the templates load in the background, so opening the dialog before they arrived made the chip row appear above the Name field and shove everything down while you were already typing in it. Sitting last, a late arrival can't move anything.

Nothing else changed — same chips, same click behaviour, still nothing shown when there are no templates. A new test pins the on-screen order so it can't drift back.

Follow-up to SWO-523. SWO-556.

## Test plan

- [x] Unit tests pass (19, one new)
- [x] Type check and build pass for `packages/ui`
- [x] No new lint findings
- [x] Verified the change is a pure move — removed and added lines are byte-identical
- [x] Mutation-tested the order test: moving the chips back to the top makes it fail
- [ ] With a template seeded, open the finance Add Expense dialog and confirm the chips sit under the Amount/Category row