### PR TITLE
[WIP] feat(db): add pending_session_string to telegram_credentials

### DIFF
--- a/apps/hasura/metadata/databases/sworld/tables/public_telegram_credentials.yaml
+++ b/apps/hasura/metadata/databases/sworld/tables/public_telegram_credentials.yaml
@@ -11,6 +11,8 @@ configuration:
       custom_name: createdAt
     pending_phone_code_hash:
       custom_name: pendingPhoneCodeHash
+    pending_session_string:
+      custom_name: pendingSessionString
     phone_number:
       custom_name: phoneNumber
     session_string:
@@ -22,6 +24,7 @@ configuration:
     api_id: apiId
     created_at: createdAt
     pending_phone_code_hash: pendingPhoneCodeHash
+    pending_session_string: pendingSessionString
     phone_number: phoneNumber
     session_string: sessionString
     updated_at: updatedAt

--- a/apps/hasura/migrations/sworld/1784362020119_add_pending_session_string_to_telegram_credentials/down.sql
+++ b/apps/hasura/migrations/sworld/1784362020119_add_pending_session_string_to_telegram_credentials/down.sql
@@ -1,0 +1,3 @@
+COMMENT ON TABLE "public"."telegram_credentials" IS E'Per-user Telegram MTProto credentials and session. Admin-secret mediated only (no role:user permissions) - the extension never reads this directly, only through the telegram-actions Hono handlers. session_string and pending_phone_code_hash are credential-equivalent secrets.';
+
+ALTER TABLE "public"."telegram_credentials" DROP COLUMN "pending_session_string";

--- a/apps/hasura/migrations/sworld/1784362020119_add_pending_session_string_to_telegram_credentials/up.sql
+++ b/apps/hasura/migrations/sworld/1784362020119_add_pending_session_string_to_telegram_credentials/up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "public"."telegram_credentials" ADD COLUMN "pending_session_string" text NULL;
+
+COMMENT ON TABLE "public"."telegram_credentials" IS E'Per-user Telegram MTProto credentials and session. Admin-secret mediated only (no role:user permissions) - the extension never reads this directly, only through the telegram-actions Hono handlers. session_string, pending_session_string and pending_phone_code_hash are credential-equivalent secrets. session_string only ever holds an AUTHORIZED session; an in-progress login is held in pending_session_string so a re-login never overwrites a working session.';


### PR DESCRIPTION
## Summary

No user-facing changes. Adds a `pending_session_string` column to the `telegram_credentials` data-layer table (Watch app's Telegram import feature). It separates the *in-progress* login session from the *authorized* one, so a user who starts and then abandons a re-login can never overwrite and destroy their existing working session. The column is credential-holding and stays admin-secret-only — no client role can read it.

This is the deploy-order-first piece of the SWO-490 wave: it must merge (and Hasura Cloud auto-applies it) **before** SWO-491, whose queries select `pendingSessionString`. Recovered from the pre-monorepo `sworld-hasura-v2` branch and transplanted into `apps/hasura`.

Refs SWO-499.

## Test plan

- [ ] Migration applies cleanly and metadata stays consistent (`hasura migrate apply` + `hasura metadata apply` — verified locally, no inconsistencies)
- [ ] The table gains no new `role: user` permission — it remains admin-secret-only
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for storing an in-progress Telegram login session separately from an authorized session.
  * Exposed the new pending session value consistently through the application’s schema.

* **Documentation**
  * Clarified the roles and security-sensitive nature of Telegram session credentials in table metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->