### PR TITLE
[WIP] docs(skills): update security and supply-chain skills for the single lockfile

### DIFF
--- a/.claude/skills/security-reviewer/SKILL.md
+++ b/.claude/skills/security-reviewer/SKILL.md
@@ -51,9 +51,10 @@ root `pnpm-lock.yaml`. A review can read every layer without leaving the checkou
 
 ```
 Browser SPA ──Auth0 JWT (Bearer)──▶ Hasura ──admin secret (bypasses RLS)──▶ Postgres
-  (apps/<app>)                   (apps/hasura)   │
-                                                 └──x-webhook-signature──▶ Hono
-External webhooks ──signature header─────────────────────────────────────▶ (apps/backend)
+ (apps/<app>)                    (apps/hasura)
+                                      │
+                                      └──x-webhook-signature──▶ Hono
+External webhooks ──signature header────────────────────────▶ (apps/backend)
 ```
 
 | # | Boundary | Mechanism | The core question |
@@ -127,7 +128,7 @@ specific traps. Don't just pattern-match — understand the boundary.
 
 ### Hono backend → `references/hono-backend.md`
 - [ ] Every route that a shared secret is meant to gate verifies it **constant-time** (`crypto.timingSafeEqual`) — not `===`/`!==`. The Hashnode webhook validator is the in-repo reference pattern; the Hasura one is not.
-- [ ] Each router is mounted behind the gate it needs. Action routers deliberately skip the webhook signature — establish what *does* authenticate them before concluding either way.
+- [ ] Each router is mounted behind the gate it needs. Only two routers in the backend carry a signature check at all — for every other one, establish what *does* authenticate it before concluding either way.
 - [ ] User identity is read from Hasura-set `session_variables`, never from a client-controllable header.
 - [ ] Admin-secret calls to Hasura are preceded by an explicit authorisation/ownership check.
 - [ ] Inputs are validated (Zod) before use; no raw SQL, dynamic query strings, or shelling out.
@@ -141,7 +142,7 @@ specific traps. Don't just pattern-match — understand the boundary.
 - [ ] Tokens/PII aren't hand-written to `localStorage`/logs outside the Auth0 SDK's managed cache.
 
 ### Infra / backend host → `references/infra-cloud-run.md`
-- [ ] Hono being internet-reachable is **by design** (Hasura Cloud is off-host, can't present the host's identity) — so the real check is that the `X-Hasura-Signature` gate is robust (boundary 2), not "why no IAM". Tightening ingress is hardening, not a vuln.
+- [ ] Hono being internet-reachable is **by design** (Hasura Cloud is off-host, can't present the host's identity) — so the real check is that the signature gate is robust (boundary 2), not "why no IAM". Tightening ingress is hardening, not a vuln.
 - [ ] **No committed secrets** — the one genuinely high-severity infra check. Scan `.env*` (real values), service-account JSON, private keys, connection strings. Only `.example` templates in git.
 - [ ] CI auth uses short-lived/federated credentials rather than long-lived static deploy keys: a real hardening item — severity tracks the key's blast radius (prod deploy). Not launch-blocking; not over-engineering.
 - [ ] Container non-root (`USER`): good practice; marginal in a sandboxed runtime — Low hardening.

--- a/.claude/skills/security-reviewer/SKILL.md
+++ b/.claude/skills/security-reviewer/SKILL.md
@@ -2,8 +2,9 @@
 name: security-reviewer
 description: >-
   Stack-aware security & vulnerability reviewer for this codebase — tuned to our actual
-  stack: Auth0 (authentication), Hasura (authorisation), Hono backend (separate sworld-backend repo),
-  Vite/React SPA (frontend), and Postgres. Use whenever asked to review security, audit for
+  stack: Auth0 (authentication), Hasura (authorisation, in-repo at `apps/hasura`), the Hono backend
+  (in-repo at `apps/backend`), Vite/React SPA (frontend), and Postgres — all one monorepo, so a
+  review can read every layer. Use whenever asked to review security, audit for
   vulnerabilities, check for security weaknesses or misconfigurations, threat-model a change, or
   assess the security posture of the app — and reach for it proactively when touching anything on a
   trust boundary: authentication, Auth0/JWT claims, Hasura permissions or metadata, role
@@ -44,17 +45,21 @@ honest about whether it reaches anywhere at all.
 
 ## The stack and its five trust boundaries
 
+Everything below lives in **one repo** — the frontends, the Hono backend (`apps/backend`) and the
+Hasura metadata/migrations (`apps/hasura`) are all workspace packages of the same monorepo, on one
+root `pnpm-lock.yaml`. A review can read every layer without leaving the checkout.
+
 ```
 Browser SPA ──Auth0 JWT (Bearer)──▶ Hasura ──admin secret (bypasses RLS)──▶ Postgres
-  (apps/<app>)                  (sworld-hasura-v2)     │
-                                                        └──X-Hasura-Signature──▶ Hono
-External webhooks ──auth header──────────────────────────────────────────────▶ (sworld-backend)
+  (apps/<app>)                   (apps/hasura)   │
+                                                 └──x-webhook-signature──▶ Hono
+External webhooks ──signature header─────────────────────────────────────▶ (apps/backend)
 ```
 
 | # | Boundary | Mechanism | The core question |
 |---|----------|-----------|-------------------|
 | 1 | Browser ↔ Hasura | Auth0 JWT, validated by Hasura via JWKS; `x-hasura-role` / `x-hasura-user-id` come from JWT claims | Is every row scoped to the caller's identity, and does role come only from the verified token? |
-| 2 | Hasura ↔ Hono | Shared secret in `X-Hasura-Signature` header | Does every Hono route verify it, **constant-time**, before doing anything? |
+| 2 | Hasura ↔ Hono | Shared secret in the `x-webhook-signature` header | Does every Hono route that needs it verify it, **constant-time**, before doing anything? |
 | 3 | Hono ↔ Hasura | `x-hasura-admin-secret` — **bypasses all row-level permissions** | Does Hono authorise the caller *before* using admin access to read/mutate? |
 | 4 | SPA bundle | Vite build — everything shipped is public | Is anything secret sitting behind a `VITE_` prefix or in client code? |
 | 5 | Backend host ingress / IAM | Host networking + IAM (Hono is internet-reachable **by design** — Hasura Cloud is off-host) | The gate is the signature (boundary 2), not IAM — so: is it robust, and are any secrets committed? |
@@ -64,9 +69,14 @@ client-supplied header as if it were a Hasura-set session variable).
 
 ## Scope: review live code only
 
-Review the live stack: the frontend apps under `apps/<app>`, the shared `packages/core` /
-`packages/ui`, the Hono backend (separate `sworld-backend` repo), and the Hasura metadata (separate
-`sworld-hasura-v2` repo).
+Review the live stack, all of it inside this repo: the frontend apps under `apps/<app>`, the shared
+`packages/core` / `packages/ui`, the Hono backend under `apps/backend`, and the Hasura metadata and
+migrations under `apps/hasura`. The old `sworld-backend` / `sworld-hasura-v2` repos are the
+pre-consolidation copies — never review or cite them; they are not what deploys.
+
+Dependencies are **out of scope here**: one root `pnpm-lock.yaml` covers every app and package,
+including the backend, and the `supply-chain-security` skill owns that whole layer (pinning,
+lockfile hygiene, cooldown, lifecycle scripts). Point at it rather than re-deriving it.
 
 **Ignore — and never report findings against — dead or unmaintained code.** If a path predates the
 current architecture, isn't maintained, and isn't deployed, its patterns are *not* how the live
@@ -116,7 +126,8 @@ specific traps. Don't just pattern-match — understand the boundary.
 - [ ] Action permissions don't hand a role more than it should reach; Hono re-authorises action inputs.
 
 ### Hono backend → `references/hono-backend.md`
-- [ ] Every Action/Event route verifies `X-Hasura-Signature` **constant-time** (`crypto.timingSafeEqual`), like `verifyBasicAuth.ts` does — not `===`/`!==`.
+- [ ] Every route that a shared secret is meant to gate verifies it **constant-time** (`crypto.timingSafeEqual`) — not `===`/`!==`. The Hashnode webhook validator is the in-repo reference pattern; the Hasura one is not.
+- [ ] Each router is mounted behind the gate it needs. Action routers deliberately skip the webhook signature — establish what *does* authenticate them before concluding either way.
 - [ ] User identity is read from Hasura-set `session_variables`, never from a client-controllable header.
 - [ ] Admin-secret calls to Hasura are preceded by an explicit authorisation/ownership check.
 - [ ] Inputs are validated (Zod) before use; no raw SQL, dynamic query strings, or shelling out.
@@ -148,6 +159,7 @@ and the false-positives list before writing it up.
 - `dangerouslySetInnerHTML`, `.innerHTML =`, `eval(`, `new Function(` with non-constant input.
 - `x-hasura-admin-secret` used in a Hono handler with no preceding ownership/authorisation check (boundary 3).
 - A route reading `x-hasura-role` / `x-hasura-user-id` from request **headers** rather than the Hasura-provided `session_variables` body (boundary 1↔2 confusion → privilege escalation).
+- A router mounted with no signature middleware that still trusts `session_variables` from the body — the body is only Hasura-attested if *something* proved the request came from Hasura (boundary 2).
 - Hasura metadata hardening (judge against **production**, not local): introspection on, empty `api_limits.yaml`, `HASURA_GRAPHQL_DEV_MODE: "true"`.
 
 ## Known false positives in this stack
@@ -159,9 +171,9 @@ this list is the distilled memory of corrections from engineers who know the sta
   pattern — gated by its filtered parent. *Real* only if root fields are exposed, or an inbound
   relationship comes from an unfiltered parent. See `references/hasura-authorization.md`.
 - **Hono / a webhook being publicly invokable on the backend host.** By design — Hasura Cloud is
-  off-host and can't present the host's identity, so the `X-Hasura-Signature` / auth header is the
+  off-host and can't present the host's identity, so the signature / auth header is the
   intended gate. Review the gate's robustness, not the public reachability.
-- **Local `docker-compose.yml` settings** (`postgrespassword`, `DEV_MODE: "true"`, permissive CORS).
+- **Local `apps/hasura/docker-compose.yaml` settings** (`postgrespassword`, `DEV_MODE: "true"`, permissive CORS).
   That's the dev stack. Only a finding if the same holds in production Hasura Cloud / the backend host.
 - **Dead code.** Unmaintained, undeployed paths are not how the live system behaves. Anything read
   from them (e.g. code hard-coding a role) does not reflect production.

--- a/.claude/skills/security-reviewer/references/hasura-authorization.md
+++ b/.claude/skills/security-reviewer/references/hasura-authorization.md
@@ -112,7 +112,7 @@ there's **another** way in. So for each such table, confirm:
 - [ ] **Sensitive columns** (e.g. `hasura_role`, internal flags) are column-restricted for `user`.
 - [ ] **`manager` scope** is its actual job, not a global backdoor. As of writing `manager` has no
       explicit table permissions (see "Roles" above) — this item is forward-looking: the moment a
-      table grants `manager` anything, re-verify with `grep -rl "role: manager" metadata/` and check
+      table grants `manager` anything, re-verify with `grep -rl "role: manager" apps/hasura/metadata/` and check
       its filter isn't `{}` on `users`/financial tables.
 - [ ] **Production hardening** (judge against the deployed/production Hasura, *not*
       `apps/hasura/docker-compose.yaml`):

--- a/.claude/skills/security-reviewer/references/hasura-authorization.md
+++ b/.claude/skills/security-reviewer/references/hasura-authorization.md
@@ -8,16 +8,18 @@ produce a CRITICAL that wasn't (see "The `filter: {}` false positive" below).
 
 ## How it's wired (live)
 
-- Metadata (sibling repo `sworld-hasura-v2`) under `metadata/databases/sworld/tables/` — one YAML
-  per table, each with per-role permissions for `select`/`insert`/`update`/`delete`.
+- Metadata lives **in this repo** at `apps/hasura/metadata/databases/sworld/tables/` — one YAML per
+  table, each with per-role permissions for `select`/`insert`/`update`/`delete`. Migrations sit
+  alongside under `apps/hasura/migrations/`. (The old `sworld-hasura-v2` repo is the
+  pre-consolidation copy — don't read permissions from it.)
 - **Roles:** `anonymous` (unauthenticated — several content tables intentionally expose read-only
   `select` access, e.g. `public_audios.yaml`, `public_videos.yaml`; `anonymous` must never appear
   in an `insert`/`update`/`delete` permission block — flag that as a real finding, not hardening),
   `user` (every authenticated user), and `vip` (elevated non-admin, currently permissioned on a
   couple of tables, e.g. `public_crawl_requests.yaml`). Role comes from the validated JWT
   (`auth0-and-jwt.md`). `manager` is referenced as a role concept at the JWT/allowed-roles layer
-  but currently has no explicit permissions on any table in this repo's metadata — verify with a
-  fresh `grep -rl "role: manager" metadata/` before treating a `manager`-specific finding as live
+  but currently has no explicit permissions on any table in the metadata — verify with a
+  fresh `grep -rl "role: manager" apps/hasura/metadata/` before treating a `manager`-specific finding as live
   (see also the `manager` checklist item below, which describes what to check once it does gain
   permissions).
 - Writes to most domain tables go through the **backend with the admin secret**, not direct
@@ -112,8 +114,8 @@ there's **another** way in. So for each such table, confirm:
       explicit table permissions (see "Roles" above) — this item is forward-looking: the moment a
       table grants `manager` anything, re-verify with `grep -rl "role: manager" metadata/` and check
       its filter isn't `{}` on `users`/financial tables.
-- [ ] **Production hardening** (judge against the deployed/production Hasura, *not* the local
-      `docker-compose.yml`):
+- [ ] **Production hardening** (judge against the deployed/production Hasura, *not*
+      `apps/hasura/docker-compose.yaml`):
   - **Introspection** (`graphql_schema_introspection.yaml`): leaving it on lets an *authenticated*
     user enumerate the schema. The data is still behind permissions, so this is **information
     disclosure / hardening, not a data breach** — it speeds up an attacker mapping the API, and only
@@ -124,10 +126,18 @@ there's **another** way in. So for each such table, confirm:
   - **`HASURA_GRAPHQL_DEV_MODE`** must be `false` in prod (leaks error internals). `"true"` in the
     local compose file is fine — only a finding if prod has it on.
   - Console off in prod; admin secret strong and never shipped to the SPA.
-- [ ] **Actions** (`actions.yaml`): each is permissioned to the right role and forwards
-      `X-Hasura-Signature`. Hasura does **not** apply row permissions to action *arguments* — the
-      backend must authorise (see `hono-backend.md`). An action exposed to `user` that accepts
-      arbitrary IDs is only as safe as the backend's own ownership check.
+- [ ] **Actions** (`apps/hasura/metadata/actions.yaml`): each is permissioned to the right role.
+      Hasura does **not** apply row permissions to action *arguments* — the backend must authorise
+      (see `hono-backend.md`). An action exposed to `user` that accepts arbitrary IDs is only as safe
+      as the backend's own ownership check.
+- [ ] **Action headers.** Actions set `X-Hasura-Action` and `Content-Type`, and no shared-secret
+      header — so nothing in the Action path proves to the backend that the call came from Hasura.
+      Pair this with the "what authenticates the Action routers?" check in `hono-backend.md`; the two
+      halves only make sense read together.
+- [ ] **`forward_client_headers: true`** is set on every Action. That relays the *caller's* headers
+      to the backend, so any header the browser can set arrives at the handler. Harmless while the
+      backend reads identity only from `session_variables` — a privilege-escalation path the moment a
+      handler trusts an inbound header. Check both ends before judging.
 
 ## Business invariant: `public` is owner-only, on every content table
 
@@ -144,8 +154,11 @@ never shows up as a frontend type change — the only place it's visible is the 
 `x-hasura-admin-secret` + `x-hasura-role: user` (or `vip`) attempting to set `public` on
 insert/update — expect a Hasura validation error (`field 'public' not found in type:
 ..._insert_input` / `..._set_input`). That response *is* the guard; don't add a live-Hasura
-regression test for this static metadata fact (`sworld-hasura-v2` CI only runs lint, not the
-vitest role-suite — a live test here is a rabbit hole, not a safety net).
+regression test for this static metadata fact — the data layer's PR check (`hasura-pr.yml`) runs
+eslint only, over the TypeScript tests and configs, and never reads `metadata/` or `migrations/`. So
+nothing in CI validates permission YAML, and the role-suite needs a live Hasura endpoint it doesn't
+have. A live test here is a rabbit hole, not a safety net; the flip side is that **a permission
+regression will not be caught by CI** — metadata changes need a human read.
 
 ## Severity calibration for this layer
 

--- a/.claude/skills/security-reviewer/references/hono-backend.md
+++ b/.claude/skills/security-reviewer/references/hono-backend.md
@@ -1,92 +1,121 @@
 # Hono backend — boundaries 2 & 3 (business-logic trust)
 
-The Hono backend (sibling repo `sworld-backend`) exists for one reason: to handle Hasura
-Actions/Events and a few external webhooks. It holds two trust boundaries — it must verify that a
-request *really* came from Hasura (boundary 2), and it wields the admin secret that bypasses all row
-permissions, so it must authorise callers *itself* before using it (boundary 3).
+The Hono backend lives **in this repo** at `apps/backend`, as a workspace package like any app. It
+exists to handle Hasura Events and Actions plus a few external webhooks. It holds two trust
+boundaries — it must verify that a request *really* came from Hasura (boundary 2), and it wields the
+admin secret that bypasses all row permissions, so it must authorise callers *itself* before using
+it (boundary 3).
+
+Because it is in-repo, you can read the backend, the Hasura metadata (`apps/hasura`) and the
+frontends in one checkout — trace an Action from its metadata definition straight into the handler
+that serves it, rather than assuming across a repo boundary. Its dependencies come from the single
+root `pnpm-lock.yaml`, and it consumes `packages/core` as `core: workspace:*` — not from npm.
 
 ## How it's wired (live)
 
-- Entry: `sworld-backend`'s `src/server.ts` mounts per-feature routers (e.g. `projects`, `share`,
-  `uploads`, `users`, `notifications`, `email`, `webhooks`). `/health` is public.
-- **Boundary 2 — `hasuraAuth` middleware** (`src/middleware/hasuraAuth.ts`): compares the inbound
-  `X-Hasura-Signature` header to `HASURA_BACKEND_SIGNATURE`. Applied to all Action/Event routes.
-  `cronAuth` does the same for `X-Cron-Secret`.
-- **User identity** (`src/middleware/hasuraSession.ts`): reads `x-hasura-user-id` from the request
-  body's `session_variables` (which Hasura populates from the verified JWT) and validates it is a
-  positive integer.
-- **Boundary 3 — admin client** (`src/hasura/client.ts`): sends `x-hasura-admin-secret` on every
-  call. All persistence goes through typed `graphql()` codegen — variables are parameters, not
-  string-interpolated.
-- **Input validation:** Zod `.safeParse()` at each router (e.g. `projects/createProject/router.ts`,
-  `share/inviteShare/schema.ts`).
-- **Secrets & logging:** `src/envConfig.ts` fail-fast validates required env at boot.
-  `src/lib/logger.ts` (pino) redacts `password`/`secret`/`token`/`authorization`/
-  `x-hasura-admin-secret`. `src/lib/errors/appError.ts` returns only a safe message +
-  code to the client; system messages and stack traces stay server-side.
+- **Three services, not one server.** `src/gateway.ts`, `src/io.ts` and `src/compute.ts` each build
+  their own Hono app and mount per-feature routers from `src/apps/{gateway,io,compute}/…`. `/hz` is
+  the public health route on each. (The service split and Cloud Task pipeline are the
+  `backend-architecture` skill's subject — this file covers only the trust boundaries.)
+- **Boundary 2 — webhook signature.** `src/utils/validators/validateHasuraSignature/` reads the
+  `x-webhook-signature` header and compares it to `envConfig.webhookSignature`. It is applied per
+  router, e.g. `videosRouter.use('*', validateHasuraSignature())` in
+  `src/apps/gateway/videos/index.ts`. The external Hashnode webhook has its own, stronger validator
+  (below).
+- **Action routers are *not* behind that signature.** `src/apps/gateway/videos-actions` and
+  `src/apps/gateway/storage` mount only Zod validation, and take the caller's identity from the
+  request body's `session_variables['x-hasura-user-id']`. The routers document this as deliberate —
+  Actions are "authenticated by the caller's session" rather than by the webhook secret. Read that
+  claim critically (see Traps).
+- **Boundary 3 — admin client.** `src/services/hasura/client.ts` sends `x-hasura-admin-secret`
+  (`envConfig.hasuraAdminSecret`) on every call. Persistence goes through typed `graphql()` codegen —
+  variables are parameters, never string-interpolated.
+- **Input validation:** Zod schemas under `src/schema/**`, applied by `honoValidateRequest`
+  (`src/utils/validators/request.ts`) and `validateHeaders`.
+- **Secrets & logging:** `src/utils/envConfig.ts` is a plain read of `process.env` — it does **not**
+  fail-fast on missing values, so an unset secret surfaces as a runtime `undefined`, not a boot
+  error. `src/utils/logger/` (pino) sets a `redact` list. `AppError` (`src/utils/schema.ts`) shapes
+  the client-facing error payload.
+- **Ambient middleware:** body limit, request id, Sentry, and `hono-rate-limiter` — the limiter is
+  keyed on the `x-webhook-signature` header, not on client IP.
 
 ## What good looks like
 
 - **Constant-time secret comparison.** Compare shared secrets with `crypto.timingSafeEqual`, not
-  `===`/`!==`. The webhook Basic-auth verifier (`src/webhooks/.../verifyBasicAuth.ts`) does this
-  correctly — it's the reference pattern. Any secret/signature check that uses `!==` is a
-  timing-oracle lead (the `hasuraAuth`/`cronAuth` middleware are the places to check).
-- **Authorise before admin access.** Because the admin secret bypasses row permissions, every
-  handler must prove the `session_variables` user is allowed to touch the target *before* the admin
-  client reads/mutates it. Hasura does **not** apply row filters to action inputs — a `user`-scoped
-  action receiving an arbitrary `projectId` is only safe if Hono checks ownership. This is the most
-  important Hono check: find the ownership assertion for each mutating handler.
-- **Identity only from `session_variables`.** Never read role/user-id from a client-settable header.
-  The body's `session_variables` are Hasura-attested; an inbound header is attacker-controlled.
+  `===`/`!==`. The in-repo reference pattern is
+  `src/utils/validators/validateHashnodeSignature/validator.ts`: HMAC-SHA256 over
+  `timestamp.payload`, compared with `timingSafeEqual`, plus a freshness window on the timestamp so a
+  captured signature can't be replayed later. Measure the Hasura validator against it.
+- **Authorise before admin access.** Because the admin secret bypasses row permissions, every handler
+  must prove the `session_variables` user is allowed to touch the target *before* the admin client
+  reads or mutates it. Hasura does **not** apply row filters to action inputs — a `user`-scoped action
+  receiving an arbitrary id is only safe if the backend checks ownership. This is the most important
+  backend check: find the ownership assertion for each mutating handler.
+- **Identity only from attested `session_variables`.** Never read role/user-id from a client-settable
+  header — and remember `session_variables` are only attested if something proved the request came
+  from Hasura.
 
 ## Checks
 
-- [ ] Every Action/Event/webhook route is behind signature/secret verification — none mounted raw.
-      `/health` is the only intended public route; confirm it leaks nothing useful.
-- [ ] Signature/secret comparisons are constant-time (`timingSafeEqual`), matching `verifyBasicAuth.ts`.
+- [ ] Every Event/webhook route is behind signature verification — none mounted raw. `/hz` is the
+      only intended public route; confirm it leaks nothing useful.
+- [ ] Signature comparisons are constant-time (`timingSafeEqual`), matching the Hashnode validator.
+      The Hasura signature validator uses `===` as of writing — re-read it before writing anything up,
+      then report it as the timing-oracle lead it is (Low on its own: guessing a whole secret through
+      a network timing side-channel is slow and noisy).
+- [ ] For each router mounted **without** the signature middleware, name what actually authenticates
+      it. If the answer is only "the body carries `session_variables`", that body is attacker-supplied
+      and every ownership check downstream is checking an id the caller chose.
 - [ ] Each admin-secret mutation/read is preceded by an explicit ownership/authorisation check on the
-      `session_variables` user. List the handlers; flag any that act on a client-supplied ID without one.
-- [ ] User identity is taken from `session_variables`, never request headers.
-- [ ] All action inputs are Zod-validated before use; no raw SQL, query-string building, `exec`/`spawn`/`eval`.
-- [ ] Errors return only `AppError`'s safe message; no stack/system message reaches the client.
-- [ ] `AppError` metadata never carries a secret (e.g. `{ cause: err.toString() }` where `err` holds
-      a token). Redaction covers logs, but the response `extensions` are constructed by hand — audit them.
-- [ ] CORS: none today (server-to-server). If added, it must be an explicit origin allow-list, never
-      `*` with credentials.
-- [ ] *Hardening — error detail persisted to the DB.* If a handler writes `error.stack` to a table
-      (e.g. an `email_outbox` failure column), it leaks internal paths/framework versions to anyone who
-      can later read that row. Store `error.message`, not the stack. **Low** — info-disclosure to an
-      already-permissioned reader, not an external exploit.
-- [ ] *Consistency — Zod on every boundary.* Every router should `safeParse` its input. A handler that
-      type-casts instead (a payment/webhook route may be the known exception) breaks the
-      validate-at-the-boundary pattern; worth closing for consistency even where validation happens
-      downstream. **Low**, but real — uniform input validation is cheap defence.
+      `session_variables` user. List the handlers; flag any that act on a client-supplied id without one.
+- [ ] All action inputs are Zod-validated before use; no raw SQL, query-string building,
+      `exec`/`spawn`/`eval`.
+- [ ] Errors return only `AppError`'s safe message; no stack or system message reaches the client, and
+      `AppError` metadata never carries a secret — the response payload is built by hand, so audit it
+      separately from the logger's `redact` list.
+- [ ] Missing or blank secrets fail **closed**. `envConfig` doesn't validate, so an unset
+      `WEBHOOK_SIGNATURE` yields `undefined`; confirm the validator rejects the request rather than
+      comparing two empty values. A misconfigured deploy must not open the gate.
+- [ ] Rate limiting keyed on the signature header rather than the caller: everyone without the header
+      shares one bucket, and anyone varying it gets a fresh one. Abuse-resistance **hardening**, not a
+      confidentiality bug.
+- [ ] CORS: none configured today (server-to-server). If added, it must be an explicit origin
+      allow-list, never `*` with credentials.
+- [ ] *Hardening — error detail persisted to the DB.* If a handler writes `error.stack` to a table it
+      leaks internal paths and framework versions to anyone who can later read that row. Store
+      `error.message`. **Low** — info-disclosure to an already-permissioned reader.
 
 ## Traps specific to us
 
-- **The `verifyBasicAuth` inconsistency.** One secret check uses `timingSafeEqual`; the signature/
-  cron checks use `!==`. That inconsistency is the tell — when one place in a codebase does it right
-  and another doesn't, the odd one out is the finding.
-- **Session-variable trust is only as good as Hasura.** Hono trusts `session_variables` implicitly.
-  That's correct *if* Hasura always sets them from the JWT and never lets a client inject them. The
-  assumption lives at boundary 1/2 — state it, and confirm no action is configured to pass through
-  client-supplied session variables.
+- **The validator inconsistency.** One signature check uses `timingSafeEqual` with a replay window;
+  the other uses `===`. When one place in a codebase does it right and another doesn't, the odd one
+  out is the finding — and the strong one is the fix template, so the remediation is cheap.
+- **"Actions are authenticated by the session" is an assumption, not a mechanism.** A code comment
+  saying a router is session-authenticated does not make it so. Trace the request end to end: does
+  anything between the internet and the handler verify it came from Hasura? If not, a stranger can
+  POST the same JSON with any `x-hasura-user-id` they like. Verify before asserting in either
+  direction — the gate may sit in front of the service (ingress rules, an unpublished URL) rather than
+  in code, and "I can't see one" is **needs-verification**, not "confirmed".
+- **Session-variable trust is only as good as Hasura.** Where the signature *is* enforced, the backend
+  trusts `session_variables` implicitly. That's correct *if* Hasura always sets them from the JWT and
+  never lets a client inject them — state the assumption, and confirm no Action is configured to pass
+  through client-supplied session variables.
 - **Admin secret = keys to the kingdom.** It bypasses every Hasura row permission. A handler that
-  mutates based purely on its input, with no ownership check, turns a `user`-role action into
-  arbitrary cross-tenant writes. Trace authorisation, not just validation — Zod proves the input is
+  mutates purely on its input, with no ownership check, turns a `user`-role action into arbitrary
+  cross-tenant writes. Trace authorisation, not just validation — Zod proves the input is
   *well-formed*, not that the caller is *allowed*.
 
 ## Why the signature gate is load-bearing
 
-The backend is internet-reachable **by design**: Hasura runs on a different host and can't present
-the backend host's identity, so host/network IAM can't be the gate (see
-`references/infra-cloud-run.md`). That's not a hole to flag — it means boundary 2's
-`X-Hasura-Signature` check is the *primary* authentication standing between the public internet and
-the admin-secret client. So weight it accordingly: constant-time comparison, present on every
-Action/Event route, and a secret with real entropy that's rotated. These checks earn their
-importance precisely *because* the network in front of them is open on purpose.
+The backend is internet-reachable **by design**: Hasura Cloud runs elsewhere and can't present the
+backend host's identity, so host/network IAM can't be the gate (see `references/infra-cloud-run.md`).
+That's not a hole to flag — it means boundary 2's signature check is the *primary* authentication
+standing between the public internet and the admin-secret client. Weight it accordingly: constant-time
+comparison, present on every route that needs it, and a secret with real entropy that is rotated.
 
 ## Can't be verified from the repo
 
-The actual `HASURA_BACKEND_SIGNATURE`/`CRON_SECRET` values, their entropy, and rotation cadence live
-in the host/Hasura consoles. Flag those as needs-verification rather than asserting on them.
+The actual `WEBHOOK_SIGNATURE` / `HASURA_ADMIN_SECRET` / `HASHNODE_WEBHOOK_SECRET` values, their
+entropy and rotation cadence, live in the deploy consoles. The backend's container build and deploy
+pipeline are **mid-rework**, so don't infer deploy-time or ingress behaviour from what is currently in
+the repo. Flag all of these as needs-verification rather than asserting on them.

--- a/.claude/skills/security-reviewer/references/hono-backend.md
+++ b/.claude/skills/security-reviewer/references/hono-backend.md
@@ -22,11 +22,15 @@ root `pnpm-lock.yaml`, and it consumes `packages/core` as `core: workspace:*` �
   router, e.g. `videosRouter.use('*', validateHasuraSignature())` in
   `src/apps/gateway/videos/index.ts`. The external Hashnode webhook has its own, stronger validator
   (below).
-- **Action routers are *not* behind that signature.** `src/apps/gateway/videos-actions` and
-  `src/apps/gateway/storage` mount only Zod validation, and take the caller's identity from the
-  request body's `session_variables['x-hasura-user-id']`. The routers document this as deliberate —
+- **Most routers are *not* behind that signature.** Repo-wide, `validateHasuraSignature` is mounted
+  in exactly one place (`apps/gateway/videos`), and `apps/gateway/hashnode` has its own validator —
+  those two are the only gated routers in the whole backend. Everything else mounts only Zod:
+  `apps/gateway/{auth,storage,videos-actions}`, and **every** router on the io and compute services.
+  The Action routers take the caller's identity from the request body's
+  `session_variables['x-hasura-user-id']`; `videos-actions/index.ts` documents this as deliberate —
   Actions are "authenticated by the caller's session" rather than by the webhook secret. Read that
-  claim critically (see Traps).
+  claim critically (see Traps), and don't assume the io/compute services are private just because
+  they sit behind Cloud Tasks — establish what enforces that.
 - **Boundary 3 — admin client.** `src/services/hasura/client.ts` sends `x-hasura-admin-secret`
   (`envConfig.hasuraAdminSecret`) on every call. Persistence goes through typed `graphql()` codegen —
   variables are parameters, never string-interpolated.

--- a/.claude/skills/security-reviewer/references/infra-cloud-run.md
+++ b/.claude/skills/security-reviewer/references/infra-cloud-run.md
@@ -7,17 +7,23 @@ can't see; say what to confirm in the console.
 
 ## How it's wired (live, from the repo)
 
-- **Topology:** Frontend (CDN/edge host; some apps deploy to Vercel) → Hasura (sibling repo
-  `sworld-hasura-v2`) → Hono backend (sibling repo `sworld-backend`, its own deploy) → back to
-  Hasura via admin secret. Postgres sits behind Hasura; the backend never talks to it directly.
-- **Deploy:** the backend has its own CI deploy pipeline that builds its `Dockerfile`, pushes the
-  image, and ships it to the backend host. Frontend apps deploy separately (e.g. Vercel / an edge
-  host).
-- **Secrets:** backend / Hasura runtime env (set in their consoles) + CI secrets (federated CI
-  credentials and/or any deploy tokens). The backend's `envConfig.ts` fail-fast validates at boot.
-  Only `.example` templates committed.
-- **Container:** `node:22-slim`, multi-stage, `pnpm install --frozen-lockfile`, `dist/` only in the
-  runtime image.
+- **Topology:** Frontends (Cloudflare Pages, one project per app) → Hasura Cloud → the Hono backend
+  → back to Hasura via the admin secret. Postgres sits behind Hasura; the backend never talks to it
+  directly. All three layers are **one repo** now — frontends under `apps/<app>`, the backend under
+  `apps/backend`, Hasura metadata and migrations under `apps/hasura` — but they still deploy to
+  three separate places, so "same repo" does **not** mean "same trust zone".
+- **Deploy:** Cloudflare Pages builds and deploys each frontend from its own pipeline on merge to
+  main; Hasura Cloud applies metadata from its GitHub integration. **The backend's container build
+  and deploy pipeline is mid-rework** — the old per-repo deploy workflows are gone and the
+  replacement isn't in place yet. Don't describe backend deploy mechanics as though they exist, and
+  don't infer them from leftover files.
+- **Secrets:** backend / Hasura runtime env (set in their consoles) + CI secrets. Only `.example`
+  templates are committed. Note the backend's `envConfig.ts` does **not** validate at boot (see
+  `hono-backend.md`), so a missing secret shows up at request time, not startup.
+- **Container:** the `apps/backend/Dockerfile.*` files are **stale** — they still `COPY
+  package-lock.json` and `npm ci`, from before the repos merged onto a single root `pnpm-lock.yaml`,
+  so they can't build as written. Treat them as pending work, not as evidence of how the runtime
+  image is built; a finding about their contents is about a file nobody deploys.
 
 ## The invocation model — get this right
 
@@ -29,7 +35,7 @@ Here's the part a naive review gets wrong: **Hasura runs on a different host, so
 the backend host's identity token.** For Hasura to call the backend at all, the backend must accept
 unauthenticated (IAM-wise) requests — i.e. it is *intentionally* publicly invokable. That's not a
 misconfiguration; it's the consequence of the architecture. The real authentication happens at the
-**application layer**: the `X-Hasura-Signature` header (boundary 2, `hono-backend.md`).
+**application layer**: the `x-webhook-signature` header (boundary 2, `hono-backend.md`).
 
 So the review question is **not** "why is this publicly invokable?" — it's:
 
@@ -45,6 +51,12 @@ So the review question is **not** "why is this publicly invokable?" — it's:
       `.example`), `*.json` service-account keys, `BEGIN PRIVATE KEY`, connection strings with
       embedded passwords. Today only templates are committed. A committed secret is genuinely
       **Critical** — rotate immediately (don't just delete; git history retains it).
+- [ ] **One repo = one blast radius.** Frontends, backend and data layer now share a checkout, a CI
+      runner and a root `pnpm-lock.yaml`. A compromised dependency or a workflow with too-broad
+      permissions reaches all three at once, where it used to reach one. Check that workflow
+      `permissions:` blocks are least-privilege and that any deploy credential is scoped to its own
+      target. The dependency half of this belongs to the `supply-chain-security` skill — send it there
+      rather than re-deriving lockfile rules here.
 - [ ] **CI auth to the host — long-lived deploy key vs federated CI credentials.** A long-lived
       static key/JSON credential is a standing credential that can leak; **federated CI credentials**
       (OIDC, e.g. GitHub Actions → cloud provider) issue short-lived, run-scoped tokens with no key
@@ -55,15 +67,15 @@ So the review question is **not** "why is this publicly invokable?" — it's:
       rotation schedule.
 - [ ] **Non-root container.** No `USER` directive → runs as root. Worth fixing, but calibrate
       against the container runtime: if instances run in a sandbox, the marginal risk of in-container
-      root is lower than on shared/raw infra. **Low** hardening, not a scary finding.
+      root is lower than on shared/raw infra. **Low** hardening — and while the Dockerfiles are being
+      reworked, raise it as an input to that work rather than as a live finding.
 - [ ] **Secret hygiene & transport.** Secrets from the host's console / secret manager, not the repo;
-      rotation for `HASURA_BACKEND_SIGNATURE`/`HASURA_ADMIN_SECRET`/`CRON_SECRET`/vendor keys
+      rotation for `WEBHOOK_SIGNATURE`/`HASURA_ADMIN_SECRET`/`HASHNODE_WEBHOOK_SECRET`/vendor keys
       documented; all hops HTTPS (the host and Hasura terminate TLS).
-- [ ] **Public surfaces.** `/health` and any payment/webhook endpoint are intentionally public —
-      confirm `/health` leaks nothing useful and the webhook verifies its secret/Basic auth
-      constant-time.
-- [ ] **Local-only credentials aren't production.** A local `docker-compose.yml`'s `postgrespassword`
-      is the dev stack — never a production finding.
+- [ ] **Public surfaces.** `/hz` (health) and any external webhook endpoint are intentionally public —
+      confirm `/hz` leaks nothing useful and the webhook verifies its signature constant-time.
+- [ ] **Local-only credentials aren't production.** The `postgrespassword` in
+      `apps/hasura/docker-compose.yaml` is the dev stack — never a production finding.
 
 ## Traps specific to us
 

--- a/.claude/skills/security-reviewer/references/infra-cloud-run.md
+++ b/.claude/skills/security-reviewer/references/infra-cloud-run.md
@@ -7,7 +7,7 @@ can't see; say what to confirm in the console.
 
 ## How it's wired (live, from the repo)
 
-- **Topology:** Frontends (Cloudflare Pages, one project per app) → Hasura Cloud → the Hono backend
+- **Topology:** Frontends (Cloudflare Pages, each app its own project) → Hasura Cloud → the Hono backend
   → back to Hasura via the admin secret. Postgres sits behind Hasura; the backend never talks to it
   directly. All three layers are **one repo** now — frontends under `apps/<app>`, the backend under
   `apps/backend`, Hasura metadata and migrations under `apps/hasura` — but they still deploy to

--- a/.claude/skills/supply-chain-security/SKILL.md
+++ b/.claude/skills/supply-chain-security/SKILL.md
@@ -15,7 +15,29 @@ description: >-
 
 This skill captures a standing posture for npm-ecosystem projects so that a compromised package
 release becomes a non-event rather than a credential leak. It is pnpm-first (the primary tooling
-here), with npm/yarn equivalents in `references/package-manager-config.md`.
+here), with npm/yarn equivalents in `references/package-manager-config.md` for other projects.
+
+## In this repo
+
+**One lockfile, one package manager.** Everything — every frontend app, the Hono backend
+(`apps/backend`), the data layer (`apps/hasura`) and the shared packages — resolves through a single
+`pnpm-lock.yaml` at the repo root. pnpm is the only package manager: there is no
+`package-lock.json` and no `yarn.lock` anywhere, and the backend consumes `packages/core` as
+`core: workspace:*` rather than from the registry.
+
+Three consequences worth holding on to:
+
+- **A second lockfile is a bug, not a state to maintain.** If one appears under an app, it means a
+  bare `npm install`/`yarn` ran somewhere it shouldn't have. Delete it and re-resolve through pnpm at
+  the root — don't try to keep two in sync.
+- **`npm ci` in a script, Dockerfile or workflow is stale.** It cannot work without a
+  `package-lock.json`. Treat any such step as left over from before the repos merged.
+- **One lockfile means one blast radius.** A compromised transitive dependency now reaches the
+  frontends *and* the backend in the same install, so the vetting checklist below matters more than
+  it did when they were separate projects.
+
+The live settings (cooldown, exclusions, lifecycle scripts, pinned pnpm version) are recorded in
+`references/package-manager-config.md` — read them there rather than restating them.
 
 ## The threat model (why this matters)
 
@@ -146,7 +168,9 @@ Walk the standing-posture list above. Concretely:
 - Review the dependency list for anything not critically needed — every package removed is attack
   surface removed. Flag candidates for replacement with built-ins or removal.
 - Check `package.json` for `^`/`~` and offer to convert to exact pins.
-- Confirm a lockfile exists and is committed (`git ls-files | grep lock`).
+- Confirm a lockfile exists and is committed (`git ls-files | grep lock`). Here the right answer is
+  **exactly one**, `pnpm-lock.yaml` at the root — more than one means something re-resolved outside
+  pnpm.
 - Confirm `onlyBuiltDependencies` is present and minimal (in pnpm 11 this is `allowBuilds`).
 - Check pnpm version (`pnpm -v`) and whether a cooldown is configured.
 

--- a/.claude/skills/supply-chain-security/references/package-manager-config.md
+++ b/.claude/skills/supply-chain-security/references/package-manager-config.md
@@ -3,6 +3,33 @@
 Read this when configuring cooldowns, frozen installs, or script controls on a specific package
 manager, or when checking what a given pnpm version gives you by default.
 
+**This repo is pnpm-only** — one root `pnpm-lock.yaml` for every app and package. The npm and yarn
+sections below are reference material for *other* projects; nothing here uses them, and a
+`package-lock.json` or `yarn.lock` appearing in this repo is a mistake to remove, not a config to
+tune.
+
+## What this repo already has
+
+Verified against the checked-in config — check these files before changing anything, and update this
+list if they move:
+
+| Setting | Value | Where |
+|---|---|---|
+| Package manager | `pnpm@10.34.3`, `engines.pnpm >= 10.34.3` | root `package.json` |
+| Workspace members | `apps/*`, `packages/*` — the backend and data layer included | `pnpm-workspace.yaml` |
+| Cooldown | `minimumReleaseAge: 10080` (7 days) | `pnpm-workspace.yaml` |
+| Cooldown exclusions | the vite/rolldown build toolchain + `postcss`, each with a written reason | `pnpm-workspace.yaml` |
+| Lifecycle scripts | `onlyBuiltDependencies: []` — **nothing** may run install scripts | `pnpm-workspace.yaml` |
+| Security overrides | pinned-forward transitive versions | `pnpm.overrides` in root `package.json` |
+
+Two notes that bite in practice:
+
+- The 7-day cooldown blocks *any* local re-resolve while a recently-bumped package is still young.
+  Add a targeted `minimumReleaseAgeExclude` entry with a comment explaining why — never lower the
+  global window and never hand-edit the lockfile.
+- `onlyBuiltDependencies: []` is an empty allowlist, not a missing one. Adding a dependency that
+  demands a build script is a decision to make deliberately, with a reason recorded next to it.
+
 ## pnpm
 
 ### Frozen installs


### PR DESCRIPTION
## Summary

The backend and the data layer used to live in their own separate repositories. They now sit inside the main one, and everything installs from a single shared dependency list. Two of the guidance documents the team relies on when reviewing security still described the old arrangement — pointing at repositories that are no longer where the code lives, and at file locations that had moved.

This updates both so anyone (or any assistant) following them looks in the right place. Along the way it corrects a handful of details that turned out never to have matched this codebase at all: the name of the header used to prove a request came from the data layer, which files do the checking, and which parts of the backend are actually protected by it. Those corrections were verified file by file against the real code rather than assumed.

It also records the practical consequence of the merge: one shared dependency list means a single compromised package now reaches the website and the backend together, so the care taken when adding dependencies matters more than it did before.

Documentation only — no code, no dependency changes, nothing shipped to users.

## What changed

- `security-reviewer` — description, trust-boundary diagram, and scope now name `apps/backend` / `apps/hasura`; dependency review explicitly deferred to `supply-chain-security` rather than restated.
- `references/hono-backend.md` — rewritten "how it's wired" against the real code: three services (`gateway`/`io`/`compute`), `/hz` health route, `x-webhook-signature` (not `X-Hasura-Signature`), the `===` vs `timingSafeEqual` split between the Hasura and Hashnode validators, and the fact that only two routers in the whole backend carry a signature gate.
- `references/hasura-authorization.md` — metadata/migration paths, `manager` grep path, Action header facts (`forward_client_headers: true`, no signature header), and an honest note that CI lints only JS/TS and never validates permission YAML.
- `references/infra-cloud-run.md` — Cloudflare Pages topology, backend deploy/Docker flagged as mid-rework (SWO-545/546) rather than described, stale `npm ci` Dockerfiles called out as pending work, and a new "one repo = one blast radius" check.
- `supply-chain-security` + `references/package-manager-config.md` — new "In this repo" section (one root `pnpm-lock.yaml`, pnpm only, `core: workspace:*`), plus a table of the live settings verified against `pnpm-workspace.yaml` and root `package.json`.

## Test plan

Documentation change, so there is nothing to run. To check it, open either guide and confirm every path and file it names exists where it says, and that nothing points at the old separate repositories any more.

Refs SWO-554

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security review guidance to match the current monorepo structure and trust boundaries.
  * Clarified Hasura Action authorization, session-variable handling, webhook signature verification, and backend authentication expectations.
  * Expanded guidance for Cloud Run hosting, endpoint checks, secrets, and deployment assumptions.
  * Documented pnpm-only repository hygiene, the single root lockfile, dependency cooldowns, and lifecycle-script controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->