### PR TITLE
[WIP] chore(core): regen graphql types for pendingSessionString

### DIFF
--- a/packages/core/schema.graphql
+++ b/packages/core/schema.graphql
@@ -11766,7 +11766,7 @@ type telegram_credentials {
   createdAt: timestamptz!
   id: uuid!
   pendingPhoneCodeHash: String
-  pending_session_string: String
+  pendingSessionString: String
   phoneNumber: String!
   sessionString: String
   updatedAt: timestamptz!
@@ -11804,7 +11804,7 @@ input telegram_credentials_bool_exp {
   createdAt: timestamptz_comparison_exp
   id: uuid_comparison_exp
   pendingPhoneCodeHash: String_comparison_exp
-  pending_session_string: String_comparison_exp
+  pendingSessionString: String_comparison_exp
   phoneNumber: String_comparison_exp
   sessionString: String_comparison_exp
   updatedAt: timestamptz_comparison_exp
@@ -11835,7 +11835,7 @@ input telegram_credentials_insert_input {
   createdAt: timestamptz
   id: uuid
   pendingPhoneCodeHash: String
-  pending_session_string: String
+  pendingSessionString: String
   phoneNumber: String
   sessionString: String
   updatedAt: timestamptz
@@ -11850,7 +11850,7 @@ type telegram_credentials_max_fields {
   createdAt: timestamptz
   id: uuid
   pendingPhoneCodeHash: String
-  pending_session_string: String
+  pendingSessionString: String
   phoneNumber: String
   sessionString: String
   updatedAt: timestamptz
@@ -11864,7 +11864,7 @@ type telegram_credentials_min_fields {
   createdAt: timestamptz
   id: uuid
   pendingPhoneCodeHash: String
-  pending_session_string: String
+  pendingSessionString: String
   phoneNumber: String
   sessionString: String
   updatedAt: timestamptz
@@ -11897,7 +11897,7 @@ input telegram_credentials_order_by {
   createdAt: order_by
   id: order_by
   pendingPhoneCodeHash: order_by
-  pending_session_string: order_by
+  pendingSessionString: order_by
   phoneNumber: order_by
   sessionString: order_by
   updatedAt: order_by
@@ -11925,7 +11925,7 @@ enum telegram_credentials_select_column {
   """column name"""
   pendingPhoneCodeHash
   """column name"""
-  pending_session_string
+  pendingSessionString
   """column name"""
   phoneNumber
   """column name"""
@@ -11945,7 +11945,7 @@ input telegram_credentials_set_input {
   createdAt: timestamptz
   id: uuid
   pendingPhoneCodeHash: String
-  pending_session_string: String
+  pendingSessionString: String
   phoneNumber: String
   sessionString: String
   updatedAt: timestamptz
@@ -11969,7 +11969,7 @@ input telegram_credentials_stream_cursor_value_input {
   createdAt: timestamptz
   id: uuid
   pendingPhoneCodeHash: String
-  pending_session_string: String
+  pendingSessionString: String
   phoneNumber: String
   sessionString: String
   updatedAt: timestamptz
@@ -11991,7 +11991,7 @@ enum telegram_credentials_update_column {
   """column name"""
   pendingPhoneCodeHash
   """column name"""
-  pending_session_string
+  pendingSessionString
   """column name"""
   phoneNumber
   """column name"""

--- a/packages/core/src/graphql/graphql.ts
+++ b/packages/core/src/graphql/graphql.ts
@@ -11134,7 +11134,7 @@ export type Telegram_Credentials = {
   createdAt: Scalars['timestamptz']['output'];
   id: Scalars['uuid']['output'];
   pendingPhoneCodeHash?: Maybe<Scalars['String']['output']>;
-  pending_session_string?: Maybe<Scalars['String']['output']>;
+  pendingSessionString?: Maybe<Scalars['String']['output']>;
   phoneNumber: Scalars['String']['output'];
   sessionString?: Maybe<Scalars['String']['output']>;
   updatedAt: Scalars['timestamptz']['output'];
@@ -11175,7 +11175,7 @@ export type Telegram_Credentials_Bool_Exp = {
   createdAt?: InputMaybe<Timestamptz_Comparison_Exp>;
   id?: InputMaybe<Uuid_Comparison_Exp>;
   pendingPhoneCodeHash?: InputMaybe<String_Comparison_Exp>;
-  pending_session_string?: InputMaybe<String_Comparison_Exp>;
+  pendingSessionString?: InputMaybe<String_Comparison_Exp>;
   phoneNumber?: InputMaybe<String_Comparison_Exp>;
   sessionString?: InputMaybe<String_Comparison_Exp>;
   updatedAt?: InputMaybe<Timestamptz_Comparison_Exp>;
@@ -11198,7 +11198,7 @@ export type Telegram_Credentials_Insert_Input = {
   createdAt?: InputMaybe<Scalars['timestamptz']['input']>;
   id?: InputMaybe<Scalars['uuid']['input']>;
   pendingPhoneCodeHash?: InputMaybe<Scalars['String']['input']>;
-  pending_session_string?: InputMaybe<Scalars['String']['input']>;
+  pendingSessionString?: InputMaybe<Scalars['String']['input']>;
   phoneNumber?: InputMaybe<Scalars['String']['input']>;
   sessionString?: InputMaybe<Scalars['String']['input']>;
   updatedAt?: InputMaybe<Scalars['timestamptz']['input']>;
@@ -11214,7 +11214,7 @@ export type Telegram_Credentials_Max_Fields = {
   createdAt?: Maybe<Scalars['timestamptz']['output']>;
   id?: Maybe<Scalars['uuid']['output']>;
   pendingPhoneCodeHash?: Maybe<Scalars['String']['output']>;
-  pending_session_string?: Maybe<Scalars['String']['output']>;
+  pendingSessionString?: Maybe<Scalars['String']['output']>;
   phoneNumber?: Maybe<Scalars['String']['output']>;
   sessionString?: Maybe<Scalars['String']['output']>;
   updatedAt?: Maybe<Scalars['timestamptz']['output']>;
@@ -11229,7 +11229,7 @@ export type Telegram_Credentials_Min_Fields = {
   createdAt?: Maybe<Scalars['timestamptz']['output']>;
   id?: Maybe<Scalars['uuid']['output']>;
   pendingPhoneCodeHash?: Maybe<Scalars['String']['output']>;
-  pending_session_string?: Maybe<Scalars['String']['output']>;
+  pendingSessionString?: Maybe<Scalars['String']['output']>;
   phoneNumber?: Maybe<Scalars['String']['output']>;
   sessionString?: Maybe<Scalars['String']['output']>;
   updatedAt?: Maybe<Scalars['timestamptz']['output']>;
@@ -11259,7 +11259,7 @@ export type Telegram_Credentials_Order_By = {
   createdAt?: InputMaybe<Order_By>;
   id?: InputMaybe<Order_By>;
   pendingPhoneCodeHash?: InputMaybe<Order_By>;
-  pending_session_string?: InputMaybe<Order_By>;
+  pendingSessionString?: InputMaybe<Order_By>;
   phoneNumber?: InputMaybe<Order_By>;
   sessionString?: InputMaybe<Order_By>;
   updatedAt?: InputMaybe<Order_By>;
@@ -11285,7 +11285,7 @@ export enum Telegram_Credentials_Select_Column {
   /** column name */
   PendingPhoneCodeHash = 'pendingPhoneCodeHash',
   /** column name */
-  PendingSessionString = 'pending_session_string',
+  PendingSessionString = 'pendingSessionString',
   /** column name */
   PhoneNumber = 'phoneNumber',
   /** column name */
@@ -11303,7 +11303,7 @@ export type Telegram_Credentials_Set_Input = {
   createdAt?: InputMaybe<Scalars['timestamptz']['input']>;
   id?: InputMaybe<Scalars['uuid']['input']>;
   pendingPhoneCodeHash?: InputMaybe<Scalars['String']['input']>;
-  pending_session_string?: InputMaybe<Scalars['String']['input']>;
+  pendingSessionString?: InputMaybe<Scalars['String']['input']>;
   phoneNumber?: InputMaybe<Scalars['String']['input']>;
   sessionString?: InputMaybe<Scalars['String']['input']>;
   updatedAt?: InputMaybe<Scalars['timestamptz']['input']>;
@@ -11325,7 +11325,7 @@ export type Telegram_Credentials_Stream_Cursor_Value_Input = {
   createdAt?: InputMaybe<Scalars['timestamptz']['input']>;
   id?: InputMaybe<Scalars['uuid']['input']>;
   pendingPhoneCodeHash?: InputMaybe<Scalars['String']['input']>;
-  pending_session_string?: InputMaybe<Scalars['String']['input']>;
+  pendingSessionString?: InputMaybe<Scalars['String']['input']>;
   phoneNumber?: InputMaybe<Scalars['String']['input']>;
   sessionString?: InputMaybe<Scalars['String']['input']>;
   updatedAt?: InputMaybe<Scalars['timestamptz']['input']>;
@@ -11345,7 +11345,7 @@ export enum Telegram_Credentials_Update_Column {
   /** column name */
   PendingPhoneCodeHash = 'pendingPhoneCodeHash',
   /** column name */
-  PendingSessionString = 'pending_session_string',
+  PendingSessionString = 'pendingSessionString',
   /** column name */
   PhoneNumber = 'phoneNumber',
   /** column name */


### PR DESCRIPTION
## Summary

No user-facing changes. Regenerates the shared GraphQL types so the `telegram_credentials` field is exposed under its camelCase name `pendingSessionString`, matching the database mapping added in #526. The frontend-codegen ripple of a Hasura schema change is landed as this separate follow-up per our workflow (the migration goes live first). No app reads this table today, so nothing depended on the old name in the meantime.

Refs SWO-602. Follows #526 (SWO-499).

## Test plan

- [ ] Type checks pass in `packages/core` (verified locally)
- [ ] Diff is generated-only — a 1:1 field rename, no hand-written source touched
- [ ] CI green