### PR TITLE
fix(backend): build the service images from the monorepo root as a pnpm workspace slice

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# The backend Dockerfiles build from the monorepo root, so this file guards
+# every backend image build. Keep it minimal: the Dockerfiles COPY only the
+# paths they need, this just stops host-only artefacts riding along.
+**/node_modules
+**/dist
+**/.turbo
+**/coverage
+.git
+.github
+.claude
+**/.env
+**/.env.*

--- a/apps/backend/Dockerfile.compute
+++ b/apps/backend/Dockerfile.compute
@@ -2,20 +2,28 @@
 #   docker build -f apps/backend/Dockerfile.compute .
 FROM --platform=linux/amd64 node:24.18.0-slim
 
-# pnpm at the exact version pinned in the root package.json `packageManager`.
-ENV PNPM_HOME="/pnpm" \
-    PATH="/pnpm:$PATH"
+# corepack resolves pnpm from the root package.json `packageManager` field.
 RUN corepack enable
 
 WORKDIR /app
 
 # Manifests first so the install layer is only rebuilt when a dependency changes.
+# One manifest per workspace package in the `backend...` closure — add to this
+# list if backend or core ever gains another `workspace:*` dependency.
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/backend/package.json apps/backend/
 COPY packages/core/package.json packages/core/
 COPY packages/tsconfig/package.json packages/tsconfig/
 
-RUN pnpm install --frozen-lockfile --filter backend...
+# --ignore-scripts: the workspace already blocks dependency lifecycle scripts
+# (`onlyBuiltDependencies: []`), and the root `prepare` runs husky, which has no
+# .git to work with in here.
+RUN pnpm install --frozen-lockfile --ignore-scripts --filter backend...
+
+# @ffprobe-installer ships its binary non-executable and relies on a postinstall
+# `chmod` that the workspace's blocked lifecycle scripts never run. Without this,
+# ffprobe fails with EACCES and getDuration() silently falls back to 1 second.
+RUN cd apps/backend && chmod +x "$(node -p "require('@ffprobe-installer/ffprobe').path")"
 
 # There is no build step: the service runs `tsx` over TypeScript SOURCE, and the
 # backend tsconfig maps `core`/`core/*` to ../../packages/core/src — so core's

--- a/apps/backend/Dockerfile.compute
+++ b/apps/backend/Dockerfile.compute
@@ -1,11 +1,29 @@
+# Build context is the MONOREPO ROOT, not apps/backend:
+#   docker build -f apps/backend/Dockerfile.compute .
 FROM --platform=linux/amd64 node:24.18.0-slim
+
+# pnpm at the exact version pinned in the root package.json `packageManager`.
+ENV PNPM_HOME="/pnpm" \
+    PATH="/pnpm:$PATH"
+RUN corepack enable
 
 WORKDIR /app
 
-COPY package.json package-lock.json ./
-RUN npm ci
+# Manifests first so the install layer is only rebuilt when a dependency changes.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/backend/package.json apps/backend/
+COPY packages/core/package.json packages/core/
+COPY packages/tsconfig/package.json packages/tsconfig/
 
-COPY . .
+RUN pnpm install --frozen-lockfile --filter backend...
+
+# There is no build step: the service runs `tsx` over TypeScript SOURCE, and the
+# backend tsconfig maps `core`/`core/*` to ../../packages/core/src — so core's
+# source must sit at its workspace-relative path inside the image.
+COPY apps/backend apps/backend
+COPY packages/core packages/core
+
+WORKDIR /app/apps/backend
 
 EXPOSE 4000
 CMD ["npm", "run", "start-compute", "--", "--listen", "0.0.0.0"]

--- a/apps/backend/Dockerfile.gateway
+++ b/apps/backend/Dockerfile.gateway
@@ -1,11 +1,29 @@
+# Build context is the MONOREPO ROOT, not apps/backend:
+#   docker build -f apps/backend/Dockerfile.gateway .
 FROM --platform=linux/amd64 node:24.18.0-slim
+
+# pnpm at the exact version pinned in the root package.json `packageManager`.
+ENV PNPM_HOME="/pnpm" \
+    PATH="/pnpm:$PATH"
+RUN corepack enable
 
 WORKDIR /app
 
-COPY package.json package-lock.json ./
-RUN npm ci
+# Manifests first so the install layer is only rebuilt when a dependency changes.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/backend/package.json apps/backend/
+COPY packages/core/package.json packages/core/
+COPY packages/tsconfig/package.json packages/tsconfig/
 
-COPY . .
+RUN pnpm install --frozen-lockfile --filter backend...
+
+# There is no build step: the service runs `tsx` over TypeScript SOURCE, and the
+# backend tsconfig maps `core`/`core/*` to ../../packages/core/src — so core's
+# source must sit at its workspace-relative path inside the image.
+COPY apps/backend apps/backend
+COPY packages/core packages/core
+
+WORKDIR /app/apps/backend
 
 EXPOSE 4000
 CMD ["npm", "run", "start-gateway", "--", "--listen", "0.0.0.0"]

--- a/apps/backend/Dockerfile.gateway
+++ b/apps/backend/Dockerfile.gateway
@@ -2,20 +2,23 @@
 #   docker build -f apps/backend/Dockerfile.gateway .
 FROM --platform=linux/amd64 node:24.18.0-slim
 
-# pnpm at the exact version pinned in the root package.json `packageManager`.
-ENV PNPM_HOME="/pnpm" \
-    PATH="/pnpm:$PATH"
+# corepack resolves pnpm from the root package.json `packageManager` field.
 RUN corepack enable
 
 WORKDIR /app
 
 # Manifests first so the install layer is only rebuilt when a dependency changes.
+# One manifest per workspace package in the `backend...` closure — add to this
+# list if backend or core ever gains another `workspace:*` dependency.
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/backend/package.json apps/backend/
 COPY packages/core/package.json packages/core/
 COPY packages/tsconfig/package.json packages/tsconfig/
 
-RUN pnpm install --frozen-lockfile --filter backend...
+# --ignore-scripts: the workspace already blocks dependency lifecycle scripts
+# (`onlyBuiltDependencies: []`), and the root `prepare` runs husky, which has no
+# .git to work with in here.
+RUN pnpm install --frozen-lockfile --ignore-scripts --filter backend...
 
 # There is no build step: the service runs `tsx` over TypeScript SOURCE, and the
 # backend tsconfig maps `core`/`core/*` to ../../packages/core/src — so core's

--- a/apps/backend/Dockerfile.io
+++ b/apps/backend/Dockerfile.io
@@ -8,20 +8,23 @@ RUN apt-get update && \
     apt-get install -y procps && \
     rm -rf /var/lib/apt/lists/*
 
-# pnpm at the exact version pinned in the root package.json `packageManager`.
-ENV PNPM_HOME="/pnpm" \
-    PATH="/pnpm:$PATH"
+# corepack resolves pnpm from the root package.json `packageManager` field.
 RUN corepack enable
 
 WORKDIR /app
 
 # Manifests first so the install layer is only rebuilt when a dependency changes.
+# One manifest per workspace package in the `backend...` closure — add to this
+# list if backend or core ever gains another `workspace:*` dependency.
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/backend/package.json apps/backend/
 COPY packages/core/package.json packages/core/
 COPY packages/tsconfig/package.json packages/tsconfig/
 
-RUN pnpm install --frozen-lockfile --filter backend...
+# --ignore-scripts: the workspace already blocks dependency lifecycle scripts
+# (`onlyBuiltDependencies: []`), and the root `prepare` runs husky, which has no
+# .git to work with in here. Playwright's browsers are installed explicitly below.
+RUN pnpm install --frozen-lockfile --ignore-scripts --filter backend...
 
 # Install the chromium build Playwright expects, plus its system libraries.
 RUN pnpm --filter backend exec playwright install --with-deps chromium

--- a/apps/backend/Dockerfile.io
+++ b/apps/backend/Dockerfile.io
@@ -1,3 +1,5 @@
+# Build context is the MONOREPO ROOT, not apps/backend:
+#   docker build -f apps/backend/Dockerfile.io .
 FROM --platform=linux/amd64 node:24.18.0-slim
 
 # Install procps package to provide the 'ps' command
@@ -6,15 +8,31 @@ RUN apt-get update && \
     apt-get install -y procps && \
     rm -rf /var/lib/apt/lists/*
 
+# pnpm at the exact version pinned in the root package.json `packageManager`.
+ENV PNPM_HOME="/pnpm" \
+    PATH="/pnpm:$PATH"
+RUN corepack enable
+
 WORKDIR /app
 
-COPY package.json package-lock.json ./
-RUN npm ci
+# Manifests first so the install layer is only rebuilt when a dependency changes.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/backend/package.json apps/backend/
+COPY packages/core/package.json packages/core/
+COPY packages/tsconfig/package.json packages/tsconfig/
 
-# Install Playwright and its dependencies with a single command
-RUN npx playwright install --with-deps chromium
+RUN pnpm install --frozen-lockfile --filter backend...
 
-COPY . .
+# Install the chromium build Playwright expects, plus its system libraries.
+RUN pnpm --filter backend exec playwright install --with-deps chromium
+
+# There is no build step: the service runs `tsx` over TypeScript SOURCE, and the
+# backend tsconfig maps `core`/`core/*` to ../../packages/core/src — so core's
+# source must sit at its workspace-relative path inside the image.
+COPY apps/backend apps/backend
+COPY packages/core packages/core
+
+WORKDIR /app/apps/backend
 
 EXPOSE 4000
 CMD ["npm", "run", "start-io", "--", "--listen", "0.0.0.0"]


### PR DESCRIPTION
## Summary

No user-facing changes. The three backend service images (gateway, compute, io) could not be built at all after the backend moved into this monorepo — they still installed with `npm ci` against a lockfile that no longer exists, and they could not see the shared `core` package. They now build from the repository root and install just the backend's slice of the workspace with pnpm. There is no new build step: the services run TypeScript source directly, so the shared package's source is simply copied in alongside. Refs SWO-545.

Also fixes a silent bug the switch uncovered: the tool that reads a video's length shipped without permission to run, which would have made every converted video record a length of one second.

## Test plan

- [ ] All three images build from the repository root: `docker build -f apps/backend/Dockerfile.<service> .`
- [ ] Each image starts and answers on port 4000 (`/hz` returns `healthy`) — verified locally, output below
- [ ] The io image can still start a browser for the crawler — verified locally, output below
- [ ] The video tools (ffmpeg and ffprobe) run inside the compute image — verified locally, output below
- [ ] CI green

<details>
<summary>Local verification output (Docker 28.4.0, images built for linux/amd64)</summary>

Clean `--no-cache` build of each service, then boot:

```
#12 [ 8/11] RUN pnpm install --frozen-lockfile --ignore-scripts --filter backend...
#12 16.18 Done in 13.9s using pnpm v10.34.3
#12 DONE 17.2s
#13 [ 9/11] COPY apps/backend apps/backend
#14 [10/11] COPY packages/core packages/core
#15 [11/11] WORKDIR /app/apps/backend
```

```
--- swo545-gw (host :14000 -> container :4000) ---
{"status":"healthy","timestamp":"2026-07-21T07:47:40.369Z"} HTTP:200
Server started on port 4000
--- swo545-compute (host :14001 -> container :4000) ---
{"status":"healthy","timestamp":"2026-07-21T07:47:40.448Z"} HTTP:200
Server started on port 4000
--- swo545-io (host :14002 -> container :4000) ---
{"status":"healthy","timestamp":"2026-07-21T07:47:40.537Z"} HTTP:200
Server started on port 4000
```

(host port 4000 was already in use locally, so containers were published on 14000-14002; each still listens on 4000 inside.)

io — chromium present and launching:

```
chromium-1228
chromium_headless_shell-1228
ffmpeg-1011
/usr/bin/ps
chromium OK: hello 149.0.7827.55
```

compute — ffprobe and ffmpeg execute:

```
-rwxr-xr-x 1 root root 78926144 /app/node_modules/.pnpm/@ffprobe-installer+linux-x64@5.2.0/node_modules/@ffprobe-installer/linux-x64/ffprobe
ffprobe version N-66595-gc2b38619c0-static
ffmpeg version N-47683-g0e8eb07980-static
```

Shared package resolves from source inside the image (no built output shipped):

```
core-backed module loaded OK: CustomError,ERROR_SEVERITY
```

Container arch is `x86_64` on Node `v24.18.0`.

</details>

### Notes for the reviewer

- **Architecture.** `FROM --platform=linux/amd64` is kept from the existing files, so these images are amd64-only by design — matching Cloud Run. The ticket's acceptance criteria mention amd64/arm64; that is **not** met and never was, and changing it would risk pushing an arm image to an amd64 runtime. Verified amd64 only (built and run under emulation on an arm64 Mac); arm64 images were not produced.
- **No `.dockerignore` existed** anywhere in the repo before this. The new root one is required — without it the root build context would drag in every app's `node_modules` and the local worktrees under `.claude/`.
- **Nothing in CI builds these images** (no workflow references them; SWO-546 owns restoring the deploy path), so the local runs above are the only validation available.
- **Follow-up, not done here:** several docs still say the images do not build (`AGENTS.md`, `.claude/skills/backend-architecture`, `.claude/skills/architecture`, `.claude/skills/backend-ops`, `.claude/skills/security-reviewer/references/infra-cloud-run.md`). Those files are being rewritten in parallel under SWO-551/SWO-553, so they are deliberately untouched here to avoid conflicts.
- **Pre-existing, out of scope:** the same blocked-postinstall problem leaves ffprobe non-executable in local installs too; and a filtered pnpm install still pulls the repository's root dev tooling into the image.