### PR TITLE
[WIP] docs(skills): copy .linear.toml into new worktrees (SWO-565)

### DIFF
--- a/.claude/skills/parallel-workflow/SKILL.md
+++ b/.claude/skills/parallel-workflow/SKILL.md
@@ -16,7 +16,7 @@ user-invocable: false
 This workflow applies to the whole workspace — **sworld** (frontend), **sworld-backend** (Hono), and **sworld-hasura-v2** (Hasura) — not just the frontend. Same rules everywhere: tracker issue first, dedicated worktree, commit often / push immediately, self-review loop before PR, CI loop after. Repo-specific adjustments:
 
 - **Substitute the repo name in `gh` commands.** Every `gh` / GraphQL call is repo-scoped — fill in `sworld`, `sworld-backend`, or `sworld-hasura-v2`. Querying the wrong repo silently returns nothing. (The `ci-loop` gate queries carry the same rule.)
-- **Worktree setup steps 7–8 are frontend-specific** (.env copies into `apps/<app>/`, `packages/core/.env`, `pnpm install`). In a sibling repo, follow that repo's own setup instead.
+- **Worktree setup step 7 (`.linear.toml`) applies everywhere; step 8 is frontend-specific** (.env copies into `apps/<app>/`, `packages/core/.env`, `pnpm install`). In a sibling repo, copy `.linear.toml` the same way, then follow that repo's own setup instead of step 8.
 - **Trust boundaries get the deep treatment.** Hasura permissions/metadata and Hono Action/Event/webhook handlers are trust boundaries — in those repos the self-review loop (step 11) MUST also include the `security-reviewer` skill.
 - **Hasura changes are not done when their PR is clean.** A schema change ripples into the frontend: apply the migration locally, re-run `pnpm codegen` in `packages/core` (it introspects the LOCAL Hasura), and land the regenerated types as a follow-up frontend PR — linked in the tracker with a blocking relation from the Hasura issue.
 
@@ -43,8 +43,8 @@ The refresh mechanic and every trigger for it are owned by the `cleanup` skill �
 
 5. `git fetch origin main` first, then create worktree inside `.claude/worktrees/` from `origin/main`.
 6. Create the worktree under `.claude/worktrees/` — self-contained, gitignored, and aligned with Claude Code's official default — named for the issue per `task-tracker`'s branch convention.
-7. Copy `.env` files from the main worktree into the matching `apps/<app>/` directories. **Also copy `packages/core/.env`** — `pnpm codegen` reads `HASURA_GRAPHQL_URL` / `HASURA_ADMIN_SECRET` from it; without it codegen aborts with `Unable to find any GraphQL type definitions ... - undefined`.
-8. Run `pnpm install` in each worktree.
+7. **Copy `.linear.toml` from the repo root into the worktree root.** It is gitignored (it can hold a plaintext API key), so a fresh worktree starts without it — and the `linear` CLI's config lookup stops at the checkout root, never walking up to the main worktree. Without it every tracker command silently resolves to the account's *default* workspace, which is not `sworld`: reads return the wrong workspace's data, and writes fail with `Team not found: SWO`. Applies to all three repos.
+8. Copy `.env` files from the main worktree into the matching `apps/<app>/` directories. **Also copy `packages/core/.env`** — `pnpm codegen` reads `HASURA_GRAPHQL_URL` / `HASURA_ADMIN_SECRET` from it; without it codegen aborts with `Unable to find any GraphQL type definitions ... - undefined`. Then run `pnpm install` in the worktree.
 
 ## During work
 
@@ -60,7 +60,7 @@ Once a breakdown or plan is approved, work through it without pausing to reconfi
 ## Codegen
 
 - ALWAYS `git fetch origin main && git merge origin/main` before running codegen.
-- Run `pnpm codegen` in `packages/core` to regenerate GraphQL types. Needs `packages/core/.env` in the worktree (see step 7) — codegen introspects the live Hasura schema using the URL/secret from it.
+- Run `pnpm codegen` in `packages/core` to regenerate GraphQL types. Needs `packages/core/.env` in the worktree (see step 8) — codegen introspects the live Hasura schema using the URL/secret from it.
 - See `architecture` skill for GraphQL conventions (generated files, `graphql()` usage).
 
 ## Resolving conflicts

--- a/.claude/skills/task-tracker/SKILL.md
+++ b/.claude/skills/task-tracker/SKILL.md
@@ -35,7 +35,12 @@ live in Linear.
 - **Never the Linear MCP.** A connected Linear MCP server authenticates as the *wrong account* —
   never use `mcp__*Linear*` tools for any tracker operation. If the CLI is missing or broken, stop
   and tell the user; do not fall back to MCP.
-- **The CLI resolves its workspace from `.linear.toml` at the checkout root.** That file is gitignored, so a fresh git worktree has none and the CLI silently falls back to the account's default workspace — which is not `sworld`. Reads then return another workspace's data and writes fail with `Team not found: SWO`. `parallel-workflow`'s worktree setup copies the file in; if a tracker command behaves oddly, check the file is there before anything else.
+- **The CLI resolves its workspace from `.linear.toml` at the checkout root**, and never
+  walks up to a parent. That file is gitignored, so a fresh git worktree starts without
+  one and the CLI silently falls back to the account's default workspace — which is not
+  `sworld`: reads return another workspace's data, writes fail with `Team not found: SWO`.
+  `parallel-workflow`'s worktree setup copies it in. If a tracker command misbehaves in a
+  worktree, check that file first.
 - **For anything the CLI doesn't expose** (e.g. querying parent/sub-issue relationships), use
   `linear auth token` + a direct Linear GraphQL API call with curl.
 

--- a/.claude/skills/task-tracker/SKILL.md
+++ b/.claude/skills/task-tracker/SKILL.md
@@ -35,6 +35,7 @@ live in Linear.
 - **Never the Linear MCP.** A connected Linear MCP server authenticates as the *wrong account* —
   never use `mcp__*Linear*` tools for any tracker operation. If the CLI is missing or broken, stop
   and tell the user; do not fall back to MCP.
+- **The CLI resolves its workspace from `.linear.toml` at the checkout root.** That file is gitignored, so a fresh git worktree has none and the CLI silently falls back to the account's default workspace — which is not `sworld`. Reads then return another workspace's data and writes fail with `Team not found: SWO`. `parallel-workflow`'s worktree setup copies the file in; if a tracker command behaves oddly, check the file is there before anything else.
 - **For anything the CLI doesn't expose** (e.g. querying parent/sub-issue relationships), use
   `linear auth token` + a direct Linear GraphQL API call with curl.
 


### PR DESCRIPTION
## Summary

The `linear` CLI reads which Linear workspace to talk to from `.linear.toml` at the root of the checkout. That file is gitignored — deliberately, since it can hold a plaintext `api_key` (#424) — so a freshly created git worktree has none, and the CLI's lookup stops at the checkout root rather than walking up to the main worktree.

The result: every tracker command run from a worktree silently resolved to the account's *default* workspace instead of `sworld`. Reads returned another workspace's data; writes failed with `Team not found: SWO`.

Reproduced from an existing worktree:

```
$ linear team list          # no .linear.toml present
FEA Dev
PRO Product

$ printf 'workspace = "sworld"\n' > .linear.toml && linear team list
SWO SWorld
```

Fix is to copy the file as part of worktree setup rather than commit it, keeping the no-token-in-git guarantee intact:

- `parallel-workflow` — new step 7 copies `.linear.toml`. It applies to all three repos, unlike the frontend-only `.env` / `pnpm install` work, which folds into step 8.
- `task-tracker` — records the symptom next to where the CLI is documented, so `Team not found: SWO` is diagnosable at the point of failure.

Known gap, accepted: because the file stays untracked, nothing self-heals — a worktree created without following step 7 is still pointed at the wrong workspace. Same tradeoff `.env` already carries here.

Renumbering was checked across all three repos' `.claude/` trees: the surviving `step 11` / `step 14` references (including `review-gate.sh`) are unaffected, since only steps 7–8 moved.

## Test plan

- [x] `linear team list` from a worktree **without** the file lists `FEA`/`PRO` (wrong workspace)
- [x] `linear team list` from a worktree **with** the file lists `SWO`
- [x] `linear issue update SWO-565` succeeds from this worktree with the file copied in
- [x] `git status` still shows no `.linear.toml` — it remains gitignored and uncommitted
- [x] No remaining stale `step N` reference in any skill, hook, or AGENTS.md

Refs SWO-565