### PR TITLE
[WIP] chore(hasura): point package.json URLs at the monorepo

### DIFF
--- a/apps/hasura/package.json
+++ b/apps/hasura/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/shinaBR2/sworld-hasura-v2.git"
+    "url": "git+https://github.com/shinaBR2/sworld.git",
+    "directory": "apps/hasura"
   },
   "keywords": [
     "hasura"
@@ -21,9 +22,9 @@
   "author": "ShinaBR2",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/shinaBR2/sworld-hasura-v2/issues"
+    "url": "https://github.com/shinaBR2/sworld/issues"
   },
-  "homepage": "https://github.com/shinaBR2/sworld-hasura-v2#readme",
+  "homepage": "https://github.com/shinaBR2/sworld/tree/main/apps/hasura#readme",
   "devDependencies": {
     "@eslint/js": "^9.17.0",
     "@types/node": "^24",


### PR DESCRIPTION
## Summary
The Hasura package's `repository`, `bugs`, and `homepage` URLs still pointed at the standalone `sworld-hasura-v2` repo, which is about to be archived read-only. Repointed them at the monorepo (`shinaBR2/sworld`), adding `repository.directory: apps/hasura` per the npm monorepo convention. Package `name` intentionally unchanged.

Part of the post-cutover cleanup so nothing in `main` links to an archived repo before we archive it.

## Test plan
Metadata-only change — no runtime effect. CI (typecheck/lint) confirms the JSON is valid.

Refs SWO-550