### PR TITLE
[WIP] docs(backend): update CLI README for the monorepo layout

### DIFF
--- a/apps/backend/src/cli/README.md
+++ b/apps/backend/src/cli/README.md
@@ -10,13 +10,13 @@ Read this top-to-bottom once and you can pick up the whole area.
 
 ## 1. The big picture
 
-sworld is split across three repos:
+sworld is one monorepo. Three areas matter here:
 
-| Repo                | Role                                                        |
-| ------------------- | ---------------------------------------------------------- |
-| `sworld`            | Frontend (React).                                          |
-| `sworld-hasura-v2`  | Hasura metadata + Postgres migrations (the data layer).    |
-| `sworld-backend`    | Hono services that run Hasura **Actions** and **Events**.  |
+| Path            | Role                                                        |
+| --------------- | ---------------------------------------------------------- |
+| `apps/*`        | Frontend apps (React) — `main`, `watch`, `listen`, `til`, `docs`, `extension`, `game`. |
+| `apps/hasura`   | Hasura metadata + Postgres migrations (the data layer).    |
+| `apps/backend`  | Hono services that run Hasura **Actions** and **Events** (this CLI lives at `apps/backend/src/cli`). |
 
 A video is just a row in the `videos` table. When that row is inserted, Hasura
 fires an **event trigger** that calls the backend, which downloads/copies the


### PR DESCRIPTION
## Summary

The backend CLI README opened by claiming the project was split across three separate repos (`sworld`, `sworld-hasura-v2`, `sworld-backend`). That is stale — everything now lives in one monorepo. This rewrites the "big picture" section to describe the single-monorepo layout, pointing at the real in-repo paths (`apps/*` for the frontend apps, `apps/hasura` for the data layer, `apps/backend` for the Hono services / this CLI).

## Test plan

- `grep -nE 'sworld-backend|sworld-hasura-v2|three repos' apps/backend/src/cli/README.md` returns nothing.
- All other `src/...` paths referenced in the README verified to exist under `apps/backend`.
- Documentation-only change; no code or behaviour affected.

Refs SWO-590

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the project overview to reflect the monorepo structure.
  * Clarified the roles of frontend apps, Hasura metadata and migrations, and backend services.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->