### PR TITLE
fix: drop a Biome flag that no longer exists from 8 lint scripts

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -13,7 +13,7 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc",
-    "lint": "biome lint --quit-on-problem .",
+    "lint": "biome lint .",
     "format": "biome format --write ."
   },
   "dependencies": {

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -7,7 +7,7 @@
     "dev": "vite build --watch",
     "build": "vite build",
     "test": "vitest",
-    "lint": "biome lint --quit-on-problem .",
+    "lint": "biome lint .",
     "format": "biome format --write .",
     "typecheck": "tsc --noEmit -p tsconfig.typecheck.json",
     "codegen": "dotenvx run -- graphql-codegen --config codegen.ts"

--- a/apps/game/package.json
+++ b/apps/game/package.json
@@ -6,7 +6,7 @@
     "dev": "pnpm run pre-dev && vite",
     "pre-dev": "cp ../../.env.development.local .env",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist && rm -f .env*",
-    "lint": "biome lint --quit-on-problem .",
+    "lint": "biome lint .",
     "format": "biome format --write ."
   },
   "dependencies": {

--- a/apps/listen/package.json
+++ b/apps/listen/package.json
@@ -11,7 +11,7 @@
     "dev": "pnpm run pre-dev && vite",
     "e2e": "pnpm exec playwright test",
     "e2e-codegen": "pnpm exec playwright codegen",
-    "lint": "biome lint --quit-on-problem .",
+    "lint": "biome lint .",
     "format": "biome format --write .",
     "typecheck": "tsc --noEmit -p tsconfig.typecheck.json"
   },

--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -12,7 +12,7 @@
     "build:e2e": "VITE_HASURA_DOMAIN=https://hasura.e2e.local VITE_AUTH0_DOMAIN=auth.e2e.local VITE_AUTH0_CLIENT_ID=e2e-client-id VITE_MAIN_SITE_URL=e2e.local VITE_ROLLBAR_TOKEN=e2e-token VITE_ROLLBAR_ENV=test vite build",
     "preview:e2e": "vite preview --port 4000 --strictPort",
     "e2e": "playwright test",
-    "lint": "biome lint --quit-on-problem .",
+    "lint": "biome lint .",
     "format": "biome format --write .",
     "typecheck": "tsc --noEmit -p tsconfig.typecheck.json"
   },

--- a/apps/til/package.json
+++ b/apps/til/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist && rm -f .env*",
     "pre-dev": "cp ../../.env.development.local .env",
-    "lint": "biome lint --quit-on-problem .",
+    "lint": "biome lint .",
     "format": "biome format --write .",
     "dev": "pnpm run pre-dev && vite",
     "build": "vite build",

--- a/apps/watch/package.json
+++ b/apps/watch/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist && rm -f .env*",
     "pre-dev": "cp ../../.env.development.local .env",
-    "lint": "biome lint --quit-on-problem .",
+    "lint": "biome lint .",
     "format": "biome format --write .",
     "dev": "pnpm run pre-dev && vite",
     "build": "vite build",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,7 +31,7 @@
     "build-watch": "tsup --watch --no-dts",
     "clean": "rm -rf dist",
     "dev": "tsup src/index.ts --format esm,cjs --watch --dts --external react",
-    "lint": "biome lint --quit-on-problem .",
+    "lint": "biome lint .",
     "format": "biome format --write .",
     "test": "vitest --coverage",
     "typecheck": "tsc --noEmit -p tsconfig.typecheck.json"


### PR DESCRIPTION
## Summary

The code-quality check does not run for most of the codebase. It fails instantly with a complaint about an unrecognised option, so nothing gets checked — and because the failure looks like a tooling problem rather than a code problem, nobody chased it.

Biome 2.2 removed `--quit-on-problem`, but eight packages still pass it, so `biome lint --quit-on-problem .` exits with `Error: --quit-on-problem is not expected in this context` before linting a single file. Only `packages/ui` (`biome check .`) escaped it.

**Nothing was going red over this**, which is why it survived: the root `pnpm lint` is `biome check .`, which works, and no CI workflow runs lint at all. What was actually broken is `turbo run lint` and running `pnpm lint` inside any of those packages.

## What this changes

Removing the flag turns a meaningless failure into real signal:

| | Before | After |
|---|---|---|
| extension, listen, main, watch | fail (flag) | **pass** |
| core (16), game (13), til (2), docs (1) | fail (flag) | fail (real errors) |

No package regresses. The 32 errors were always there, just unreachable behind a broken flag — mostly `noExplicitAny`, `noUnusedFunctionParameters` and `useExhaustiveDependencies`.

**This PR deliberately does not fix them.** They need type judgement, not a flag removal, and `apps/game` (13 of the 32) is a dead undeployed app whose fate should be decided before anyone spends effort on it. Tracked as SWO-564, blocked by this. Note the same debt is already visible today: root `pnpm lint` fails on `main` right now with 17 errors.

So `turbo run lint` still fails after this — for true reasons instead of a fake one.

Refs SWO-563

## Test plan

- Per-package `biome lint .` exit codes measured before and after: 8 fail → 4 pass / 4 fail on real errors
- `pnpm install` succeeds, so all 8 `package.json` files remain valid
- Root `pnpm lint` (`biome check .`) behaviour unchanged
- No CI workflow references lint, so no job's outcome changes
- No rule disabled, no `biome-ignore` added