### PR TITLE
ci(backend): port prod gateway/io/compute deploy workflows to the monorepo

### DIFF
--- a/.github/workflows/backend-prod-compute.yml
+++ b/.github/workflows/backend-prod-compute.yml
@@ -32,10 +32,17 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    # Least privilege: this job only reads the repo and uploads coverage.
+    permissions:
+      contents: read
     environment:
       name: prod
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Don't leave GITHUB_TOKEN in .git/config where a dependency's
+          # postinstall could read it; no later git op in this job needs it.
+          persist-credentials: false
       - name: Install pnpm
         uses: pnpm/action-setup@v4.0.0
       - name: Setup Node.js
@@ -71,6 +78,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # WIF/Docker Hub auth below is independent of the git credential.
+          persist-credentials: false
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/backend-prod-compute.yml
+++ b/.github/workflows/backend-prod-compute.yml
@@ -1,0 +1,117 @@
+name: Deploy Compute to PROD
+
+# Ported from the standalone sworld-backend repo into the monorepo (SWO-546).
+# Behaviour changes vs the original are limited to what the move forced (path
+# prefixes, the single pnpm lockfile, root Docker build context) plus the WIF
+# auth swap; runtime deploy args (port, region, no public access) are preserved.
+
+on:
+  # Manual redeploy (e.g. to ship a shared-code change that already merged).
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      # Re-prefixed with apps/backend/ — the backend now lives inside the monorepo.
+      - 'apps/backend/src/apps/compute/**'
+      - 'apps/backend/src/compute.ts'
+      - 'apps/backend/src/middleware/**' # shared
+      - 'apps/backend/src/schema/**' # shared
+      - 'apps/backend/src/services/**' # shared
+      - 'apps/backend/src/utils/**' # shared
+      - 'apps/backend/Dockerfile.compute'
+      - 'apps/backend/package.json'
+      # The image copies these workspace packages' SOURCE (backend depends on
+      # core; core depends on tsconfig), so a change to either alters the built
+      # image. The standalone repo had no way to express this dependency.
+      - 'packages/core/**'
+      - 'packages/tsconfig/**'
+      # Single workspace lockfile replaces the old per-repo package-lock.json.
+      - 'pnpm-lock.yaml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    environment:
+      name: prod
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4.0.0
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.18.0'
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Run tests
+        run: pnpm --filter backend test:ci
+        env:
+          NODE_ENV: test
+          CI: true
+      - name: Upload coverage
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          # Kept false until the backend coverage config lands (SWO-599): a
+          # Codecov upload hiccup must not block a prod deploy.
+          fail_ci_if_error: false
+
+  deploy:
+    needs: test
+    runs-on: ubuntu-latest
+    environment:
+      name: prod
+    # Required for keyless Workload Identity Federation: the auth step below
+    # mints a GitHub OIDC token to exchange for GCP credentials.
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: shinabr2
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and Push Compute Image
+        id: build-and-push-compute
+        uses: docker/build-push-action@v6
+        with:
+          # Build context is the monorepo root — the Dockerfile copies the
+          # workspace manifests and packages/core source from there.
+          context: .
+          file: ./apps/backend/Dockerfile.compute
+          # Cloud Run runs amd64; the Dockerfile pins FROM --platform=linux/amd64,
+          # so the old dual-platform arm64 build was unused dead weight.
+          platforms: linux/amd64
+          push: true
+          tags: shinabr2/sworld-backend:compute-${{ github.ref_name }}-${{ github.sha }}
+
+      # WIF replaces the retired credentials_json / secrets.GH_ACTIONS_SWORLD key.
+      - name: Authenticate with Google Cloud
+        uses: 'google-github-actions/auth@v2'
+        with:
+          workload_identity_provider: 'projects/500095367427/locations/global/workloadIdentityPools/githubactions/providers/github'
+          service_account: 'github-action-559417054@sworld-prod.iam.gserviceaccount.com'
+
+      - name: Set up Cloud SDK
+        uses: 'google-github-actions/setup-gcloud@v2'
+
+      - name: Deploy Compute to Cloud Run
+        # No --allow-unauthenticated: compute is an internal service, not public
+        # (only the gateway is publicly reachable).
+        run: |
+          IMAGE_TAG="shinabr2/sworld-backend:compute-${{ github.ref_name }}-${{ github.sha }}"
+          gcloud run deploy compute \
+            --image $IMAGE_TAG \
+            --platform managed \
+            --port 4000 \
+            --region asia-southeast1

--- a/.github/workflows/backend-prod-gateway.yml
+++ b/.github/workflows/backend-prod-gateway.yml
@@ -32,10 +32,17 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    # Least privilege: this job only reads the repo and uploads coverage.
+    permissions:
+      contents: read
     environment:
       name: prod
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Don't leave GITHUB_TOKEN in .git/config where a dependency's
+          # postinstall could read it; no later git op in this job needs it.
+          persist-credentials: false
       - name: Install pnpm
         uses: pnpm/action-setup@v4.0.0
       - name: Setup Node.js
@@ -71,6 +78,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # WIF/Docker Hub auth below is independent of the git credential.
+          persist-credentials: false
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/backend-prod-gateway.yml
+++ b/.github/workflows/backend-prod-gateway.yml
@@ -1,0 +1,116 @@
+name: Deploy Gateway to PROD
+
+# Ported from the standalone sworld-backend repo into the monorepo (SWO-546).
+# Behaviour changes vs the original are limited to what the move forced (path
+# prefixes, the single pnpm lockfile, root Docker build context) plus the WIF
+# auth swap; runtime deploy args (port, region, public access) are preserved.
+
+on:
+  # Manual redeploy (e.g. to ship a shared-code change that already merged).
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      # Re-prefixed with apps/backend/ — the backend now lives inside the monorepo.
+      - 'apps/backend/src/apps/gateway/**'
+      - 'apps/backend/src/gateway.ts'
+      - 'apps/backend/src/middleware/**' # shared
+      - 'apps/backend/src/schema/**' # shared
+      - 'apps/backend/src/services/**' # shared
+      - 'apps/backend/src/utils/**' # shared
+      - 'apps/backend/Dockerfile.gateway'
+      - 'apps/backend/package.json'
+      # The image copies these workspace packages' SOURCE (backend depends on
+      # core; core depends on tsconfig), so a change to either alters the built
+      # gateway. The standalone repo had no way to express this dependency.
+      - 'packages/core/**'
+      - 'packages/tsconfig/**'
+      # Single workspace lockfile replaces the old per-repo package-lock.json.
+      - 'pnpm-lock.yaml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    environment:
+      name: prod
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4.0.0
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.18.0'
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Run tests
+        run: pnpm --filter backend test:ci
+        env:
+          NODE_ENV: test
+          CI: true
+      - name: Upload coverage
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          # Kept false until the backend coverage config lands (SWO-599): a
+          # Codecov upload hiccup must not block a prod deploy.
+          fail_ci_if_error: false
+
+  deploy:
+    needs: test
+    runs-on: ubuntu-latest
+    environment:
+      name: prod
+    # Required for keyless Workload Identity Federation: the auth step below
+    # mints a GitHub OIDC token to exchange for GCP credentials.
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: shinabr2
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and Push Gateway Image
+        id: build-and-push-gateway
+        uses: docker/build-push-action@v6
+        with:
+          # Build context is the monorepo root — the Dockerfile copies the
+          # workspace manifests and packages/core source from there.
+          context: .
+          file: ./apps/backend/Dockerfile.gateway
+          # Cloud Run runs amd64; the Dockerfile pins FROM --platform=linux/amd64,
+          # so the old dual-platform arm64 build was unused dead weight.
+          platforms: linux/amd64
+          push: true
+          tags: shinabr2/sworld-backend:gateway-${{ github.ref_name }}-${{ github.sha }}
+
+      # WIF replaces the retired credentials_json / secrets.GH_ACTIONS_SWORLD key.
+      - name: Authenticate with Google Cloud
+        uses: 'google-github-actions/auth@v2'
+        with:
+          workload_identity_provider: 'projects/500095367427/locations/global/workloadIdentityPools/githubactions/providers/github'
+          service_account: 'github-action-559417054@sworld-prod.iam.gserviceaccount.com'
+
+      - name: Set up Cloud SDK
+        uses: 'google-github-actions/setup-gcloud@v2'
+
+      - name: Deploy Gateway to Cloud Run
+        run: |
+          IMAGE_TAG="shinabr2/sworld-backend:gateway-${{ github.ref_name }}-${{ github.sha }}"
+          gcloud run deploy gateway \
+            --image $IMAGE_TAG \
+            --platform managed \
+            --port 4000 \
+            --region asia-southeast1 \
+            --allow-unauthenticated

--- a/.github/workflows/backend-prod-io.yml
+++ b/.github/workflows/backend-prod-io.yml
@@ -32,10 +32,17 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    # Least privilege: this job only reads the repo and uploads coverage.
+    permissions:
+      contents: read
     environment:
       name: prod
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Don't leave GITHUB_TOKEN in .git/config where a dependency's
+          # postinstall could read it; no later git op in this job needs it.
+          persist-credentials: false
       - name: Install pnpm
         uses: pnpm/action-setup@v4.0.0
       - name: Setup Node.js
@@ -71,6 +78,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # WIF/Docker Hub auth below is independent of the git credential.
+          persist-credentials: false
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/backend-prod-io.yml
+++ b/.github/workflows/backend-prod-io.yml
@@ -1,0 +1,117 @@
+name: Deploy IO to PROD
+
+# Ported from the standalone sworld-backend repo into the monorepo (SWO-546).
+# Behaviour changes vs the original are limited to what the move forced (path
+# prefixes, the single pnpm lockfile, root Docker build context) plus the WIF
+# auth swap; runtime deploy args (port, region, no public access) are preserved.
+
+on:
+  # Manual redeploy (e.g. to ship a shared-code change that already merged).
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      # Re-prefixed with apps/backend/ — the backend now lives inside the monorepo.
+      - 'apps/backend/src/apps/io/**'
+      - 'apps/backend/src/io.ts'
+      - 'apps/backend/src/middleware/**' # shared
+      - 'apps/backend/src/schema/**' # shared
+      - 'apps/backend/src/services/**' # shared
+      - 'apps/backend/src/utils/**' # shared
+      - 'apps/backend/Dockerfile.io'
+      - 'apps/backend/package.json'
+      # The image copies these workspace packages' SOURCE (backend depends on
+      # core; core depends on tsconfig), so a change to either alters the built
+      # image. The standalone repo had no way to express this dependency.
+      - 'packages/core/**'
+      - 'packages/tsconfig/**'
+      # Single workspace lockfile replaces the old per-repo package-lock.json.
+      - 'pnpm-lock.yaml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    environment:
+      name: prod
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4.0.0
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.18.0'
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Run tests
+        run: pnpm --filter backend test:ci
+        env:
+          NODE_ENV: test
+          CI: true
+      - name: Upload coverage
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          # Kept false until the backend coverage config lands (SWO-599): a
+          # Codecov upload hiccup must not block a prod deploy.
+          fail_ci_if_error: false
+
+  deploy:
+    needs: test
+    runs-on: ubuntu-latest
+    environment:
+      name: prod
+    # Required for keyless Workload Identity Federation: the auth step below
+    # mints a GitHub OIDC token to exchange for GCP credentials.
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: shinabr2
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and Push IO Image
+        id: build-and-push-io
+        uses: docker/build-push-action@v6
+        with:
+          # Build context is the monorepo root — the Dockerfile copies the
+          # workspace manifests and packages/core source from there.
+          context: .
+          file: ./apps/backend/Dockerfile.io
+          # Cloud Run runs amd64; the Dockerfile pins FROM --platform=linux/amd64,
+          # so the old dual-platform arm64 build was unused dead weight.
+          platforms: linux/amd64
+          push: true
+          tags: shinabr2/sworld-backend:io-${{ github.ref_name }}-${{ github.sha }}
+
+      # WIF replaces the retired credentials_json / secrets.GH_ACTIONS_SWORLD key.
+      - name: Authenticate with Google Cloud
+        uses: 'google-github-actions/auth@v2'
+        with:
+          workload_identity_provider: 'projects/500095367427/locations/global/workloadIdentityPools/githubactions/providers/github'
+          service_account: 'github-action-559417054@sworld-prod.iam.gserviceaccount.com'
+
+      - name: Set up Cloud SDK
+        uses: 'google-github-actions/setup-gcloud@v2'
+
+      - name: Deploy IO to Cloud Run
+        # No --allow-unauthenticated: io is an internal service, not public
+        # (only the gateway is publicly reachable).
+        run: |
+          IMAGE_TAG="shinabr2/sworld-backend:io-${{ github.ref_name }}-${{ github.sha }}"
+          gcloud run deploy io \
+            --image $IMAGE_TAG \
+            --platform managed \
+            --port 4000 \
+            --region asia-southeast1


### PR DESCRIPTION
## Summary

Restores the three backend **prod** Cloud Run deploy workflows (gateway, io, compute) that were dropped when the backend was imported into the monorepo (SWO-544). Until this lands, a backend change cannot be released at all.

Each workflow is a faithful port of its `sworld-backend` original, with only the changes the move forced plus the WIF auth swap:

- **Paths** re-prefixed to `apps/backend/**`, plus `packages/core/**` and `packages/tsconfig/**` (the images `COPY` those workspace sources, so a change to either alters the built image) and `pnpm-lock.yaml` (single workspace lockfile).
- **Toolchain:** `npm ci` → `pnpm install --frozen-lockfile`; tests via `pnpm --filter backend test:ci`.
- **Docker build context** moved to the monorepo root (`context: .`, `file: ./apps/backend/Dockerfile.<svc>`).
- **Auth:** keyless **Workload Identity Federation** replaces the `credentials_json` service-account key (`id-token: write` scoped to the deploy job).
- **amd64-only** build (matches the Dockerfile's `FROM --platform=linux/amd64` pin; the old arm64 build was unused).
- `fail_ci_if_error: false` on the coverage upload until backend coverage config lands (SWO-599) — a Codecov hiccup must not block a prod deploy.

Runtime deploy args are preserved exactly: `--port 4000`, `--region asia-southeast1`, and `--allow-unauthenticated` **only** on the public gateway (io/compute stay internal).

**Not ported:** `backend-on-pr.yml`. The root `unit-test-pr.yml` already runs the backend's vitest suite (backend is a workspace member of `turbo run test`), so porting it would double-run tests on every frontend PR. Backend PR coverage depth is folded into SWO-599.

## Test plan

Verified locally before pushing (no push-and-recheck loop):

- `actionlint` clean on all three workflows.
- `docker build --platform linux/amd64 -f apps/backend/Dockerfile.<svc> .` from the monorepo root succeeds for gateway, io, and compute.
- Each image **boots**: `docker run` → `Server started on port 4000`, container stays running.

Post-merge, the real deploy path (WIF auth → Cloud Run) exercises on the first push that touches `apps/backend/**`.

Refs SWO-546


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated production deployment pipelines for the Compute, Gateway, and IO services.
  * Deployments can be started manually or triggered by relevant changes merged into the main branch.
  * Services are built, tested, and deployed to Cloud Run after successful validation.
  * Gateway remains publicly accessible, while Compute and IO retain restricted access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->