### PR TITLE
docs: describe backend and hasura as in-repo workspace members

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,14 +50,14 @@ Everything below is a member of the one pnpm workspace, resolved by the single r
 - **til** — "Today I Learned" blog/notes application
 - **watch** — Video streaming/watching application
 
-### Backend & data layer (`apps/`)
+### Backend & data layer
 
-- **backend** (`apps/backend`) — Hono backend handling Hasura Actions / Events (custom business logic triggered by Hasura). Three services — gateway, io, compute — in one package; it consumes `core` as a workspace dependency (`workspace:*`).
-- **hasura** (`apps/hasura`) — Hasura GraphQL + Postgres: migrations, metadata, and permissions — the data layer the frontend queries. Hasura Cloud's GitHub integration watches this directory and applies metadata and migrations when a change merges to `main`.
+- **`apps/backend`** (package `backend`) — Hono backend handling Hasura Actions / Events (custom business logic triggered by Hasura). Three services — gateway, io, compute — in one package; it consumes `core` as a workspace dependency (`workspace:*`).
+- **`apps/hasura`** (package `sworld-hasura-v2` — the one package whose name doesn't match its directory, so `cd` rather than `--filter` it) — Hasura GraphQL + Postgres: migrations, metadata, and permissions, the data layer the frontend queries. Hasura Cloud's GitHub integration watches this directory and applies metadata and migrations when a change merges to `main`.
 
 Two ways these differ from the frontend apps:
 
-- **Both are excluded from the root Biome config**, so the root `pnpm lint` does not cover them — each brought its own toolchain through the move rather than having its history rewritten by a different formatter. Lint them from their own directory: `apps/backend` has its own Biome config, `apps/hasura` uses eslint. Hasura's PR gate (`hasura-pr.yml`) covers only its JS/TS files, not the SQL migrations or the YAML metadata.
+- **Neither is linted by the root command.** `biome.json` excludes both, so `pnpm lint` skips them — each kept its own toolchain through the move rather than having its history rewritten by a different formatter. Lint them from their own directory (`apps/backend` has its own Biome config, `apps/hasura` uses eslint). Root `pnpm typecheck` and `pnpm test` still cover the backend; Hasura has neither script. On PRs, `hasura-pr.yml` gates Hasura's JS/TS files — not its SQL migrations or YAML metadata — and nothing gates the backend's lint at all.
 - **The backend's build and deploy path is mid-migration**: the old per-repo deploy workflows are gone and its Dockerfiles don't build yet. Don't assume a backend deploy path exists until that work lands.
 
 ### Shared packages (`packages/`)
@@ -70,7 +70,7 @@ Two ways these differ from the frontend apps:
 
 - **Frontend:** React 18, TypeScript, Material-UI, Emotion, Vite, TanStack Router
 - **Data:** GraphQL via Hasura, Auth0 for auth, React Query for server state
-- **Backend:** Hono (Hasura Actions/Events) in `apps/backend`, on Cloud Run
+- **Backend:** Hono (Hasura Actions/Events) in `apps/backend`
 - **Testing:** Vitest, Playwright, Storybook
 - **Build:** Turborepo, pnpm, tsup
 - **Gaming:** Phaser.js, Matter.js physics
@@ -109,9 +109,11 @@ Per-package:
 cd packages/core && pnpm codegen        # Regenerate GraphQL types (also: pnpm watch-codegen)
 cd packages/ui   && pnpm storybook      # Component development
 cd apps/backend  && pnpm dev-gateway    # Run a backend service (also: dev-io, dev-compute)
-cd apps/backend  && pnpm lint           # Root `pnpm lint` skips backend and hasura —
-cd apps/hasura   && pnpm lint           # lint each from its own directory
+cd apps/backend  && pnpm lint           # Biome, and it auto-fixes (`--write`)
+cd apps/hasura   && pnpm lint           # eslint
 ```
+
+Root `pnpm lint` skips `apps/backend` and `apps/hasura` — lint those two from their own directory.
 
 ## Common Workflows
 
@@ -129,9 +131,9 @@ The style law lives in the `code-conventions` skill, which auto-triggers on any 
 ## Key directories
 
 ```text
-apps/<app>/src/         # per-app frontend source (routes/, components/, config)
-apps/backend/src/       # Hono services (gateway, io, compute) + their handlers
-apps/hasura/            # migrations/, metadata/ — the data layer
-packages/core/src/      # graphql/, providers/ (auth, query), <domain>/{query-hooks,mutation-hooks}
-packages/ui/src/        # shared MUI + Emotion components (+ Storybook)
+apps/<frontend app>/src/  # per-app frontend source (routes/, components/, config)
+apps/backend/src/         # Hono services (gateway, io, compute) + their handlers
+apps/hasura/              # migrations/ (SQL), metadata/ (YAML), tests/ — the data layer
+packages/core/src/        # graphql/, providers/ (auth, query), <domain>/{query-hooks,mutation-hooks}
+packages/ui/src/          # shared MUI + Emotion components (+ Storybook)
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-Context for AI agents working in **sworld** — a personal Turborepo + pnpm monorepo of several web apps and shared packages. The how-to-code conventions live in `.claude/skills/` and trigger automatically by task; this file is the always-on context around them.
+Context for AI agents working in **sworld** — a personal Turborepo + pnpm monorepo holding the whole product: the web apps, the shared packages, the backend, and the data layer. The how-to-code conventions live in `.claude/skills/` and trigger automatically by task; this file is the always-on context around them.
 
 ## Hard gate: plan before code — always
 
@@ -38,14 +38,27 @@ Every change should answer four questions:
 
 ## The apps & packages
 
-### Applications (`apps/`)
+Everything below is a member of the one pnpm workspace, resolved by the single root `pnpm-lock.yaml`. Frontend, backend, and data layer all land in this repo — there is no sibling repo to switch to.
+
+### Frontend applications (`apps/`)
 
 - **docs** — Docusaurus documentation site with technical guides and blog posts
+- **extension** — Browser extension
 - **game** — Phaser.js gaming platform with multiple games (Bobble Dungeon, Evil Minds)
 - **listen** — Audio/music streaming application
 - **main** — Main application with finance, journal, and library features
 - **til** — "Today I Learned" blog/notes application
 - **watch** — Video streaming/watching application
+
+### Backend & data layer (`apps/`)
+
+- **backend** (`apps/backend`) — Hono backend handling Hasura Actions / Events (custom business logic triggered by Hasura). Three services — gateway, io, compute — in one package; it consumes `core` as a workspace dependency (`workspace:*`).
+- **hasura** (`apps/hasura`) — Hasura GraphQL + Postgres: migrations, metadata, and permissions — the data layer the frontend queries. Hasura Cloud's GitHub integration watches this directory and applies metadata and migrations when a change merges to `main`.
+
+Two ways these differ from the frontend apps:
+
+- Hasura is excluded from Biome (`biome.json`) and keeps its own eslint toolchain — reformatting it with a different formatter would rewrite the history the move preserved. Its PR gate is `hasura-pr.yml`, which lints only its JS/TS files, not the SQL migrations or YAML metadata.
+- The backend's build and deploy path is mid-migration: the old per-repo deploy workflows are gone and its Dockerfiles don't build yet. Don't assume a backend deploy path exists until that work lands.
 
 ### Shared packages (`packages/`)
 
@@ -53,20 +66,11 @@ Every change should answer four questions:
 - **ui** — UI component library using Material-UI and Emotion (+ Storybook)
 - **tsconfig** — Shared TypeScript configurations
 
-### Backend & data layer (sibling repos)
-
-These live **outside** this pnpm workspace, as separate repos next to `sworld/`:
-
-- **sworld-backend** — Hono backend handling Hasura Actions / Events (custom business logic triggered by Hasura).
-- **sworld-hasura-v2** — Hasura GraphQL + Postgres: migrations, metadata, and permissions — the data layer the frontend queries.
-
-When work spans the backend or schema, the change lands in those repos, not here.
-
 ## Tech Stack
 
 - **Frontend:** React 18, TypeScript, Material-UI, Emotion, Vite, TanStack Router
 - **Data:** GraphQL via Hasura, Auth0 for auth, React Query for server state
-- **Backend:** Hono (Hasura Actions/Events) on the sibling `sworld-backend` repo
+- **Backend:** Hono (Hasura Actions/Events) in `apps/backend`, on Cloud Run
 - **Testing:** Vitest, Playwright, Storybook
 - **Build:** Turborepo, pnpm, tsup
 - **Gaming:** Phaser.js, Matter.js physics
@@ -102,13 +106,15 @@ App-specific `dev:*` commands use `turbo watch`. How a `packages/core` / `packag
 Per-package:
 
 ```bash
-cd packages/core && pnpm codegen   # Regenerate GraphQL types (also: pnpm watch-codegen)
-cd packages/ui   && pnpm storybook # Component development
+cd packages/core && pnpm codegen        # Regenerate GraphQL types (also: pnpm watch-codegen)
+cd packages/ui   && pnpm storybook      # Component development
+cd apps/backend  && pnpm dev-gateway    # Run a backend service (also: dev-io, dev-compute)
+cd apps/hasura   && pnpm lint           # Hasura keeps its own eslint, not Biome
 ```
 
 ## Common Workflows
 
-- **Before any work touching sworld-backend or sworld-hasura-v2** — load the `backend-architecture` skill. It documents the full service architecture, Cloud Task pipeline, task lifecycle, notification flow, and event vs action patterns. Do not reason about the backend without it.
+- **Before any work touching `apps/backend` or `apps/hasura`** — load the `backend-architecture` skill. It documents the full service architecture, Cloud Task pipeline, task lifecycle, notification flow, and event vs action patterns. Do not reason about the backend without it.
 - **Before designing a new mutation/Action, or reasoning about concurrent writes or data validation** — load the `hasura-architecture` skill. It covers the single-gateway rule, when a write needs a concurrency-safe database pattern, and the three validation layers.
 - **Code exploration — always use CodeGraph first, not grep.** Setup and the exact rule live in `dev-environment-gotchas`.
 - **Adding a feature** — identify which app(s) change; decide where the code lives (`frontend-ui-architecture`); run the relevant `dev:*` command; make changes; run `pnpm lint` and `pnpm test` before committing.
@@ -122,7 +128,9 @@ The style law lives in the `code-conventions` skill, which auto-triggers on any 
 ## Key directories
 
 ```text
-apps/<app>/src/         # per-app source (routes/, components/, config)
+apps/<app>/src/         # per-app frontend source (routes/, components/, config)
+apps/backend/src/       # Hono services (gateway, io, compute) + their handlers
+apps/hasura/            # migrations/, metadata/ — the data layer
 packages/core/src/      # graphql/, providers/ (auth, query), <domain>/{query-hooks,mutation-hooks}
 packages/ui/src/        # shared MUI + Emotion components (+ Storybook)
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,10 +55,11 @@ Everything below is a member of the one pnpm workspace, resolved by the single r
 - **`apps/backend`** (package `backend`) — Hono backend handling Hasura Actions / Events (custom business logic triggered by Hasura). Three services — gateway, io, compute — in one package; it consumes `core` as a workspace dependency (`workspace:*`).
 - **`apps/hasura`** (package `sworld-hasura-v2` — the one package whose name doesn't match its directory, so `cd` rather than `--filter` it) — Hasura GraphQL + Postgres: migrations, metadata, and permissions, the data layer the frontend queries. Hasura Cloud's GitHub integration watches this directory and applies metadata and migrations when a change merges to `main`.
 
-Two ways these differ from the frontend apps:
+How this pair differs from the frontend apps:
 
-- **Neither is linted by the root command.** `biome.json` excludes both, so `pnpm lint` skips them — each kept its own toolchain through the move rather than having its history rewritten by a different formatter. Lint them from their own directory (`apps/backend` has its own Biome config, `apps/hasura` uses eslint). Root `pnpm typecheck` and `pnpm test` still cover the backend; Hasura has neither script. On PRs, `hasura-pr.yml` gates Hasura's JS/TS files — not its SQL migrations or YAML metadata — and nothing gates the backend's lint at all.
-- **The backend's build and deploy path is mid-migration**: the old per-repo deploy workflows are gone and its Dockerfiles don't build yet. Don't assume a backend deploy path exists until that work lands.
+- **Neither is linted by the root command.** `biome.json` excludes both, so `pnpm lint` skips them — each kept its own toolchain through the move rather than having its history rewritten by a different formatter. Lint them from their own directory (`apps/backend` has its own Biome config, `apps/hasura` uses eslint). On PRs, `hasura-pr.yml` gates Hasura's JS/TS files — not its SQL migrations or YAML metadata — and nothing gates the backend's lint at all.
+- **Root `typecheck` and `test` reach the backend but not Hasura.** Hasura's suite is named `test:local` / `test:ci` on purpose: it needs a live Hasura endpoint and Auth0 credentials, and naming it `test` would drag it into the root gate. Run it yourself from `apps/hasura`; don't "fix" the missing script.
+- **Only the backend's deploy path is mid-migration** (Hasura's is not — see above): its old per-repo deploy workflows are gone and its Dockerfiles don't build yet. Don't assume a backend deploy path exists until that work lands.
 
 ### Shared packages (`packages/`)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Every change should answer four questions:
 
 ## The apps & packages
 
-Everything below is a member of the one pnpm workspace, resolved by the single root `pnpm-lock.yaml`. Frontend, backend, and data layer all land in this repo — there is no sibling repo to switch to.
+Everything below is a member of the one pnpm workspace, resolved by the single root `pnpm-lock.yaml`. Frontend, backend, and data layer all land here; no change moves to another repo.
 
 ### Frontend applications (`apps/`)
 
@@ -57,8 +57,8 @@ Everything below is a member of the one pnpm workspace, resolved by the single r
 
 Two ways these differ from the frontend apps:
 
-- Hasura is excluded from Biome (`biome.json`) and keeps its own eslint toolchain — reformatting it with a different formatter would rewrite the history the move preserved. Its PR gate is `hasura-pr.yml`, which lints only its JS/TS files, not the SQL migrations or YAML metadata.
-- The backend's build and deploy path is mid-migration: the old per-repo deploy workflows are gone and its Dockerfiles don't build yet. Don't assume a backend deploy path exists until that work lands.
+- **Both are excluded from the root Biome config**, so the root `pnpm lint` does not cover them — each brought its own toolchain through the move rather than having its history rewritten by a different formatter. Lint them from their own directory: `apps/backend` has its own Biome config, `apps/hasura` uses eslint. Hasura's PR gate (`hasura-pr.yml`) covers only its JS/TS files, not the SQL migrations or the YAML metadata.
+- **The backend's build and deploy path is mid-migration**: the old per-repo deploy workflows are gone and its Dockerfiles don't build yet. Don't assume a backend deploy path exists until that work lands.
 
 ### Shared packages (`packages/`)
 
@@ -109,7 +109,8 @@ Per-package:
 cd packages/core && pnpm codegen        # Regenerate GraphQL types (also: pnpm watch-codegen)
 cd packages/ui   && pnpm storybook      # Component development
 cd apps/backend  && pnpm dev-gateway    # Run a backend service (also: dev-io, dev-compute)
-cd apps/hasura   && pnpm lint           # Hasura keeps its own eslint, not Biome
+cd apps/backend  && pnpm lint           # Root `pnpm lint` skips backend and hasura —
+cd apps/hasura   && pnpm lint           # lint each from its own directory
 ```
 
 ## Common Workflows


### PR DESCRIPTION
The backend and the database layer used to live in two other code repositories. They were moved into this one, but the guide every AI agent reads at the start of a session still said they were elsewhere — and told the agent that backend or database work "lands in those repos, not here". That is the first thing an agent reads, so every session started from a picture of the project that is no longer true.

This rewrites that guide to match reality, and adds the practical things that bite you once the three are in one place: which lint command actually covers which part, which test command reaches which part, and one honest warning that the backend's deployment setup is still being moved and should not be relied on yet.

Refs SWO-551

## Summary

Rewrites `AGENTS.md` for the single-monorepo model. `CLAUDE.md` and `WARP.md` are already pure pointers at it, so they needed no change.

- Split the app list into **Frontend applications** and **Backend & data layer**, describing `apps/backend` and `apps/hasura` as workspace members rather than sibling repos. Dropped "these live outside this pnpm workspace" and "the change lands in those repos, not here".
- Added three notes an agent gets wrong otherwise: root `pnpm lint` skips both (`biome.json` excludes them) and nothing gates the backend's lint on a PR; root `typecheck`/`test` reach the backend but not Hasura, whose suite is deliberately named `test:local` so turbo can't pull a live-credential suite into the root gate; and `apps/hasura`'s package is still named `sworld-hasura-v2`, so `--filter` by directory name matches nothing and exits 0.
- Added backend/hasura dev commands and directories, and `apps/extension` to the app list.
- Deliberately **not** documented: the backend build (SWO-545) and deploy/PR workflows (SWO-546) are unfinished, so the doc says the deploy path is mid-migration rather than describing mechanics that do not exist. The Tech Stack no longer claims Cloud Run for the same reason.

## Test plan

Docs only — no code paths touched, nothing to run.

- [ ] `AGENTS.md` no longer mentions `sworld-backend` or `sworld-hasura-v2` as separate repos
- [ ] Every command in the two command blocks exists (`apps/backend`: `dev-gateway`/`dev-io`/`dev-compute`/`lint`; `apps/hasura`: `lint`)
- [ ] The lint/test coverage claims match `biome.json`, root `package.json` and `.github/workflows/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development guidance to reflect backend and data-layer code now living within the unified workspace.
  * Added details for backend services, GraphQL/Postgres infrastructure, directory structure, and common backend development and linting commands.
  * Revised architecture guidance and technology references to match the current workspace layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->