### PR TITLE
feat(extension): wire the app into the typecheck job

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -9,6 +9,7 @@
     "test": "vitest",
     "lint": "biome lint --quit-on-problem .",
     "format": "biome format --write .",
+    "typecheck": "tsc --noEmit -p tsconfig.typecheck.json",
     "codegen": "dotenvx run -- graphql-codegen --config codegen.ts"
   },
   "dependencies": {

--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -49,11 +49,7 @@ const detectPdfTab = (url: string) => {
   currentPdfMetadata = {
     url,
     title,
-    author: null,
     pageCount: 0,
-    fileUrl: url,
-    fileName,
-    fileSizeBytes: null,
   };
 
   currentPageContent = {

--- a/apps/extension/tsconfig.typecheck.json
+++ b/apps/extension/tsconfig.typecheck.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "exclude": [
+    "node_modules",
+    "src/graphql",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.stories.ts",
+    "**/*.stories.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx"
+  ],
+  "compilerOptions": {
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## Summary

Every pull request runs an automatic check that reads the code and catches whole classes of mistakes before anyone opens the app. The browser extension was never connected to it — so it was the one live piece of the product where those mistakes could reach production unnoticed, despite it borrowing a lot of shared code that changes underneath it.

This connects it up. Final part of SWO-560; the two earlier PRs (#501, #502) cleared the way.

- **`tsconfig.typecheck.json`**, mirroring the four sibling apps: tests and stories excluded, `skipLibCheck: true` (which drops a `pdfjs-dist` `.d.ts` error that needs TypeScript 5.9 to resolve — the error is in a third-party type definition, not our source). It also excludes `src/graphql`, the generated codegen output — `biome.json` already excludes generated GraphQL for exactly the same reason. Verified nothing typechecked imports it, so this opens no gap.
- **`typecheck` script**, so the app joins `turbo run typecheck`.
- **One genuine type error fixed**, in `background.ts`.

### The `background.ts` fix

`detectPdfTab` built a `PdfMetadata` with `author: null` plus three fields the type has never had — `fileUrl`, `fileName`, `fileSizeBytes`. Nothing reads them: `importBook` takes only `title`, `author`, `url` and `pageCount`, and builds its mutation variables field-by-field with no spread. Note the type declares `fileSize`, not `fileSizeBytes` — that field was unreadable from the day it was written.

Behaviour-preserving: both readers of `author` use falsy coercion (`metadata.author || ''`), so `null` and absent collapse identically and Hasura receives a byte-identical `insert_books_one` payload. Omitting `author` also matches what the real PDF parser already emits.

`apps/game` is deliberately out of scope — dead and undeployed.

Refs SWO-560

## Test plan

- `turbo run typecheck --filter='!docs' --force` (what CI runs): **7/7 pass**, with `extension#typecheck` now present in the task graph — confirmed via `--dry=json`. Run with `--force` so no cache hit masks the result.
- `npx vitest run` in `apps/extension`: 5 files, 92 tests pass
- `npx vite build`: builds clean
- `tsc --listFiles` confirms test files and `src/graphql` are genuinely excluded
- PDF detection still imports a book with the same title, author and page count as before