### PR TITLE
docs(skills): update backend and architecture skills for the monorepo

### DIFF
--- a/.claude/skills/architecture/SKILL.md
+++ b/.claude/skills/architecture/SKILL.md
@@ -60,24 +60,24 @@ export function useProjectQuery(id: string) {
 
 - ALWAYS use the generated `graphql()` helper for GraphQL queries and mutations — never raw template literal strings. Operations are fed through `useRequest` / `useMutationRequest`.
 - NEVER manually edit generated files (`generated/graphql.ts`, `generated/gql.ts`, `schema.graphql`) — always run `pnpm codegen` (in `packages/core`).
-- All database operations go through Hasura. The backend (the separate `sworld-backend` repo) only handles Hasura Actions/Events.
+- All database operations go through Hasura. The backend (`apps/backend`) only handles Hasura Actions/Events.
 
 ## Data layer: schema changes and codegen
 
-Schema and permission changes live in the sibling **`sworld-hasura-v2`** repo (migrations + metadata), never here.
+Schema and permission changes live in **`apps/hasura`** (migrations + metadata), never in a frontend app or `packages/core`.
 
-- **ALWAYS run `pnpm codegen` against LOCAL Hasura** (`localhost:8030`), never against Cloud. Local is the only environment where you control exactly which migrations/metadata are applied — apply your schema change locally first (`hasura migrate apply` / `hasura metadata apply`), then codegen introspects it. This keeps generated types in sync with the schema you're building against and avoids picking up unrelated Cloud drift.
-- **Sequence merges across repos.** A frontend query/mutation on a new table/column only works at runtime once the Hasura PR is merged and live. Land the data-layer PR before any frontend PR that reads/writes the new shape goes live.
+- **ALWAYS run `pnpm codegen` against LOCAL Hasura** (`localhost:8030`), never against Cloud. Local is the only environment where you control exactly which migrations/metadata are applied — apply your schema change locally first (`hasura migrate apply` / `hasura metadata apply` from `apps/hasura`), then codegen introspects it. This keeps generated types in sync with the schema you're building against and avoids picking up unrelated Cloud drift.
+- **Sequence the merges.** A frontend query/mutation on a new table/column only works at runtime once the schema change is merged and live. Land the data-layer PR before any frontend PR that reads/writes the new shape goes live. Now that both live in one repo, nothing *stops* you committing them together — the runtime ordering is the reason not to; splitting them is `micro-prs`' rule.
 
 ## Deployment: merging is deploying
 
 This skill owns the deploy model — other skills point here rather than restating it.
 
-**Merging into `main` ships to production**, in all three repos. There is no promote step, no staging, and no manual deploy: the only two environments are **local** and **production**. Treat every merge as a release.
+**Merging into `main` ships to production.** There is no promote step, no staging, and no manual deploy: the only two environments are **local** and **production**. Treat every merge as a release.
 
 - **Frontend** — **Cloudflare Pages** hosts `main` (`shinabr2.com`), `listen`, `watch` and `til`. Each site has its own build pipeline and env vars, configured in the Cloudflare dashboard and **not in this repo**. Nothing in `.github/workflows` deploys a frontend app. `docs` and `game` are not deployed anywhere.
-- **Data layer** — merging a `sworld-hasura-v2` PR applies its migrations + metadata to Hasura Cloud production, via Hasura Cloud's GitHub integration rather than a GitHub Actions workflow. That repo has no deploy job (only lint), so merging *looks* inert. It isn't.
-- **Backend** — merging `sworld-backend` deploys to Cloud Run.
+- **Data layer** — merging a change under `apps/hasura` applies its migrations + metadata to Hasura Cloud production, via Hasura Cloud's GitHub integration rather than a GitHub Actions workflow. `hasura-pr.yml` only lints, so merging *looks* inert. It isn't.
+- **Backend** — nothing deploys `apps/backend` right now. The workflows that pushed it to Cloud Run were removed in the monorepo move and the container images don't build; both are being rebuilt (see `backend-architecture`). Merging a backend change is currently a no-op in production — the running Cloud Run services keep serving the last image built before the move.
 
 **What CI does after a merge is verify, not deploy.** `Live Listen` runs Playwright + Argos and a Lighthouse budget against the live site; `Live Watch` runs a Lighthouse budget. A red check there means production is bad — not that a deploy failed. Neither waits for Cloudflare to finish publishing, so both can measure the previous release (SWO-558).
 

--- a/.claude/skills/backend-architecture/SKILL.md
+++ b/.claude/skills/backend-architecture/SKILL.md
@@ -206,7 +206,7 @@ Local testing options:
 | **Unit tests** | `vitest` with mocked deps | Handler business logic, schema validation, error paths |
 | **Direct handler call** | `curl POST localhost:4000/videos/<handler> -H 'x-task-id: <uuid>' -d '{...}'` | Handler in isolation (bypasses Cloud Tasks) |
 | **Gateway + Compute locally** | From `apps/backend`, `pnpm dev-gateway` and `pnpm dev-compute` in separate terminals, then call the action manually | Action → Gateway → Cloud Task creation (but task never delivers locally) |
-| **Full integration** | Run against real Cloud Run, trigger via Hasura | End-to-end: action → gateway → cloud task → handler → notification |
+| **Full integration** | Run against real Cloud Run, trigger via Hasura — **blocked today, see below** | End-to-end: action → gateway → cloud task → handler → notification |
 
 When developing a new Cloud Task handler, the practical workflow is: unit tests (full confidence in logic) → local direct call (sanity check) → real integration. Never expect `createCloudTasks` to deliver a task locally — it will fail with missing GCP credentials or be silently ignored.
 

--- a/.claude/skills/backend-architecture/SKILL.md
+++ b/.claude/skills/backend-architecture/SKILL.md
@@ -1,12 +1,23 @@
 ---
 name: backend-architecture
-description: The sworld backend architecture — four services (gateway, io, compute, hasura), the Hasura Event → Cloud Task → handler pipeline, task lifecycle, notification flow, and when to use Cloud Tasks vs direct actions. Auto-triggers when working in sworld-backend, planning backend features, touching Hasura Actions/Events, creating Cloud Task handlers, or designing any server-side video/audio processing flow.
+description: The sworld backend architecture — four services (gateway, io, compute, hasura), the Hasura Event → Cloud Task → handler pipeline, task lifecycle, notification flow, and when to use Cloud Tasks vs direct actions. Auto-triggers when working in apps/backend, planning backend features, touching Hasura Actions/Events, creating Cloud Task handlers, or designing any server-side video/audio processing flow.
 user-invocable: false
 ---
 
 # Backend Architecture
 
-The backend is a single TypeScript codebase (`sworld-backend`) deployed as **four services** that share source but run different entry points. Three are custom Hono servers; the fourth is Hasura GraphQL Engine.
+The backend is a single TypeScript codebase — the `backend` workspace package at **`apps/backend`** — deployed as **four services** that share source but run different entry points. Three are custom Hono servers; the fourth is Hasura GraphQL Engine.
+
+## Where it lives
+
+The backend and the data layer are workspace packages in the sworld monorepo, not separate repos:
+
+| Package | Directory | Notes |
+|---------|-----------|-------|
+| `backend` | `apps/backend` | Hono services. Depends on `core` via `workspace:*`; the whole `backend` → `core` chain is ESM (`"type": "module"` on both). |
+| `sworld-hasura-v2` | `apps/hasura` | The one workspace package whose name doesn't match its directory. Keeps its own eslint toolchain; excluded from biome. |
+
+One `pnpm-lock.yaml` at the repo root covers everything — there is no per-app lockfile and no `npm ci` anywhere. Every `src/…` path below is relative to `apps/backend`.
 
 ## The four services
 
@@ -15,9 +26,15 @@ The backend is a single TypeScript codebase (`sworld-backend`) deployed as **fou
 | **gateway** | `src/gateway.ts` | `Dockerfile.gateway` | Receives Hasura Events/Actions, validates webhook signatures, routes to Cloud Tasks. Also handles direct synchronous Actions (set-thumbnail, auth, storage upload URLs). |
 | **io** | `src/io.ts` | `Dockerfile.io` | Light I/O operations: byte-copy HLS streaming, platform imports, Playwright crawling. Includes Playwright + Chromium for crawlers. |
 | **compute** | `src/compute.ts` | `Dockerfile.compute` | CPU-heavy ffmpeg work: video conversion (re-encode to fMP4 HLS). Same Docker image as gateway but different entry. |
-| **hasura** | — | `sworld-hasura-v2/` | Hasura GraphQL Engine + Postgres. Owns the schema, permissions, event triggers, and action definitions. |
+| **hasura** | — | `apps/hasura` | Hasura GraphQL Engine + Postgres. Owns the schema, permissions, event triggers, and action definitions. |
 
-Gateway, io, and compute are deployed as separate Cloud Run services. They share a single codebase (`sworld-backend`) but each has its own entry point (different `CMD` in Dockerfile).
+Gateway, io, and compute run as separate Cloud Run services off one codebase, each with its own entry point (different `CMD` in its Dockerfile).
+
+### Container build and deploy are mid-rebuild — don't rely on them
+
+The three Dockerfiles still install with `npm ci` against a `package-lock.json` that no longer exists, so **none of them currently build**, and the workflows that deployed the backend were removed in the monorepo move with nothing yet in their place. Nothing here deploys the backend today.
+
+Both are being rebuilt: SWO-545 owns making the images build (shipping the workspace slice with pnpm from a monorepo-root build context — not bundling), SWO-546 owns restoring the deploy pipeline. Until those land, treat a backend change as unshippable, and check those tickets rather than this skill for how a build or deploy will work.
 
 ## The full pipeline: Hasura Event → video processing
 
@@ -92,7 +109,7 @@ The deterministic `task_id` (uuidv5) ensures the same logical task is never enqu
    - Inserts a `notifications` row: `{ type: 'video-ready', entityId, entityType: 'video', user_id }`
    - Updates the `videos` row: `{ source, status: 'ready', thumbnailUrl, duration, sId }`
 
-2. The `notifications` table has **subscription permissions** for the `user` role (`select` on subscription root, filtered `user_id = X-Hasura-User-Id`). See `sworld-hasura-v2/metadata/.../public_notifications.yaml:53`.
+2. The `notifications` table has **subscription permissions** for the `user` role (`select` on subscription root, filtered `user_id = X-Hasura-User-Id`). See `apps/hasura/metadata/.../public_notifications.yaml:53`.
 
 3. The frontend creates a Hasura **GraphQL subscription** on `notifications(where: { read_at: { _is_null: true } })`. When a new notification arrives, the UI shows it to the user (e.g. "Your video is ready").
 
@@ -146,7 +163,7 @@ The pattern for adding a new handler to the compute service:
 2. **Handler** (`src/apps/compute/videos/routes/<feature>/`): business logic using existing core engines
 3. **Router** (`src/apps/compute/videos/index.ts`): register `POST /<feature>-handler` with `withVideoFailureReport`
 4. **Gateway route** (if user-initiated Action): schema + handler on `videoActionsRouter` that creates a Cloud Task → compute
-5. **Hasura metadata** (`sworld-hasura-v2/metadata/actions.yaml`): define the Action + custom types
+5. **Hasura metadata** (`apps/hasura/metadata/actions.yaml`): define the Action + custom types
 
 ## Key files reference
 
@@ -174,9 +191,9 @@ The pattern for adding a new handler to the compute service:
 | convertToHLS (ffmpeg encode) | `src/services/videos/helpers/ffmpeg/index.ts` |
 | convert handler (compute) | `src/services/videos/convert/handler.ts` |
 | CLI scripts | `src/cli/stream-m3u8.ts`, `src/cli/convert.ts`, `src/cli/repair-fmp4.ts` |
-| Hasura actions metadata | `sworld-hasura-v2/metadata/actions.yaml` |
-| Hasura Event triggers | `sworld-hasura-v2/metadata/databases/sworld/tables/public_videos.yaml` |
-| Notifications permissions | `sworld-hasura-v2/metadata/databases/sworld/tables/public_notifications.yaml` |
+| Hasura actions metadata | `apps/hasura/metadata/actions.yaml` |
+| Hasura Event triggers | `apps/hasura/metadata/databases/sworld/tables/public_videos.yaml` |
+| Notifications permissions | `apps/hasura/metadata/databases/sworld/tables/public_notifications.yaml` |
 
 ## Local testing limitations
 
@@ -188,10 +205,12 @@ Local testing options:
 |-------|-----|-------------------|
 | **Unit tests** | `vitest` with mocked deps | Handler business logic, schema validation, error paths |
 | **Direct handler call** | `curl POST localhost:4000/videos/<handler> -H 'x-task-id: <uuid>' -d '{...}'` | Handler in isolation (bypasses Cloud Tasks) |
-| **Gateway + Compute locally** | Run gateway + compute in separate terminals, call the action manually | Action → Gateway → Cloud Task creation (but task never delivers locally) |
-| **Full integration** | Deploy to Cloud Run, trigger via Hasura | End-to-end: action → gateway → cloud task → handler → notification |
+| **Gateway + Compute locally** | From `apps/backend`, `pnpm dev-gateway` and `pnpm dev-compute` in separate terminals, then call the action manually | Action → Gateway → Cloud Task creation (but task never delivers locally) |
+| **Full integration** | Run against real Cloud Run, trigger via Hasura | End-to-end: action → gateway → cloud task → handler → notification |
 
-When developing a new Cloud Task handler, the practical workflow is: unit tests (full confidence in logic) → local direct call (sanity check) → deploy (real integration). Never expect `createCloudTasks` to deliver a task locally — it will fail with missing GCP credentials or be silently ignored.
+When developing a new Cloud Task handler, the practical workflow is: unit tests (full confidence in logic) → local direct call (sanity check) → real integration. Never expect `createCloudTasks` to deliver a task locally — it will fail with missing GCP credentials or be silently ignored.
+
+The last rung has no route today: with the images unbuildable and the deploy workflows gone (see above), there is no way to ship a backend change to Cloud Run and close the loop. Plan a backend change knowing its integration test is blocked until SWO-545 and SWO-546 land.
 
 ## Business constraints
 

--- a/.claude/skills/backend-ops/SKILL.md
+++ b/.claude/skills/backend-ops/SKILL.md
@@ -12,9 +12,9 @@ These CLIs are operator tools run straight from source with `tsx` — they don't
 
 ## Which account an op runs as
 
-Every CLI takes the acting account from `user-id` in `~/.sworld-cli/config.json`, and `--user-id <user-id>` overrides it for a single run. Pass `--user-id` whenever the op should be owned by an account other than the configured one.
+The CLIs that create rows (`audio.ts`, `convert.ts`, `stream-m3u8.ts`, `upload-subtitle.ts`) take the acting account from `user-id` in `~/.sworld-cli/config.json`, and `--user-id <user-id>` overrides it for a single run. Pass `--user-id` whenever the op should be owned by an account other than the configured one. `repair-fmp4.ts` is the exception — it reworks an existing video and takes the owner from the row, so it has no `--user-id`.
 
-Account names and their ids are local machine config, not skill content — this repo is public, so no real user id belongs in it. Read them from the local config or ask the user; never hardcode one here or in a committed script.
+Account names and their ids are identity data: they belong in local machine config, not in a skill. This repo is public, so read them from the local config or ask the user — never hardcode one here or in a committed script. (Infrastructure identifiers like the bucket and Hasura endpoint below are already public and are fine to keep.)
 
 ## Assets live in GCP Cloud Storage
 

--- a/.claude/skills/backend-ops/SKILL.md
+++ b/.claude/skills/backend-ops/SKILL.md
@@ -1,21 +1,20 @@
 ---
 name: backend-ops
-description: How to perform sworld operational tasks from the sworld-backend repo — GCS asset layout, operator CLIs, direct prod DB access, and the recurring "create audios" ingestion task. Auto-triggers when uploading media, ingesting mp3/video files, touching prod data directly, or working in sworld-backend/src/cli.
+description: How to perform sworld operational tasks from apps/backend in the sworld monorepo — GCS asset layout, operator CLIs, direct prod DB access, and the recurring "create audios" ingestion task. Auto-triggers when uploading media, ingesting mp3/video files, touching prod data directly, or working in apps/backend/src/cli.
 user-invocable: false
 ---
 
 # Backend Ops
 
-How to perform sworld operational tasks (create audios/videos, upload assets, touch prod data) from the **sworld-backend** repo (sibling to `sworld/`). This is separate from the `parallel-workflow` PR process — these are direct, already-authorized ops tasks, not feature work. Don't re-ask the user for credentials or access; they're already configured.
+How to perform sworld operational tasks (create audios/videos, upload assets, touch prod data) from **`apps/backend`** in the sworld monorepo. This is separate from the `parallel-workflow` PR process — these are direct, already-authorized ops tasks, not feature work. Don't re-ask the user for credentials or access; they're already configured.
 
-## User-id aliases
+These CLIs are operator tools run straight from source with `tsx` — they don't go through the container images, so the unbuildable Dockerfiles and missing deploy pipeline (see `backend-architecture`) don't block them.
 
-The owner has two sworld accounts, referred to by name instead of UUID:
+## Which account an op runs as
 
-- **shinabr2** → `6ff27fda-03e8-4dcd-949b-f1328f955065` — **the default account for everything.** All ops (create audios/videos, playlists, ownership) use shinabr2 unless the user explicitly names `quachtan`. Don't ask which account; assume shinabr2.
-- **quachtan** / **quachtanqt** → `fe8b7813-472f-462c-a5cf-308b53009a40`
+Every CLI takes the acting account from `user-id` in `~/.sworld-cli/config.json`, and `--user-id <user-id>` overrides it for a single run. Pass `--user-id` whenever the op should be owned by an account other than the configured one.
 
-Caveat: `~/.sworld-cli/config.json`'s `user-id` currently points at **quachtan** — for any CLI/script, override it (`--user-id 6ff27fda-...` or hardcode shinabr2 in a one-off script) rather than relying on the config default.
+Account names and their ids are local machine config, not skill content — this repo is public, so no real user id belongs in it. Read them from the local config or ask the user; never hardcode one here or in a committed script.
 
 ## Assets live in GCP Cloud Storage
 
@@ -25,33 +24,41 @@ Layout: `videos/<userId>/<videoId>/…` (HLS: `playlist.m3u8` + segments/`init.m
 
 ## Credentials (already configured — reuse, don't ask)
 
-- **`~/.sworld-cli/config.json`**: `gcp-key` (path to the service-account JSON — read the value from the config, don't hardcode a path), `gcp-bucket` (`sworld-prod.appspot.com`), `hasura-endpoint` (`https://free-lamprey-59.hasura.app/v1/graphql`), `hasura-secret` (admin), `user-id` (see aliases above — override, don't trust the default).
+- **`~/.sworld-cli/config.json`**: `gcp-key` (path to the service-account JSON — read the value from the config, don't hardcode a path), `gcp-bucket` (`sworld-prod.appspot.com`), `hasura-endpoint` (`https://free-lamprey-59.hasura.app/v1/graphql`), `hasura-secret` (admin), `user-id` (the account ops run as — see above).
 - GCS auth: `new Storage({ keyFilename })` with that `gcp-key`. `gcloud` ADC is NOT set up — always use the key file.
-- **`sworld-backend/.env`** also has: `GCP_STORAGE_BUCKET`, `HASURA_ADMIN_SECRET` + `HASURA_ENDPOINT`, `DATABASE_URL` (Neon Postgres, direct), Cloudinary, OpenAI, etc. `packages/core/.env` in the frontend repo also has `HASURA_GRAPHQL_URL` + `HASURA_ADMIN_SECRET` for quick admin queries via curl.
+- **`apps/backend/.env`** also has: `GCP_STORAGE_BUCKET`, `HASURA_ADMIN_SECRET` + `HASURA_ENDPOINT`, `DATABASE_URL` (direct Postgres), Cloudinary, OpenAI, etc. It is gitignored, so a fresh clone or worktree has only `.env.example` — copy the real file in. `packages/core/.env` also has `HASURA_GRAPHQL_URL` + `HASURA_ADMIN_SECRET` for quick admin queries via curl.
 
 ## Talking to the production DB directly
 
 - Via **Hasura admin** (endpoint + admin secret above) with GraphQL — admin bypasses all row permissions. Use for reads (dup checks) and writes (insert audios rows, link playlist_audios, etc.).
-- Or Neon Postgres directly via `DATABASE_URL`.
+- Or Postgres directly via `DATABASE_URL`.
 
-## Operator CLIs in `sworld-backend/src/cli/` (run via `npx tsx src/cli/<x>.ts`)
+## Operator CLIs in `apps/backend/src/cli/`
+
+Run them from `apps/backend` (that's where `tsx` and the backend's dependencies resolve):
+
+```bash
+cd apps/backend && pnpm exec tsx src/cli/<x>.ts …
+```
 
 - **convert.ts** — local video file → fMP4 HLS, upload to GCS, create/finalize the `videos` row (`--file`, `--title`, `--video-id`, `--playlist`, `--public`, `--dry-run`, `--user-id`).
 - **stream-m3u8.ts** — fix a failed video: process an `.m3u8` (master or media) → GCS, finalize an existing `videos` row (`--url`/`--file`, `--video-id`, `--referer`, `--playlist`). Also owns the shared CLI config (`config set <key> <value>`).
 - **upload-subtitle.ts** — upload a `.vtt` (local or URL) → GCS, insert/update `subtitles` row.
 - **repair-fmp4.ts** — repackage a video's stored `.ts` → fMP4 (fixes garbled desktop-Chrome audio).
-- **audio.ts** — publish a local `.mp3` to the listen library: no transcode, just upload verbatim to GCS + insert the `audios` row (`--file <path>` or `--dir <path>` for a whole folder, `--name`/`--artist` overrides, `--public`, `--dry-run`, `--skip-db`, `--user-id`). Handles dup-checking and filename metadata parsing itself — see below. Full CLI docs: `sworld-backend/src/cli/README.md`.
+- **audio.ts** — publish a local `.mp3` to the listen library: no transcode, just upload verbatim to GCS + insert the `audios` row (`--file <path>` or `--dir <path>` for a whole folder, `--name`/`--artist` overrides, `--public`, `--dry-run`, `--skip-db`, `--user-id`). Handles dup-checking and filename metadata parsing itself — see below. Full CLI docs: `apps/backend/src/cli/README.md`.
 
 ## Recurring task: "create audios"
 
 The owner's most common recurring ops ask: they have local `.mp3` files and ask to "create new audios." Just run `audio.ts` — don't explain the plumbing (GCS, CLI internals) unless asked; keep it simple.
 
 ```bash
+cd apps/backend
+
 # One file (name + artist parsed from "Title - Artist.mp3"):
-npx tsx src/cli/audio.ts --file './Shape of You - Ed Sheeran.mp3' --user-id 6ff27fda-03e8-4dcd-949b-f1328f955065
+pnpm exec tsx src/cli/audio.ts --file './Shape of You - Ed Sheeran.mp3' --user-id <user-id>
 
 # A whole folder, dry-run first:
-npx tsx src/cli/audio.ts --dir ./album --user-id 6ff27fda-03e8-4dcd-949b-f1328f955065 --dry-run
+pnpm exec tsx src/cli/audio.ts --dir ./album --user-id <user-id> --dry-run
 ```
 
-The CLI already handles the flow the owner cares about: `name`/`artist` parsed from the filename (`artist_name` is NOT NULL — a file with no parseable artist and no `--artist` is reported and skipped, not silently defaulted), `public: false` by default (add `--public` only if explicitly asked — publishing is an act of owning the database, not a user capability, so only flip it on explicit instruction), an existing `(user_id, name)` skipped as a dup, and a `Created / Skipped / Failed` tally on a batch. Owner = **shinabr2** by default (`--user-id`, since `~/.sworld-cli/config.json`'s default points at quachtan).
+The CLI already handles the flow the owner cares about: `name`/`artist` parsed from the filename (`artist_name` is NOT NULL — a file with no parseable artist and no `--artist` is reported and skipped, not silently defaulted), `public: false` by default (add `--public` only if explicitly asked — publishing is an act of owning the database, not a user capability, so only flip it on explicit instruction), an existing `(user_id, name)` skipped as a dup, and a `Created / Skipped / Failed` tally on a batch. The new rows are owned by whichever account `--user-id` names, falling back to the configured one.

--- a/.claude/skills/dev-environment-gotchas/SKILL.md
+++ b/.claude/skills/dev-environment-gotchas/SKILL.md
@@ -35,9 +35,11 @@ Don't trust `pnpm exec turbo build` output that reports a cache hit ("FULL TURBO
 
 ## Node version and package managers
 
-- The whole workspace (`sworld`, `sworld-backend`, `sworld-hasura-v2`) runs **Node 24.18.0**, exact-pinned. Local: `nvm use 24`. If a non-interactive shell warns `Unsupported engine`, it's likely on the default alias — prefix with `source ~/.nvm/nvm.sh && nvm use 24.18.0`.
+- The whole monorepo — frontend apps, `apps/backend`, `apps/hasura`, and every package — runs **Node 24.18.0**, exact-pinned. Local: `nvm use 24`. If a non-interactive shell warns `Unsupported engine`, it's likely on the default alias — prefix with `source ~/.nvm/nvm.sh && nvm use 24.18.0`.
 - **Pinning convention:** pin the **exact** version (`24.18.0`) in `.nvmrc`, Dockerfiles (`node:24.18.0-slim`, never the moving `node:24-slim` tag), and CI `actions/setup-node`. Keep `engines.node` as a **range** (`>=24`) — it's a floor, not a pin.
-- **Package manager differs per repo:** `sworld` = pnpm workspace (`pnpm-lock.yaml`); `sworld-backend` and `sworld-hasura-v2` = **npm** (`package-lock.json`) — use `npm ci`/`npm outdated` there, not pnpm.
+- **One package manager, one lockfile.** Everything is a single pnpm workspace with one root `pnpm-lock.yaml`. There is no `package-lock.json` and no `npm ci` — reach for `pnpm`, `pnpm --filter <pkg> …`, `pnpm outdated -r` everywhere, including in `apps/backend` and `apps/hasura`. The backend gets `core` as `workspace:*` off the local source, not from npm.
+- **`apps/hasura` is the one package whose name doesn't match its directory** — it's still `sworld-hasura-v2`. `pnpm --filter` on a name that matches nothing exits 0 with "No projects matched", so a filter built from the directory name silently does nothing. Run its scripts from the directory (`cd apps/hasura && pnpm run lint`).
+- **Lint tooling is split, and the root config skips the two backend directories.** `biome.json` at the root excludes `apps/backend` and `apps/hasura`, so a root `pnpm lint` says nothing about either. `apps/backend` has its own `biome.json` and `lint` script; `apps/hasura` uses eslint. Lint those from their own directories.
 - **`apps/game` is a dead/frozen app** — still on Vite 6 (the rest of the frontend is on Vite 8), deliberately excluded from the Node 24 migration, and no longer deployed anywhere. It has no tests at all — unit tests everywhere else in the workspace run on Vitest. Don't assume it's maintained or apply workspace-wide tooling changes to it without checking first.
 
 ## pnpm's dependency cooldown can freeze dep work for days
@@ -50,7 +52,9 @@ Don't trust `pnpm exec turbo build` output that reports a cache hit ("FULL TURBO
 
 ## CodeGraph index lives at the workspace root
 
-The CodeGraph index (`.codegraph/`) is initialized at the **workspace root** (`/Users/tranvanvuong/Projects/sworld`, not inside any single repo), so one graph covers all three repos — `sworld`, `sworld-backend`, `sworld-hasura-v2` — and cross-repo structural queries work. The workspace root isn't a git repo, so the index is machine-local; if `codegraph_*` tools ever report "not initialized," re-run `codegraph init -i` at the workspace root. Reach for `codegraph_*` first for structural questions (definitions, callers, impact) across any of the three repos — grep only for literal text.
+The CodeGraph index (`.codegraph/`) is initialized at the **workspace root** — the directory *containing* the `sworld` checkout, not inside it — so one graph covers everything under it. The workspace root isn't a git repo, so the index is machine-local; if `codegraph_*` tools ever report "not initialized," re-run `codegraph init -i` there. Reach for `codegraph_*` first for structural questions (definitions, callers, impact) — grep only for literal text.
+
+**Read the path on every hit before trusting it.** The index spans sibling checkouts and every `.claude/worktrees/` worktree, so one symbol commonly returns many identical-looking results. Since the backend and data layer moved into the monorepo, the pre-move `sworld-backend` / `sworld-hasura-v2` checkouts still exist on disk and are still indexed — so a backend symbol returns hits under both `sworld/apps/backend/…` and the old `sworld-backend/…`, and only the first is live code. Take the `sworld/apps/…` hit (or the one inside the worktree you're working in); an edit made against an old path silently changes nothing.
 
 ## Don't defer error tracking for bundle size
 

--- a/apps/hasura/docs/publishing-owner-only.md
+++ b/apps/hasura/docs/publishing-owner-only.md
@@ -47,7 +47,7 @@ exercise it against a running Hasura by simulating a role with the admin secret
 ```bash
 EP=http://localhost:8030/v1/graphql   # local; use the deployed endpoint for prod
 SEC=<admin-secret>
-UID=6ff27fda-03e8-4dcd-949b-f1328f955065   # any user id
+UID=<any-user-id>
 
 # user INSERT playlist with public -> rejected: field 'public' not found in type: 'playlist_insert_input'
 curl -s "$EP" -H "x-hasura-admin-secret: $SEC" -H "x-hasura-role: user" -H "x-hasura-user-id: $UID" \


### PR DESCRIPTION
The guides that tell the assistant how this project is put together were still describing the old setup, where the server code and the database layer lived in two separate projects alongside the website code. Those have since been folded into a single project, so the guides were sending anyone who read them to directories that no longer exist and to commands that no longer work.

This updates them to match how things are actually arranged now, and — importantly — is honest about the parts that are still half-finished: the server code currently has no working way to be packaged up or released, so the guides now say so plainly and point at the tickets that own fixing it, rather than describing a release process that would fail if anyone tried it.

It also removes two real account identifiers that were sitting in files anyone can read, since this project is public. Nothing about how the software behaves changes — these are notes for people and assistants working on the code.

## Summary

Updates `backend-architecture`, `backend-ops`, `architecture`, and `dev-environment-gotchas` for the consolidated monorepo. Every claim was verified against the repo rather than trusted from the old prose.

- **Paths** — `sworld-backend` → `apps/backend`, `sworld-hasura-v2` → `apps/hasura` throughout (service table, metadata paths, key-files reference, CLI locations). Note the Hasura package name is still `sworld-hasura-v2` while its directory is `apps/hasura`; that mismatch is documented as a `pnpm --filter` trap.
- **Build model** — one pnpm workspace, one root `pnpm-lock.yaml`; all `npm ci` / `package-lock.json` / `@shinabr2/core`-from-npm assumptions removed. Backend consumes `core` via `workspace:*`, ESM end to end.
- **Deploy — deliberately documented as broken.** The six backend deploy workflows are gone and all three Dockerfiles still `npm ci` against a lockfile that no longer exists, so none of them build. Rather than describing a pipeline that does not exist, the skills state this plainly and point at SWO-545 (make the images build, via the pnpm workspace slice — not bundling) and SWO-546 (restore the deploy pipeline). `architecture` owns the deploy model, so its backend bullet carries the same fact.
- **Identity scrub** — removed the two real account UUIDs and the owner-specific "default account" guidance from `backend-ops`, and the real UUID from `apps/hasura/docs/publishing-owner-only.md`. Placeholders instead; public-infrastructure identifiers (bucket, Hasura endpoint) kept.
- **New verified gotchas** — root `biome.json` excludes both backend directories so a root lint says nothing about either; the pre-move checkouts still exist on disk and still appear in CodeGraph results alongside the live `apps/…` paths.

## Test plan

Documentation only — no code, no behaviour change, nothing to run.

- [x] Every rewritten path checked to exist: all 24 entries in the key-files table, the three Hasura metadata paths, the `public_notifications.yaml:53` line anchor.
- [x] `pnpm exec tsx src/cli/audio.ts` run from `apps/backend` to confirm the documented invocation works and that `core` resolves through the workspace.
- [x] `--user-id` support confirmed per CLI — `repair-fmp4.ts` takes the owner from the video row and has no such flag, so the claim is scoped to the four that do.
- [x] Dockerfiles, workflow list, `biome.json` excludes, and lockfile layout each read directly from the repo.
- [x] `git grep` for account-UUID patterns returns only synthetic example UUIDs and a uuidv5 namespace constant.

Refs SWO-553