### PR TITLE
docs(skills): update workflow skills for single-repo reality

### DIFF
--- a/.claude/skills/ci-loop/SKILL.md
+++ b/.claude/skills/ci-loop/SKILL.md
@@ -36,28 +36,28 @@ loop (the `self-review` skill, before the PR is created) is `parallel-workflow`'
 pre-PR gate. When a PR merges, Step 1 hands off to `cleanup`. Issue status is never touched here — that's
 the tracker's concern; see `task-tracker`.
 
-**Repo-qualify every `gh` command.** Each PR lives in exactly one repo (`sworld`, `sworld-backend`, or
-`sworld-hasura-v2`, all under `ShinaBR2`). The Step 3 GraphQL query takes a `name:"<repo>"` placeholder —
-fill in the repo the PR actually lives in; querying the wrong repo silently returns nothing.
+**Every PR lives in `ShinaBR2/sworld`** — frontend, backend, and Hasura all ship from the one repo, under
+one CI pipeline, so a single PR's checks cover whatever layers it touched. The `gh` calls below name that
+repo explicitly rather than relying on the current directory's remote.
 
 ## Step 1: Check merge status
 
-- Run `gh pr view <number> --repo "ShinaBR2/<repo>" --json state` as the **ONLY** command. Do NOT batch it with anything else.
-- If `MERGED` → run `cleanup` for this PR (pass its number + repo). Issue status is the tracker's — see `task-tracker`. Loop is done.
+- Run `gh pr view <number> --repo ShinaBR2/sworld --json state` as the **ONLY** command. Do NOT batch it with anything else.
+- If `MERGED` → run `cleanup` for this PR (pass its number). Issue status is the tracker's — see `task-tracker`. Loop is done.
 - If `CLOSED` → stop the loop. Report to user that the PR was closed without merging.
 - If `OPEN` → proceed to Step 2.
 
 ## Step 2: Check merge conflicts
 
-- Run `gh pr view <number> --repo "ShinaBR2/<repo>" --json mergeable`.
+- Run `gh pr view <number> --repo ShinaBR2/sworld --json mergeable`.
 - If conflicting → `git fetch origin main && git merge origin/main`, resolve conflicts, push. **STOP. Wait 6 minutes. Restart from Step 1.**
 - If clean → proceed to Step 3.
 
 ## Step 3: Check unresolved review comments
 
-- Query via GitHub **GraphQL API** (REST doesn't expose resolved status). Substitute `<repo>` with the repo the PR actually lives in — `sworld`, `sworld-backend`, or `sworld-hasura-v2` — and `NUMBER` with the PR number. Querying the wrong repo silently returns nothing:
+- Query via GitHub **GraphQL API** (REST doesn't expose resolved status). Substitute `NUMBER` with the PR number:
   ```bash
-  gh api graphql -f query='{ repository(owner:"ShinaBR2", name:"<repo>") { pullRequest(number:NUMBER) { reviewThreads(first:100) { nodes { isResolved comments(first:1) { nodes { body path line } } } } } } }'
+  gh api graphql -f query='{ repository(owner:"ShinaBR2", name:"sworld") { pullRequest(number:NUMBER) { reviewThreads(first:100) { nodes { isResolved comments(first:1) { nodes { body path line } } } } } } }'
   ```
 - Filter to `isResolved: false` threads only.
 - If unresolved threads exist → read them, fix the code, push. **STOP. Wait 6 minutes. Restart from Step 1.**
@@ -67,7 +67,7 @@ fill in the repo the PR actually lives in; querying the wrong repo silently retu
 
 ## Step 4: Check CI
 
-- Run `gh pr checks <number> --repo "ShinaBR2/<repo>"` (NEVER use `--watch`).
+- Run `gh pr checks <number> --repo ShinaBR2/sworld` (NEVER use `--watch`).
 - If failures → fix them, push. **STOP. Wait 6 minutes. Restart from Step 1.**
 - If **any check is `pending`** → nothing to fix, and nothing to report. Background-`sleep 360`, then **restart from Step 1**. A review bot still marked "Review in progress" counts as pending: it has not yet had its say, and Step 3 is the gate it feeds.
 - **A `skipped` check counts as green, not as pending.** Gates that filter by path run a cheap always-on filter job and skip the expensive one when nothing relevant changed (see `e2e-main-pr.yml`); `gh pr checks` prints these as `skipped`. That is the designed pass state — never wait on it. Its *filter* job going red is a real failure and blocks like any other.
@@ -85,7 +85,7 @@ fill in the repo the PR actually lives in; querying the wrong repo silently retu
   3. **All CI green** — every check passed or was `skipped`, nothing `pending`, nothing failed.
 - **A review bot's CI check going green does NOT mean the bot has finished reviewing.** CodeRabbit and Cursor bugbot report `SUCCESS` on their status check while the review itself is still running — and they report `SUCCESS` again after finding real bugs. So a fully green `gh pr checks` can sit alongside a bot that has not yet said anything, and moments later it posts blocking comments. Treat a bot as finished only when its check is green **and** it has actually left its review (its check description no longer reads "Review in progress", and Step 3's thread query reflects its verdict). Until then it is `pending`, whatever colour the check is — background-`sleep 360` and restart from Step 1. **Never call a PR settled on green CI alone.**
 - **"You can auto merge when clean" means:** run the full loop until the PR is settled, THEN merge it yourself. It does NOT mean skip the flow and merge now, and it never means skip the review-comment gate (Step 3) — that is the single most important gate, since a green bugbot/CodeRabbit *check* says nothing about whether they left real comments.
-- **Never delegate the merge condition to `gh pr merge --auto`.** In this repo it merges the instant the PR is mergeable — GitHub auto-merge only waits on *required* status checks, and this repo's branch protection defines none, so it does not wait for `test`/E2E to go green. Run the full CI loop yourself — Steps 1–4 above, including Step 4's `gh pr checks` — then run `gh pr merge <number> --repo "ShinaBR2/<repo>" --squash` manually once settled. Skipping straight to Steps 1–3 and merging without Step 4 ships whatever CI state happens to be current, which given this workspace's merge-is-deploy model means shipping broken code to production.
+- **Never delegate the merge condition to `gh pr merge --auto`.** In this repo it merges the instant the PR is mergeable — GitHub auto-merge only waits on *required* status checks, and this repo's branch protection defines none, so it does not wait for `test`/E2E to go green. Run the full CI loop yourself — Steps 1–4 above, including Step 4's `gh pr checks` — then run `gh pr merge <number> --repo ShinaBR2/sworld --squash` manually once settled. Skipping straight to Steps 1–3 and merging without Step 4 ships whatever CI state happens to be current, which given this repo's merge-is-deploy model means shipping broken code to production.
 - Any fix mid-loop → push → wait 6 minutes → restart from Step 1. A new instruction mid-task folds into this process; it never cancels it or justifies a shortcut.
 
 ## The rule that gets violated

--- a/.claude/skills/ci-loop/SKILL.md
+++ b/.claude/skills/ci-loop/SKILL.md
@@ -36,9 +36,10 @@ loop (the `self-review` skill, before the PR is created) is `parallel-workflow`'
 pre-PR gate. When a PR merges, Step 1 hands off to `cleanup`. Issue status is never touched here — that's
 the tracker's concern; see `task-tracker`.
 
-**Every PR lives in `ShinaBR2/sworld`** — frontend, backend, and Hasura all ship from the one repo, under
-one CI pipeline, so a single PR's checks cover whatever layers it touched. The `gh` calls below name that
-repo explicitly rather than relying on the current directory's remote.
+**Every PR lives in `ShinaBR2/sworld`** — frontend, backend, and Hasura all ship from the one repo, so
+every PR runs through this same loop. The `gh` calls below name that repo explicitly rather than relying
+on the current directory's remote. Which checks actually run on a given PR is whatever the repo's
+workflows decide; read `gh pr checks` rather than assuming a layer is covered.
 
 ## Step 1: Check merge status
 

--- a/.claude/skills/cleanup/SKILL.md
+++ b/.claude/skills/cleanup/SKILL.md
@@ -32,53 +32,30 @@ for the tracker coupling — here on the git-cleanup axis.
   worktree but explicitly permits advancing it with `git pull --ff-only origin main` — which is exactly
   the refresh below. Cleanup never writes files into a main worktree; it only advances the `main` ref.
 
-## Workspace: three repos
+## The one repo
 
-Every branch/worktree belongs to exactly one repo (`sworld`, `sworld-backend`, `sworld-hasura-v2`, all
-under `ShinaBR2`). **All cleanup runs in the repo the branch belongs to — never cross-repo**, and always
-via `git -C "$repo_path"` (never rely on the current directory, which may still be a worktree being torn
-down). `<workspace>` below is the directory that holds the three repo clones side by side — the session's
-workspace root; substitute the real absolute path (set `workspace=` once). Map the repo NAME to its clone
-path under it, and confirm the clone actually exists before any `git -C`:
+Everything — frontend apps, shared packages, backend, Hasura — lives in `ShinaBR2/sworld`, so every branch
+and worktree belongs to that single clone. Cleanup always runs via `git -C "$repo_path"`, never relying on
+the current directory, which may still be the worktree being torn down. Set `repo_path` once to the clone's
+absolute path and confirm it really is a clone before any `git -C`:
 
 ```bash
-workspace="<workspace>"   # absolute path to the dir holding the three clones — substitute the real one
-case "$repo" in
-  sworld)           repo_path="$workspace/sworld" ;;
-  sworld-backend)   repo_path="$workspace/sworld-backend" ;;
-  sworld-hasura-v2) repo_path="$workspace/sworld-hasura-v2" ;;
-  *) echo "cleanup: unknown repo '$repo' — stop"; exit 1 ;;
-esac
+repo_path="<path-to-sworld-clone>"   # absolute path to the sworld clone — substitute the real one
 git -C "$repo_path" rev-parse --git-dir >/dev/null 2>&1 || { echo "cleanup: $repo_path is not a git clone — stop"; exit 1; }
 ```
 
-If a repo can't be resolved or isn't one of the three, report it and stop — don't guess.
-
 ## A. Tear down a merged branch
 
-Inputs: the PR's **repo** and its **PR number** `<N>`. Teardown keys off the PR — that's what makes the
-`MERGED` gate below unambiguous — and derives the branch from it; a caller with the branch already resolved
+Input: the **PR number** `<N>`. Teardown keys off the PR — that's what makes the `MERGED` gate below
+unambiguous — and derives the branch from it; a caller with the branch already resolved
 (`wait-for-pr-merge`) still passes the number so the gate can run. **The `MERGED` gate is mandatory on every
 path.** The two automated callers (`wait-for-pr-merge`, `ci-loop`) invoke teardown only after they've
 observed the merge, so they satisfy it; a direct `/cleanup` invocation must confirm it here.
 
-Resolve the repo (skip if the caller passed it), then read state + branch:
+Read the PR's state:
 
 ```bash
-# Prefer an explicit repo from the caller. Only when invoked with a bare PR number, probe — and because a
-# PR number is unique only WITHIN a repo, count ALL matches and abort unless exactly one owns it. Count with
-# a plain counter, never word-splitting (zsh doesn't split unquoted vars, so `set -- $matches` would misbehave).
-if [ -z "$repo" ]; then
-  n=0; matches=""
-  for r in sworld sworld-backend sworld-hasura-v2; do
-    if gh pr view <N> --repo "ShinaBR2/$r" --json state >/dev/null 2>&1; then
-      n=$((n + 1)); repo="$r"; matches="$matches $r"
-    fi
-  done
-  [ "$n" -eq 1 ] || { echo "PR <N>: expected exactly one owning repo, matched$matches — pass the repo explicitly; stop"; exit 1; }
-fi
-
-state=$(gh pr view <N> --repo "ShinaBR2/$repo" --json state -q .state)
+state=$(gh pr view <N> --repo ShinaBR2/sworld --json state -q .state)
 ```
 
 **Only ever tear down a `MERGED` PR.** If `CLOSED`, do nothing — the branch and worktree may still be
@@ -89,7 +66,7 @@ completion:
 ```bash
 [ "$state" = "MERGED" ] || { echo "PR <N>: state is '$state', not MERGED — cleanup only tears down merged PRs; stop"; exit 1; }
 
-branch=$(gh pr view <N> --repo "ShinaBR2/$repo" --json headRefName -q .headRefName)
+branch=$(gh pr view <N> --repo ShinaBR2/sworld --json headRefName -q .headRefName)
 [ -n "$branch" ] || { echo "PR <N>: cannot resolve branch — aborting cleanup"; exit 1; }
 
 # Exact worktree path for this branch (porcelain, exact ref match — never substring; handles paths with spaces).
@@ -107,20 +84,20 @@ Guardrails baked in above, all load-bearing: exact `refs/heads/$branch` match (a
 remove the wrong worktree), never act on an empty `$branch` (empty matches every worktree), only remove a
 worktree that exists, `-D` because squash-merge leaves the branch technically unmerged.
 
-Then **refresh that repo's local `main`** (section B) — a torn-down branch means `main` just moved.
+Then **refresh local `main`** (section B) — a torn-down branch means `main` just moved.
 
 ## B. Refresh local `main`
 
 Fetching only advances the `origin/main` **ref**; the local `main` branch pointer stays stale, so any lazy
 reference to local `main` (a code read, a diff, a new worktree base) is wrong. In this parallel-worktree
-workflow local `main` is *chronically* behind, so keep the pointer current. Each repo has its own `.git`
-and its own `main` — refresh **every** repo whose `main` you're about to read off or branch from.
+workflow local `main` is *chronically* behind, so keep the pointer current — refresh before you read off
+`main` or branch from it.
 
 Fast-forward only, never rebase, never a merge commit on `main`. Which command depends on what the repo's
 **main worktree** (the first entry in `git worktree list`) is checked out on — probe it, then pick:
 
 ```bash
-# Emits "main" if that repo's main worktree sits on `main`, else the feature-branch name (empty/detached => not on main).
+# Emits "main" if the main worktree sits on `main`, else the feature-branch name (empty/detached => not on main).
 onmain=$(git -C "$repo_path" worktree list --porcelain | awk '
   /^branch refs\/heads\//{sub(/^branch refs\/heads\//,""); print; found=1} /^$/{if(!found)print"detached"; exit}')
 
@@ -128,21 +105,20 @@ case "$onmain" in
   # Main worktree sits on `main`: advance the branch pointer AND its checkout. --ff-only so a diverged
   # main errors loudly instead of silently creating a merge commit; name `origin main` so it can't
   # depend on — or advance — the wrong upstream.
-  main) (cd "$repo_path" && git pull --ff-only origin main) || { echo "$repo: main refresh failed — stop"; exit 1; } ;;
+  main) (cd "$repo_path" && git pull --ff-only origin main) || { echo "main refresh failed — stop"; exit 1; } ;;
   # Main worktree sits on a feature branch (the common case here): advance the local `main` ref without a
   # checkout and without touching any working tree. It refuses loudly if `main` IS checked out somewhere —
   # that refusal is the tell to use `git pull --ff-only` in that worktree instead.
-  *)    git -C "$repo_path" fetch origin main:main || { echo "$repo: main refresh failed — stop"; exit 1; } ;;
+  *)    git -C "$repo_path" fetch origin main:main || { echo "main refresh failed — stop"; exit 1; } ;;
 esac
 ```
 
 A failed refresh must **stop** success reporting (and, for a caller that relaunches a poll, prevent the
-relaunch for that repo).
+relaunch).
 
 Run the refresh:
 
-1. **As the tail of every teardown** (section A) — for the repo whose branch was just torn down.
-2. **Before starting new work / before any code read on `main`** in a repo.
+1. **As the tail of every teardown** (section A) — the branch just torn down moved `main`.
+2. **Before starting new work / before any code read on `main`**.
 3. **Standalone, on demand** — whenever the user says "refresh main", "update main", "pull main", or any
-   equivalent. It's a one-command-per-repo action, never a question: just run it and report. If the user
-   names no repo, run it for all three (`sworld`, `sworld-backend`, `sworld-hasura-v2`).
+   equivalent. It's a one-command action, never a question: just run it and report.

--- a/.claude/skills/dependency-analysis/SKILL.md
+++ b/.claude/skills/dependency-analysis/SKILL.md
@@ -84,12 +84,12 @@ Every piece of work lands in exactly one:
 
 A wave is a barrier: everything in wave N lands before wave N+1 starts. That is a real cost in wall-clock time and coordination, so impose it **only where the test above found a genuine edge**. Never add ordering to make a plan look structured. If everything is parallel, say so plainly and skip waves and the dependency graph entirely.
 
-## Cross-repo edges are the ones that bite
+## Cross-layer edges are the ones that bite
 
-The sharpest real dependencies in this workspace run **between repos**, where nothing type-checks the seam:
+The sharpest real dependencies run **between layers**, where nothing type-checks the seam. One repo does not remove them — the compiler still never sees the frontend's call meet the schema or handler behind it:
 
-- A frontend query on a new table or column is blocked by the `sworld-hasura-v2` PR that adds it.
-- A frontend call to a new Action is blocked by the `sworld-backend` handler behind it.
+- A frontend query on a new table or column is blocked by the `apps/hasura` migration that adds it.
+- A frontend call to a new Action is blocked by the `apps/backend` handler behind it.
 
 Merging is deploying (see `architecture`), so these edges are also a **live ordering constraint in production**, not just a build-order preference. Land the data layer first and let it deploy.
 

--- a/.claude/skills/micro-prs/SKILL.md
+++ b/.claude/skills/micro-prs/SKILL.md
@@ -18,19 +18,19 @@ Apply these mechanically, before anything else — when breaking a ticket into s
 
 Not "mostly one". One. If describing the PR needs an "and", it's two PRs.
 
-### 2. ONE repo, and within it ONE app or ONE shared package — never combine
+### 2. ONE app or ONE shared package — never combine
 
-sworld spans three physically separate repos (frontend `sworld`, `sworld-backend`, `sworld-hasura-v2`), so a PR can never span repos by construction — but the same discipline has to be applied deliberately *within* the frontend repo, where nothing stops you combining things that shouldn't be combined:
+Everything now lives in one repo, so nothing stops you combining pieces that shouldn't be combined. This rule has to be applied deliberately:
 
-- A single frontend PR touches **at most one** of: one `apps/<app>` directory, or `packages/core`, or `packages/ui`.
+- A single PR touches **at most one** of: one `apps/<app>` directory — including `apps/backend` and `apps/hasura` — or `packages/core`, or `packages/ui`.
 - Touching two apps in one PR is wrong. An app plus `packages/core` in one PR is wrong. `packages/core` plus `packages/ui` in one PR is wrong.
 - Each layer carries different review and verification concerns — an app PR is checked by running that app; a `packages/core` PR is checked by its unit tests and `pnpm codegen`; a `packages/ui` PR is checked in Storybook. A PR mixing them can't be reviewed properly or reverted cleanly.
-- Across repos, the same rule shows up as sequencing instead of a single-PR constraint: a Hasura migration is its own PR in `sworld-hasura-v2`, and the frontend's regenerated types are a separate follow-up PR in `sworld` (see `parallel-workflow`) — never squashed into one change just because they're related.
+- **One repo is not permission to merge layers.** A Hasura migration in `apps/hasura` and the frontend's regenerated types in `packages/core` are still two PRs, in that order (see `parallel-workflow`) — the schema has to be live before the generated types mean anything. Sharing a repo removes the friction, not the dependency.
 
 ## Blockers land first, as their own PRs
 
-- **Database/schema.** Anything Hasura migration + metadata (permissions, relationships) is ONE dedicated PR in `sworld-hasura-v2`. It lands first; the frontend codegen follow-up is blocked-by it.
-- **Codegen never lands bundled with app logic.** It rides with the schema-change PR above when the schema changed, or — for a read-only phase with no migration — is its own tiny PR, blocked by nothing.
+- **Database/schema.** Anything Hasura migration + metadata (permissions, relationships) is ONE dedicated PR in `apps/hasura`. It lands first; the frontend codegen follow-up is blocked-by it.
+- **Codegen never lands bundled with app logic.** When a schema change drove it, it's the follow-up PR blocked by the schema PR above. For a read-only phase with no migration, it's its own tiny PR, blocked by nothing.
 - **`packages/core`.** Its own PR, even for a one-line change. Never bundled into an app PR that consumes it.
 - **Constants.** Their own independent PR, first, when a later PR needs them.
 - **Foundation/scaffolding.** A foundation-only PR containing nothing but the scaffolding, cut from `main` — never `blockedBy` the feature that surfaced the need. Foundation comes first; the feature builds on it.
@@ -48,7 +48,7 @@ Which pieces genuinely block which is `dependency-analysis`' call — take its g
 
 Common shapes:
 
-- **Database change:** table schema → migration → GraphQL schema update (all one PR, per "Blockers land first" above) → frontend codegen follow-up (separate PR, separate repo).
+- **Database change:** table schema → migration → GraphQL schema update (all one PR in `apps/hasura`, per "Blockers land first" above) → frontend codegen follow-up (separate PR in `packages/core`).
 - **New API:** endpoint stub (returns empty) → core logic → validation & error handling.
 - **Frontend feature:** component skeleton → basic functionality → styling/interactions → wire to backend.
 
@@ -81,10 +81,10 @@ This is what makes the core-logic layer above land safely ahead of the UI — be
 - Reviewable in a few minutes.
 - Safely revertible on its own.
 - Delivers value, or a foundation for the next step.
-- Single responsibility — does one thing, in one app/package/repo.
+- Single responsibility — does one thing, in one app or package.
 - Independently deployable (behind a flag if needed).
 
-Before opening any PR, ask: **what ONE problem, in ONE app/package/repo, does this solve?** If the answer names two, split it — database/schema and constants land first as blockers, app logic on top.
+Before opening any PR, ask: **what ONE problem, in ONE app or package, does this solve?** If the answer names two, split it — database/schema and constants land first as blockers, app logic on top.
 
 Once a slice is scoped, see `pr-descriptions` for writing the title and body.
 

--- a/.claude/skills/parallel-workflow/SKILL.md
+++ b/.claude/skills/parallel-workflow/SKILL.md
@@ -11,26 +11,24 @@ user-invocable: false
 - **The tracker issue is the source of truth.** A tracker issue is REQUIRED before starting any work. NEVER start working without one — if there isn't one, create it first (see `writing-task-specs`; `task-tracker` owns the tracker itself and its commands).
 - **ALWAYS work in a dedicated worktree.** NEVER create branches or make changes in the main worktree. The main worktree must stay clean — the *only* permitted operation there advances the local `main` ref (the fast-forward refresh the `cleanup` skill owns — see "Keep local `main` fresh" below). No branch work, no manual edits.
 
-## Scope: all three repos
+## Scope: one repo, the whole product
 
-This workflow applies to the whole workspace — **sworld** (frontend), **sworld-backend** (Hono), and **sworld-hasura-v2** (Hasura) — not just the frontend. Same rules everywhere: tracker issue first, dedicated worktree, commit often / push immediately, self-review loop before PR, CI loop after. Repo-specific adjustments:
+Everything ships from a single repo — the frontend apps, the shared packages, the Hono backend (`apps/backend`), and the Hasura data layer (`apps/hasura`). One lockfile, one CI pipeline, one PR flow. These rules apply to every part of it, frontend or not: tracker issue first, dedicated worktree, commit often / push immediately, self-review loop before PR, CI loop after. Two adjustments by area:
 
-- **Substitute the repo name in `gh` commands.** Every `gh` / GraphQL call is repo-scoped — fill in `sworld`, `sworld-backend`, or `sworld-hasura-v2`. Querying the wrong repo silently returns nothing. (The `ci-loop` gate queries carry the same rule.)
-- **Worktree setup step 7 (`.linear.toml`) applies everywhere; step 8 is frontend-specific** (.env copies into `apps/<app>/`, `packages/core/.env`, `pnpm install`). In a sibling repo, copy `.linear.toml` the same way, then follow that repo's own setup instead of step 8.
-- **Trust boundaries get the deep treatment.** Hasura permissions/metadata and Hono Action/Event/webhook handlers are trust boundaries — in those repos the self-review loop (step 11) MUST also include the `security-reviewer` skill.
-- **Hasura changes are not done when their PR is clean.** A schema change ripples into the frontend: apply the migration locally, re-run `pnpm codegen` in `packages/core` (it introspects the LOCAL Hasura), and land the regenerated types as a follow-up frontend PR — linked in the tracker with a blocking relation from the Hasura issue.
+- **Trust boundaries get the deep treatment.** Hasura permissions/metadata and Hono Action/Event/webhook handlers are trust boundaries — a change touching them MUST also run `security-reviewer` inside the self-review loop (step 11).
+- **Hasura changes are not done when their PR is clean.** A schema change ripples into the frontend: apply the migration locally, re-run `pnpm codegen` in `packages/core` (it introspects the LOCAL Hasura), and land the regenerated types as a follow-up PR — linked in the tracker with a blocking relation from the Hasura issue. One repo doesn't collapse that ripple: the schema still has to be live before the generated types mean anything, so the migration lands and deploys first.
 
 ## Git fundamentals
 
 - "main branch" ALWAYS means `origin/main` — fetch first with `git fetch origin main`. The local `main` is often stale.
 - ALWAYS `git merge`, NEVER `git rebase`. This applies everywhere — syncing, resolving divergence, integrating changes.
-- **Sync before analyzing, not just before coding.** Before exploring or reasoning about code anywhere in this workspace (any of the three repos), check `git status` and pull/fast-forward to `origin/main` first. Analyzing a stale checkout produces wrong conclusions and clarifying questions that contradict what's actually on main.
+- **Sync before analyzing, not just before coding.** Before exploring or reasoning about code anywhere in the repo, check `git status` and pull/fast-forward to `origin/main` first. Analyzing a stale checkout produces wrong conclusions and clarifying questions that contradict what's actually on main.
 
 ### Keep local `main` fresh
 
-Fetching only advances the `origin/main` **ref** — the local `main` branch pointer stays stale, so any lazy reference to local `main` (a code read, a diff, a new worktree base) is wrong. Because of the parallel-worktree workflow, local `main` is *chronically* behind — keep the pointer current in **every** repo whose `main` you are about to read off or branch from.
+Fetching only advances the `origin/main` **ref** — the local `main` branch pointer stays stale, so any lazy reference to local `main` (a code read, a diff, a new worktree base) is wrong. Because of the parallel-worktree workflow, local `main` is *chronically* behind — keep the pointer current.
 
-The refresh mechanic and every trigger for it are owned by the `cleanup` skill — see `cleanup`. Refresh a repo's `main` before you start new work in it or read off it.
+The refresh mechanic and every trigger for it are owned by the `cleanup` skill — see `cleanup`. Refresh `main` before you start new work or read off it.
 
 ## Before starting
 
@@ -43,7 +41,7 @@ The refresh mechanic and every trigger for it are owned by the `cleanup` skill �
 
 5. `git fetch origin main` first, then create worktree inside `.claude/worktrees/` from `origin/main`.
 6. Create the worktree under `.claude/worktrees/` — self-contained, gitignored, and aligned with Claude Code's official default — named for the issue per `task-tracker`'s branch convention.
-7. **Copy `.linear.toml` from the repo root into the worktree root.** It is gitignored (it can hold a plaintext API key), so a fresh worktree starts without it — and the `linear` CLI's config lookup stops at the checkout root, never walking up to the main worktree. Without it every tracker command silently resolves to the account's *default* workspace, which is not `sworld`: reads return the wrong workspace's data, and writes fail with `Team not found: SWO`. Applies to all three repos.
+7. **Copy `.linear.toml` from the repo root into the worktree root.** It is gitignored (it can hold a plaintext API key), so a fresh worktree starts without it — and the `linear` CLI's config lookup stops at the checkout root, never walking up to the main worktree. Without it every tracker command silently resolves to the account's *default* workspace, which is not `sworld`: reads return the wrong workspace's data, and writes fail with `Team not found: SWO`.
 8. Copy `.env` files from the main worktree into the matching `apps/<app>/` directories. **Also copy `packages/core/.env`** — `pnpm codegen` reads `HASURA_GRAPHQL_URL` / `HASURA_ADMIN_SECRET` from it; without it codegen aborts with `Unable to find any GraphQL type definitions ... - undefined`. Then run `pnpm install` in the worktree.
 
 ## During work

--- a/.claude/skills/parallel-workflow/SKILL.md
+++ b/.claude/skills/parallel-workflow/SKILL.md
@@ -13,7 +13,7 @@ user-invocable: false
 
 ## Scope: one repo, the whole product
 
-Everything ships from a single repo — the frontend apps, the shared packages, the Hono backend (`apps/backend`), and the Hasura data layer (`apps/hasura`). One lockfile, one CI pipeline, one PR flow. These rules apply to every part of it, frontend or not: tracker issue first, dedicated worktree, commit often / push immediately, self-review loop before PR, CI loop after. Two adjustments by area:
+Everything ships from a single repo — the frontend apps, the shared packages, the Hono backend (`apps/backend`), and the Hasura data layer (`apps/hasura`). One lockfile, one branch, one PR flow. These rules apply to every part of it, frontend or not: tracker issue first, dedicated worktree, commit often / push immediately, self-review loop before PR, CI loop after. Two adjustments by area:
 
 - **Trust boundaries get the deep treatment.** Hasura permissions/metadata and Hono Action/Event/webhook handlers are trust boundaries — a change touching them MUST also run `security-reviewer` inside the self-review loop (step 11).
 - **Hasura changes are not done when their PR is clean.** A schema change ripples into the frontend: apply the migration locally, re-run `pnpm codegen` in `packages/core` (it introspects the LOCAL Hasura), and land the regenerated types as a follow-up PR — linked in the tracker with a blocking relation from the Hasura issue. One repo doesn't collapse that ripple: the schema still has to be live before the generated types mean anything, so the migration lands and deploys first.

--- a/.claude/skills/self-review/SKILL.md
+++ b/.claude/skills/self-review/SKILL.md
@@ -146,14 +146,14 @@ Our style rules are non-negotiable and easy to slip past in an AI-generated diff
 
 ### Security and data handling
 
-If the PR touches a **trust boundary** — authentication / Auth0, Hasura permissions or metadata, the `sworld-backend` (Hono) Action/Event or webhook handlers, the admin secret, or `VITE_`-prefixed env vars — do a careful stack-aware pass. For changes that don't touch a boundary, the quick checks are enough:
+If the PR touches a **trust boundary** — authentication / Auth0, Hasura permissions or metadata, the Hono Action/Event or webhook handlers in `apps/backend`, the admin secret, or `VITE_`-prefixed env vars — do a careful stack-aware pass. For changes that don't touch a boundary, the quick checks are enough:
 
 - Inputs validated where they enter the system?
 - Output sanitised where it crosses a trust boundary?
 - Secrets, tokens, API keys — handled correctly, not logged or committed?
 - User data — appropriate access controls?
 
-Remember the backend lives in the separate `sworld-backend` repo and the data layer is Hasura (`sworld-hasura-v2`) over Postgres — a frontend PR can't be trusted to enforce anything on its own; validation and access control belong server-side.
+Remember the backend (`apps/backend`) and the Hasura data layer (`apps/hasura`) over Postgres now sit in the same repo as the frontend — being one diff away does not make a frontend PR able to enforce anything on its own; validation and access control still belong server-side.
 
 ### Performance
 

--- a/.claude/skills/wait-for-pr-merge/SKILL.md
+++ b/.claude/skills/wait-for-pr-merge/SKILL.md
@@ -10,46 +10,31 @@ The human merges a READY PR by hand on GitHub. This skill watches for that merge
 
 **Scope boundary:** this skill assumes each PR is already READY and the user is merging manually. It does **NOT** touch CI, conflicts, or review comments — that is the loop ("do the loop"; see [`ci-loop`](../ci-loop/SKILL.md)). If a PR simply isn't merged yet, keep waiting; never start fixing things under this skill.
 
-## Workspace: three repos
+## 1. Poll the PRs
 
-Each PR belongs to exactly one of the three repos (`sworld`, `sworld-backend`, `sworld-hasura-v2`, all under `ShinaBR2`). The repo is resolved once up front (see §1's resolve step) and every `gh pr view` is qualified with `--repo ShinaBR2/<repo>`. Per-PR cleanup is delegated to the `cleanup` skill — this skill just passes it the PR and its repo. If a PR's repo can't be resolved or isn't one of the three, report and drop the PR from the poll — don't guess.
+Everything lives in the one repo, `ShinaBR2/sworld` — a PR number identifies a PR outright, with nothing to resolve. Still pass `--repo ShinaBR2/sworld` explicitly on every `gh pr view`: the poll runs from a background shell whose working directory isn't guaranteed to be a checkout, and a bare `gh pr view` resolves against the current directory's remote. Per-PR cleanup is delegated to the `cleanup` skill — this skill just passes it the PR number.
 
-## 1. Resolve each PR's repo, then poll
+A failed `gh` call (auth, network, bad PR number) must NOT be mistaken for `OPEN` — otherwise the loop spins silently forever. Treat only a successful, non-empty state as truth; retry a few times before declaring a PR unreachable. **NEVER** use `gh pr view --watch` / `gh pr checks --watch`.
 
-Every `gh pr view <N>` in this skill MUST be **repository-qualified** — a bare `gh pr view <N>` resolves against the *current* repo's remote only, so a `sworld-backend` or `sworld-hasura-v2` PR number looked up from a `sworld` worktree either fails or, where numbers collide, resolves the **wrong PR**. Resolve each PR's repo **once up front**, then pass `--repo ShinaBR2/<repo>` on every `gh pr view`.
-
-**Resolve step (you run it, not the background script).** For each PR number, probe the three repos until one returns a PR with that number — that repo owns it:
+Keep the poll script **portable across sh / bash / zsh** — the background shell is not guaranteed to be any one of them: NO bash-only constructs (`declare -A`, associative arrays); put the PR numbers in **positional parameters** (`set -- …`) and loop with `for n in "$@"`. Do NOT write `for n in $LIST` — zsh does not word-split an unquoted variable, so it would iterate once over the whole string and poll a bogus number.
 
 ```sh
-for n in <N1> <N2>; do
-  for r in sworld sworld-backend sworld-hasura-v2; do
-    gh pr view "$n" --repo "ShinaBR2/$r" --json state >/dev/null 2>&1 && { echo "$n:$r"; break; }
-  done
-done
-```
-
-Build the resolved pairs as `<num>:<repo>` and pass them to the background poll. A failed `gh` call (auth, network, bad PR number) must NOT be mistaken for `OPEN` — otherwise the loop spins silently forever. Treat only a successful, non-empty state as truth; retry a few times before declaring a PR unreachable. **NEVER** use `gh pr view --watch` / `gh pr checks --watch`.
-
-Keep the poll script **portable across sh / bash / zsh** — the background shell is not guaranteed to be any one of them: NO bash-only constructs (`declare -A`, associative arrays); put the resolved pairs in **positional parameters** (`set -- …`) and loop with `for pair in "$@"`. Do NOT write `for pair in $LIST` — zsh does not word-split an unquoted variable, so it would iterate once over the whole string and poll a bogus pair.
-
-```sh
-# Replace the pairs below with the RESOLVED pairs from the step above (445:sworld 446:sworld-backend are only an example).
+# Replace the numbers below with the PRs being watched (445 446 are only an example).
 # Exits as soon as any tracked PR is terminal (MERGED/CLOSED) or stays unreachable after 3 quick retries.
-set -- 445:sworld 446:sworld-backend
+set -- 445 446
 while true; do
   hit=0
-  for pair in "$@"; do
-    n="${pair%%:*}"; repo="${pair#*:}"
+  for n in "$@"; do
     s=""; i=1
     while [ "$i" -le 3 ]; do
-      s=$(gh pr view "$n" --repo "ShinaBR2/$repo" --json state -q .state 2>/dev/null)
+      s=$(gh pr view "$n" --repo ShinaBR2/sworld --json state -q .state 2>/dev/null)
       [ -n "$s" ] && break
       i=$((i + 1)); sleep 5
     done
     if [ -z "$s" ]; then
       echo "ERROR:$n:gh-unreachable"; hit=1
     elif [ "$s" = "MERGED" ] || [ "$s" = "CLOSED" ]; then
-      echo "FINAL:$n:$repo:$s"; hit=1
+      echo "FINAL:$n:$s"; hit=1
     fi
   done
   [ "$hit" = 1 ] && exit 0
@@ -57,15 +42,13 @@ while true; do
 done
 ```
 
-Run it with the background flag. When it exits, read the `FINAL:<n>:<repo>:<state>` and `ERROR:<n>:...` lines and handle each (below). Then **re-launch the poll for the PRs still pending** (re-resolving is not needed — the repo is stable) and repeat, until none are left.
+Run it with the background flag. When it exits, read the `FINAL:<n>:<state>` and `ERROR:<n>:...` lines and handle each (below). Then **re-launch the poll for the PRs still pending** and repeat, until none are left.
 
 ## 2. Handle each event
 
-Each `FINAL` line already carries the resolved repo (`FINAL:<n>:<repo>:<state>`). Every `gh pr view <N>` below MUST keep `--repo "ShinaBR2/$repo"`.
-
 ### MERGED → clean up
 
-Run the `cleanup` skill for this PR, passing its repo and number. Whatever tearing down a merged PR involves is cleanup's concern, not this skill's.
+Run the `cleanup` skill for this PR, passing its number. Whatever tearing down a merged PR involves is cleanup's concern, not this skill's.
 
 Issue status is the tracker's to manage — see `task-tracker`. This path only cleans up.
 
@@ -79,6 +62,6 @@ Report that the PR could not be polled and drop it from the pending set so the u
 
 ## 3. After the round
 
-- If `cleanup` reported failure for a PR, mark **that PR** failed and surface it — but keep polling the other pending PRs; only stop watching a repo entirely if the repo itself is unreachable.
+- If `cleanup` reported failure for a PR, mark **that PR** failed and surface it — but keep polling the other pending PRs.
 - Report per PR: cleaned-up (merged), closed-without-merge, or unreachable.
 - If PRs remain pending, re-launch the poll (step 1) for just those. When the pending set is empty, report the final tally and stop.

--- a/.claude/skills/wait-for-pr-merge/SKILL.md
+++ b/.claude/skills/wait-for-pr-merge/SKILL.md
@@ -16,7 +16,7 @@ Everything lives in the one repo, `ShinaBR2/sworld` — a PR number identifies a
 
 A failed `gh` call (auth, network, bad PR number) must NOT be mistaken for `OPEN` — otherwise the loop spins silently forever. Treat only a successful, non-empty state as truth; retry a few times before declaring a PR unreachable. **NEVER** use `gh pr view --watch` / `gh pr checks --watch`.
 
-Keep the poll script **portable across sh / bash / zsh** — the background shell is not guaranteed to be any one of them: NO bash-only constructs (`declare -A`, associative arrays); put the PR numbers in **positional parameters** (`set -- …`) and loop with `for n in "$@"`. Do NOT write `for n in $LIST` — zsh does not word-split an unquoted variable, so it would iterate once over the whole string and poll a bogus number.
+Keep the poll script **portable across sh / bash / zsh** — the background shell is not guaranteed to be any one of them: NO bash-only constructs (`declare -A`, associative arrays); put the PR numbers in **positional parameters** (`set -- …`) and loop with `for n in "$@"`. Do NOT write `for n in $LIST` — zsh does not word-split an unquoted variable, so it would iterate once over the whole string and poll a bogus number. **Brace any expansion followed by `:`** (`"ERROR:${n}:…"`, never `"ERROR:$n:…"`) — zsh reads `$n:g` as a history modifier and silently swallows the number, so the emitted line stops matching the format below.
 
 ```sh
 # Replace the numbers below with the PRs being watched (445 446 are only an example).
@@ -32,7 +32,7 @@ while true; do
       i=$((i + 1)); sleep 5
     done
     if [ -z "$s" ]; then
-      echo "ERROR:$n:gh-unreachable"; hit=1
+      echo "ERROR:${n}:gh-unreachable"; hit=1
     elif [ "$s" = "MERGED" ] || [ "$s" = "CLOSED" ]; then
       echo "FINAL:$n:$s"; hit=1
     fi

--- a/.claude/skills/writing-task-specs/SKILL.md
+++ b/.claude/skills/writing-task-specs/SKILL.md
@@ -345,10 +345,10 @@ A technically broken-down feature with sequenced sub-tasks. This is the *output*
 ### Scoping conversation steps
 
 1. **Start from the user story.** Read the user story issue. Understand the problem, the ideas explored, and the open questions.
-2. **Identify the architectural shape.** What systems are touched? Frontend app, `packages/core` hooks, the Hasura layer, the `sworld-backend` Hono service? Is there an existing pattern to follow? For frontend work, `frontend-ui-architecture` decides *where* each piece lands (which package and folder), which shapes how a sub-task is scoped.
+2. **Identify the architectural shape.** What systems are touched? Frontend app, `packages/core` hooks, the Hasura layer in `apps/hasura`, the Hono backend in `apps/backend`? Is there an existing pattern to follow? For frontend work, `frontend-ui-architecture` decides *where* each piece lands (which package and folder), which shapes how a sub-task is scoped.
 3. **Resolve the open questions.** The user story's open questions become decisions in the parent issue's description.
 4. **Write the goal & verification sub-issue first** (see below) — before naming a single code sub-task. If you can't write a concrete walkthrough and "how to know it's done" list yet, the concept isn't settled enough to scope — go back to `product-planning`, don't invent sub-tasks around a fuzzy goal.
-5. **Break into sub-tasks by one-purpose, one-app/repo scope.** Apply `micro-prs`' one-purpose test to each candidate before it becomes a sub-issue — split it now, at scoping time, not after the branch is built.
+5. **Break into sub-tasks by one-purpose, one-app-or-package scope.** Apply `micro-prs`' one-purpose test to each candidate before it becomes a sub-issue — split it now, at scoping time, not after the branch is built.
 6. **Derive the dependency graph from the code** — run `dependency-analysis` over the candidates. It decides which are isolated and which carry a real `blockedBy`; this skill only records what it returns.
 7. **Group into waves only where step 6 found a real blocker**, and render them per the templates below. If everything is parallel, skip waves and the dependency graph section entirely.
 8. **Map to the deployment model.** Each sub-task must be small, independently mergeable, and revertible. Anything user-facing sits behind a feature flag until ready.
@@ -509,7 +509,7 @@ No waves — all startable now:
   types-only             — new interfaces in packages/core, no implementation
   ui-shell               — empty dialog + button in apps/til, no wiring yet
   parser-helper          — pure text→notes parser in packages/core, unit-tested alone
-  hasura-permissions     — read permission for the new table (sworld-hasura-v2, separate repo/PR)
+  hasura-permissions     — read permission for the new table (apps/hasura, its own PR)
 ```
 
 A worked dependency graph for an `Import notes` parent issue where a real blocker exists (waves are encoded by `blockedBy` relations between sub-issues — imposed here only because `dependency-analysis` returned those edges as real):


### PR DESCRIPTION
Refs SWO-552

## Summary

The instructions our AI assistant follows still described the project as three separate codebases that had to be kept in step by hand. It is now a single one, so those instructions were telling the assistant to do work that no longer exists — hunting for which of three places a change belonged to, and prefixing its commands with the right one.

This rewrites that guidance so it matches how the project is actually laid out today. The rules that were never really about having three codebases — work on a separate copy, keep the shared history tidy, review your own work before asking for a review — are untouched.

One genuine ordering rule is deliberately kept: a change to how data is stored still has to go live before the code that reads it, and sharing a codebase removes the paperwork, not that dependency.

## Changes

- `parallel-workflow` — "all three repos" section rewritten for one repo; drops the substitute-the-repo-name rule
- `wait-for-pr-merge` — removes the repo-probing step; poll script now keyed on PR number alone
- `ci-loop`, `cleanup` — commands target one repo directly; cleanup loses its repo-to-path mapping
- `micro-prs`, `writing-task-specs`, `dependency-analysis` — point at `apps/backend` / `apps/hasura`
- `self-review` — two stale sibling-repo mentions in its security section

## Test plan

Documentation only — no runtime code. Verified by:

- [x] No stale references remain (`sworld-backend`, `sworld-hasura-v2`, "three repos", "cross-repo") in the workflow skills
- [x] `apps/backend` and `apps/hasura` confirmed against the actual tree
- [x] Both shell snippets executed under sh, bash and zsh against a throwaway repo — fixed one real bug where zsh silently swallowed the PR number from the poll error line
- [x] No claims made about backend Docker builds or deploy workflows, which are still unfinished (SWO-545 / SWO-546)

Cross-references between skills left intact; no skill absorbed another one's content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)