### PR TITLE
fix(extension): restore styling broken by the MUI v9 upgrade

### DIFF
--- a/apps/extension/src/components/ActionCard.tsx
+++ b/apps/extension/src/components/ActionCard.tsx
@@ -29,18 +29,18 @@ const ActionCard = ({
 }: ActionCardProps) => (
   <Card variant="outlined">
     <CardContent>
-      <Box display="flex" alignItems="center" gap={1} mb={1}>
-        <Typography variant="subtitle2" fontWeight="bold" noWrap>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+        <Typography variant="subtitle2" sx={{ fontWeight: 'bold' }} noWrap>
           {title}
         </Typography>
         <Chip label={typeLabel} size="small" variant="outlined" />
       </Box>
       {description && (
-        <Typography variant="body2" color="text.secondary" mb={1}>
+        <Typography variant="body2" sx={{ color: 'text.secondary', mb: 1 }}>
           {description}
         </Typography>
       )}
-      <Typography variant="caption" color="text.disabled" noWrap>
+      <Typography variant="caption" noWrap sx={{ color: 'text.disabled' }}>
         {url}
       </Typography>
     </CardContent>

--- a/apps/extension/src/components/AuthPanel.tsx
+++ b/apps/extension/src/components/AuthPanel.tsx
@@ -19,7 +19,7 @@ const AuthPanel = () => {
 
   if (authenticated === null) {
     return (
-      <Box display="flex" justifyContent="center" p={4}>
+      <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
         <CircularProgress />
       </Box>
     );
@@ -27,18 +27,18 @@ const AuthPanel = () => {
 
   if (authenticated) {
     return (
-      <Box p={2}>
+      <Box sx={{ p: 2 }}>
         <Alert severity="success">Extension connected to your account.</Alert>
       </Box>
     );
   }
 
   return (
-    <Box p={2}>
+    <Box sx={{ p: 2 }}>
       <Alert severity="info" sx={{ mb: 2 }}>
         Log in to shinabr2.com in this browser to connect your extension.
       </Alert>
-      <Typography variant="body2" color="text.secondary">
+      <Typography variant="body2" sx={{ color: 'text.secondary' }}>
         Once you&apos;re signed in, your account token is sent to the extension
         automatically.
       </Typography>

--- a/apps/extension/src/components/AutoDetectTab.tsx
+++ b/apps/extension/src/components/AutoDetectTab.tsx
@@ -15,7 +15,7 @@ const AutoDetectTab = ({
 }: AutoDetectTabProps) => {
   if (isLoading) {
     return (
-      <Box display="flex" justifyContent="center" p={4}>
+      <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
         <CircularProgress />
       </Box>
     );
@@ -23,8 +23,8 @@ const AutoDetectTab = ({
 
   if (!content) {
     return (
-      <Box p={2}>
-        <Typography color="text.secondary" align="center">
+      <Box sx={{ p: 2 }}>
+        <Typography align="center" sx={{ color: 'text.secondary' }}>
           No content detected on this page.
         </Typography>
       </Box>
@@ -39,7 +39,7 @@ const AutoDetectTab = ({
   const typeLabel = isPdf ? 'PDF Document' : isVideo ? 'Video' : 'Web Page';
 
   return (
-    <Box p={2}>
+    <Box sx={{ p: 2 }}>
       <ActionCard
         title={content.title}
         description={content.description}

--- a/apps/extension/src/components/ClipboardTab.tsx
+++ b/apps/extension/src/components/ClipboardTab.tsx
@@ -15,8 +15,8 @@ const ClipboardTab = ({ onImportClipboard }: ClipboardTabProps) => {
   };
 
   return (
-    <Box p={2}>
-      <Typography color="text.secondary" gutterBottom>
+    <Box sx={{ p: 2 }}>
+      <Typography gutterBottom sx={{ color: 'text.secondary' }}>
         Paste content below to detect and import.
       </Typography>
       <TextField

--- a/apps/extension/src/components/RecentTab.tsx
+++ b/apps/extension/src/components/RecentTab.tsx
@@ -17,8 +17,8 @@ interface RecentTabProps {
 const RecentTab = ({ imports, onRetry }: RecentTabProps) => {
   if (imports.length === 0) {
     return (
-      <Box p={2}>
-        <Typography color="text.secondary" align="center">
+      <Box sx={{ p: 2 }}>
+        <Typography align="center" sx={{ color: 'text.secondary' }}>
           No recent imports.
         </Typography>
       </Box>
@@ -26,7 +26,7 @@ const RecentTab = ({ imports, onRetry }: RecentTabProps) => {
   }
 
   return (
-    <Box p={2}>
+    <Box sx={{ p: 2 }}>
       <Typography variant="subtitle2" gutterBottom>
         Recent Imports
       </Typography>
@@ -50,7 +50,14 @@ const RecentTab = ({ imports, onRetry }: RecentTabProps) => {
             <ListItemText
               primary={imp.title || imp.importId}
               secondary={
-                <Box display="flex" alignItems="center" gap={1} mt={0.5}>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1,
+                    mt: 0.5,
+                  }}
+                >
                   <ImportStatusBadge status={imp.status} />
                   <Typography variant="caption">{imp.targetApp}</Typography>
                 </Box>

--- a/apps/extension/src/popup.tsx
+++ b/apps/extension/src/popup.tsx
@@ -75,9 +75,9 @@ const Popup = () => {
     return (
       <ThemeProvider theme={darkTheme}>
         <CssBaseline />
-        <Box width={400} minHeight={400}>
-          <Box sx={{ borderBottom: 1, borderColor: 'divider' }} p={2}>
-            <Typography variant="h6" fontWeight="bold">
+        <Box sx={{ width: 400, minHeight: 400 }}>
+          <Box sx={{ borderBottom: 1, borderColor: 'divider', p: 2 }}>
+            <Typography variant="h6" sx={{ fontWeight: 'bold' }}>
               SWorld
             </Typography>
           </Box>
@@ -92,14 +92,16 @@ const Popup = () => {
     <ThemeProvider theme={darkTheme}>
       <CssBaseline />
       <Box
-        width={400}
-        minHeight={400}
-        maxHeight={600}
-        display="flex"
-        flexDirection="column"
+        sx={{
+          width: 400,
+          minHeight: 400,
+          maxHeight: 600,
+          display: 'flex',
+          flexDirection: 'column',
+        }}
       >
-        <Box sx={{ borderBottom: 1, borderColor: 'divider' }} p={2}>
-          <Typography variant="h6" fontWeight="bold">
+        <Box sx={{ borderBottom: 1, borderColor: 'divider', p: 2 }}>
+          <Typography variant="h6" sx={{ fontWeight: 'bold' }}>
             SWorld
           </Typography>
         </Box>
@@ -112,7 +114,7 @@ const Popup = () => {
           <Tab label="Clipboard" />
           <Tab label="Recent" />
         </Tabs>
-        <Box flex={1} overflow="auto">
+        <Box sx={{ flex: 1, overflow: 'auto' }}>
           {tabIndex === 0 && (
             <AutoDetectTab
               content={content}


### PR DESCRIPTION
## Summary

The browser extension's popup is currently missing most of its styling, and has been since the MUI v9 upgrade. Nothing warned about it — the settings that position and space everything were quietly dropped on the floor, so the popup renders with no padding, no column layout, no size limits, no scrolling area and no bold headings.

MUI v9 **removed** the old shorthand styling props rather than deprecating them, and unknown props get forwarded straight to the page as invalid attributes. Verified by rendering against the installed packages:

```
<Box p={2} display="flex">           ->  class="css-0" p="2" display="flex"      (no styles at all)
<Box sx={{ p: 2, display: 'flex' }}> ->  .css-1fn4vgo{padding:16px;display:flex}
```

Two forms of the same removal, 26 sites:

- **20 shorthand system props** on `Box`/`Typography` (`p`, `mb`, `mt`, `display`, `gap`, `alignItems`, `justifyContent`, `flex`, `flexDirection`, `overflow`, `width`, `minHeight`, `maxHeight`, `fontWeight`) moved into `sx`.
- **6 uses of `color="text.secondary"` / `"text.disabled"`** moved into `sx`. In v9 Typography's `color` is matched by variant name, so the dotted paths match nothing and emit no colour rule — captions, helper text and empty states were rendering at full-brightness `text.primary` with no visual hierarchy. These only typecheck because the prop type ends in `(string & {})`, so nothing catches them.

Every value carries over verbatim. The visual change is the styling coming back. Clears all 20 `TS2769` errors, which is what SWO-560 needs before the extension can join the typecheck job.

Refs SWO-560

## Test plan

- Open the extension popup and confirm it now has padding, a 400px width, the header divider, a scrollable content area and bold headings — compare against `main`, where these are absent
- Confirm caption and helper text render dimmer than primary text again (empty states, "Recent Imports" secondary line, PDF/page descriptions)
- `npx vitest run`: 5 files, 92 tests pass
- `npx vite build`: builds clean
- No component nesting, conditional, key, ref or import changed — props only

## Note

The same `color="text.*"` defect exists at ~20 more sites in `packages/ui` and `apps/main`, outside this PR's scope. Raising separately.