### PR TITLE
[WIP] ci(backend): restore Codecov coverage gate

### DIFF
--- a/.github/workflows/backend-prod-compute.yml
+++ b/.github/workflows/backend-prod-compute.yml
@@ -61,8 +61,10 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          # Kept false until the backend coverage config lands (SWO-599): a
-          # Codecov upload hiccup must not block a prod deploy.
+          # Kept false: a Codecov upload hiccup must not block a prod deploy.
+          # The coverage GATE (SWO-599) is a Codecov commit status on the PR,
+          # not this action's exit code, so keeping this false does not weaken
+          # it.
           fail_ci_if_error: false
 
   deploy:

--- a/.github/workflows/backend-prod-gateway.yml
+++ b/.github/workflows/backend-prod-gateway.yml
@@ -61,8 +61,10 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          # Kept false until the backend coverage config lands (SWO-599): a
-          # Codecov upload hiccup must not block a prod deploy.
+          # Kept false: a Codecov upload hiccup must not block a prod deploy.
+          # The coverage GATE (SWO-599) is a Codecov commit status on the PR,
+          # not this action's exit code, so keeping this false does not weaken
+          # it.
           fail_ci_if_error: false
 
   deploy:

--- a/.github/workflows/backend-prod-io.yml
+++ b/.github/workflows/backend-prod-io.yml
@@ -61,8 +61,10 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          # Kept false until the backend coverage config lands (SWO-599): a
-          # Codecov upload hiccup must not block a prod deploy.
+          # Kept false: a Codecov upload hiccup must not block a prod deploy.
+          # The coverage GATE (SWO-599) is a Codecov commit status on the PR,
+          # not this action's exit code, so keeping this false does not weaken
+          # it.
           fail_ci_if_error: false
 
   deploy:

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -19,7 +19,7 @@
     "codegen": "dotenvx run -- graphql-codegen --config src/services/hasura/codegen.ts",
     "watch-codegen-hasura": "dotenvx run -- graphql-codegen --config src/services/hasura/codegen.ts --watch",
     "watch-codegen-hashnode": "dotenvx run -- graphql-codegen --config src/services/hashnode/codegen.ts --watch",
-    "test": "vitest",
+    "test": "vitest --coverage",
     "test:ci": "vitest run --coverage",
     "typecheck": "tsc --noEmit",
     "format": "biome format --write",

--- a/apps/backend/vite.config.js
+++ b/apps/backend/vite.config.js
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'node:url';
 // only resolved in the standalone repo because that install happened to hoist it
 // into the root node_modules; under the monorepo's layout it isn't visible and
 // the config fails to load.
-import { defineConfig } from 'vitest/config';
+import { coverageConfigDefaults, defineConfig } from 'vitest/config';
 
 export default defineConfig({
   resolve: {
@@ -18,5 +18,21 @@ export default defineConfig({
   },
   test: {
     setupFiles: ['./__mocks__/sequelize.ts'],
+    coverage: {
+      provider: 'v8',
+      // `json` writes coverage-final.json, which the Codecov uploader picks up.
+      reporter: ['text', 'json'],
+      // Keep Vitest's built-in exclusions (tests, config, node_modules, dist)
+      // and add the backend-specific ones. These mirror the `ignore` list in
+      // the root codecov.yml so the local report reflects service code only.
+      exclude: [
+        ...coverageConfigDefaults.exclude,
+        'src/services/hasura/generated-graphql/**',
+        'src/services/hashnode/generated-graphql/**',
+        'src/services/hasura/codegen.ts',
+        'src/services/hashnode/codegen.ts',
+        'src/cli/**', // standalone operator tooling, run via tsx (not part of the services)
+      ],
+    },
   },
 });

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,47 @@
+# Codecov config for the sworld monorepo.
+#
+# Restores the backend coverage gate lost in the SWO-544 monorepo import
+# (SWO-599). The backend must keep very high coverage; the frontend does not.
+#
+# Every status here is scoped to `apps/backend/src` via `paths`, so the 90% /
+# 100% bars apply to the backend ONLY. Frontend coverage still uploads (from
+# unit-test-main.yml, with no config) but is never measured against these
+# targets — it has no status of its own here, which is deliberately the looser
+# treatment. Paths are repo-root-relative: the standalone backend repo's config
+# used bare `src`, which would silently match nothing now that the backend
+# lives under apps/backend/.
+coverage:
+  status:
+    project:
+      backend:
+        target: 90%
+        threshold: 2%
+        paths:
+          - 'apps/backend/src'
+    patch:
+      backend:
+        target: 100%
+        threshold: 2%
+        paths:
+          - 'apps/backend/src'
+
+# Excluded from coverage so the number reflects service code only. Mirrors the
+# Vitest `coverage.exclude` in apps/backend/vite.config.js.
+ignore:
+  - 'apps/backend/src/**/*.test.ts'
+  - 'apps/backend/src/**/*.spec.ts'
+  - 'apps/backend/src/services/hasura/generated-graphql/**'
+  - 'apps/backend/src/services/hasura/codegen.ts'
+  - 'apps/backend/src/services/hashnode/generated-graphql/**'
+  - 'apps/backend/src/services/hashnode/codegen.ts'
+  - 'apps/backend/src/cli/**' # standalone operator tooling, run via tsx (not part of the services)
+
+comment:
+  layout: 'reach, diff, files'
+  behavior: default
+  require_changes: false
+  require_base: false
+  require_head: true
+
+github_checks:
+  annotations: true


### PR DESCRIPTION
## Summary

The backend's coverage gate was lost in the monorepo import (SWO-544) and never replaced. There was no `codecov.yml` anywhere, and the PR test run (`turbo run test`) invoked the backend's plain `vitest` with no `--coverage`, so no report was ever produced or uploaded — turbo even warned it produced no output files. This restores a real, backend-scoped coverage gate.

What lands:

- **Root `codecov.yml`** — restores the deleted gate, re-anchored for the monorepo: `project` target 90% and `patch` target 100% (threshold 2%), **both path-scoped to `apps/backend/src`**. Scoping keeps the bar on the backend only; the frontend (which uploads coverage with no config) is never held to it. `ignore` covers test/spec files, both generated GraphQL dirs, both `codegen.ts` files, and `src/cli/**` so the number reflects service code. Validated against Codecov's schema API ("Valid!").
- **`apps/backend/package.json`** — `test` now runs `vitest --coverage` (mirrors `packages/core`), so `turbo run test` emits `coverage/**` (already a declared turbo output) for the existing Codecov upload step to discover. This also fixes the "no output files found for task backend#test" turbo warning.
- **`apps/backend/vite.config.js`** — v8 coverage config with a `json` reporter (writes `coverage-final.json`) and an `exclude` list mirroring the codecov `ignore`.
- **Three `backend-prod-*.yml`** — refresh the now-stale `fail_ci_if_error` comment (kept `false`: an upload hiccup must not block a prod deploy; the gate is a PR commit status, not this action's exit code).

Shape chosen: **one root `codecov.yml` with path-scoped statuses** (the shape the original config actually used), not flagged uploads. This reuses the already-working frontend auto-discovery upload and avoids the monorepo path-fixing / silent-no-match trap that flagged uploads would introduce.

Refs SWO-599

## Test plan

Verified locally in the worktree:

- `pnpm turbo run test --filter=backend` — task succeeds, `apps/backend/coverage/coverage-final.json` produced, and **zero** "no output files found for task" warnings; a second run is a turbo cache hit (coverage is now a cached, restorable output).
- Backend coverage: **95.32% statements / 95.73% lines** — comfortably above the 90% bar.
- `src/cli/**` and both `generated-graphql/` dirs are absent from `coverage-final.json` (excludes work).
- `codecov.yml` returns "Valid!" from `codecov.io/validate`; all touched workflow YAMLs parse.
- Backend Biome lint on the changed config is clean.

On this PR: expect `codecov/project/backend` and `codecov/patch/backend` checks to appear once coverage uploads. A future PR dropping backend coverage below the bar fails those checks; a frontend-only PR is unaffected.