### PR TITLE
docs(skills): remove the direct-Postgres path from backend-ops

### DIFF
--- a/.claude/skills/backend-ops/SKILL.md
+++ b/.claude/skills/backend-ops/SKILL.md
@@ -30,7 +30,7 @@ Layout: `videos/<userId>/<videoId>/…` (HLS: `playlist.m3u8` + segments/`init.m
 
 ## Reaching production data
 
-Hasura is the route, in both directions — `hasura-architecture` owns that rule; follow it there rather than reasoning about it here.
+Ops tasks reach prod data through Hasura, same as everything else — `hasura-architecture` owns that rule; follow it there rather than reasoning about it here.
 
 - **Scripted reads/writes** — **Hasura admin** (endpoint + admin secret above) with GraphQL. Admin bypasses all row permissions, so use it for reads (dup checks) and writes (insert audios rows, link playlist_audios, etc.).
 - **Anything interactive** — the **Hasura Console**.

--- a/.claude/skills/backend-ops/SKILL.md
+++ b/.claude/skills/backend-ops/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: backend-ops
-description: How to perform sworld operational tasks from apps/backend in the sworld monorepo — GCS asset layout, operator CLIs, direct prod DB access, and the recurring "create audios" ingestion task. Auto-triggers when uploading media, ingesting mp3/video files, touching prod data directly, or working in apps/backend/src/cli.
+description: How to perform sworld operational tasks from apps/backend in the sworld monorepo — GCS asset layout, operator CLIs, prod data access, and the recurring "create audios" ingestion task. Auto-triggers when uploading media, ingesting mp3/video files, touching prod data, or working in apps/backend/src/cli.
 user-invocable: false
 ---
 
@@ -26,12 +26,14 @@ Layout: `videos/<userId>/<videoId>/…` (HLS: `playlist.m3u8` + segments/`init.m
 
 - **`~/.sworld-cli/config.json`**: `gcp-key` (path to the service-account JSON — read the value from the config, don't hardcode a path), `gcp-bucket` (`sworld-prod.appspot.com`), `hasura-endpoint` (`https://free-lamprey-59.hasura.app/v1/graphql`), `hasura-secret` (admin), `user-id` (the account ops run as — see above).
 - GCS auth: `new Storage({ keyFilename })` with that `gcp-key`. `gcloud` ADC is NOT set up — always use the key file.
-- **`apps/backend/.env`** also has: `GCP_STORAGE_BUCKET`, `HASURA_ADMIN_SECRET` + `HASURA_ENDPOINT`, `DATABASE_URL` (direct Postgres), Cloudinary, OpenAI, etc. It is gitignored, so a fresh clone or worktree has only `.env.example` — copy the real file in. `packages/core/.env` also has `HASURA_GRAPHQL_URL` + `HASURA_ADMIN_SECRET` for quick admin queries via curl.
+- **`apps/backend/.env`** also has: `GCP_STORAGE_BUCKET`, `HASURA_ADMIN_SECRET` + `HASURA_ENDPOINT`, Cloudinary, OpenAI, etc. It is gitignored, so a fresh clone or worktree has only `.env.example` — copy the real file in. `packages/core/.env` also has `HASURA_GRAPHQL_URL` + `HASURA_ADMIN_SECRET` for quick admin queries via curl.
 
-## Talking to the production DB directly
+## Reaching production data
 
-- Via **Hasura admin** (endpoint + admin secret above) with GraphQL — admin bypasses all row permissions. Use for reads (dup checks) and writes (insert audios rows, link playlist_audios, etc.).
-- Or Postgres directly via `DATABASE_URL`.
+Hasura is the route, in both directions — `hasura-architecture` owns that rule; follow it there rather than reasoning about it here.
+
+- **Scripted reads/writes** — **Hasura admin** (endpoint + admin secret above) with GraphQL. Admin bypasses all row permissions, so use it for reads (dup checks) and writes (insert audios rows, link playlist_audios, etc.).
+- **Anything interactive** — the **Hasura Console**.
 
 ## Operator CLIs in `apps/backend/src/cli/`
 


### PR DESCRIPTION
## Summary

One of our internal guides told you that you could connect straight to the database. Another guide flatly forbids that — everything must go through a single front door. Anyone following the first guide would have quietly gone around every permission and validation check we have, using an address for the database that stopped working a while ago.

This deletes the bad advice. The guide now says what is actually true: there is one way in, and it points at the guide that owns that rule instead of re-explaining it.

- Deleted the "Or Postgres directly via `DATABASE_URL`" bullet.
- Retitled the section — it was never "directly", it is Hasura-mediated.
- Dropped `DATABASE_URL` from the `.env` key list.
- Defers to `hasura-architecture` for the rule itself, carrying none of its wording (consumer-defers-to-owner).
- No hosting provider is named anywhere — none is verifiable from this repo and no ops task needs one.

Docs-only. No runtime code, no config, no dependencies.

## Test plan

Acceptance criteria verified literally on this branch:

```
$ grep -rn DATABASE_URL .claude/skills/
(no output)

$ grep -rni 'neon\|cloud sql\|psql' .claude/skills/
.claude/skills/hasura-architecture/SKILL.md:15:Human/ops access follows the same rule: **use the Hasura Console, never a direct SQL client (psql, a database provider's console, etc.).** …
```

The single remaining hit is `hasura-architecture` **forbidding** psql — that is the owner skill stating the rule, which is exactly where it belongs. No other skill documents a direct Postgres path.

Public-repo check — no identity data added:

```
$ grep -nE '[0-9a-f]{8}-[0-9a-f]{4}-' .claude/skills/backend-ops/SKILL.md
(no output)
```

Refs SWO-585