### PR TITLE
[WIP] feat(backend): gateway telegram-actions router (per-user Actions)

### DIFF
--- a/apps/backend/src/apps/gateway/telegram-actions/errors.test.ts
+++ b/apps/backend/src/apps/gateway/telegram-actions/errors.test.ts
@@ -1,0 +1,37 @@
+import {
+  TelegramCodeExpiredError,
+  TelegramInvalidCodeError,
+  TelegramLoginNotStartedError,
+  TelegramMisconfiguredError,
+  TelegramNotAuthenticatedError,
+  TelegramNotProvisionedError,
+  TelegramSessionPersistError,
+  TelegramSignUpRequiredError,
+  TelegramTwoFactorNotSupportedError,
+} from 'src/services/telegram/errors';
+import { describe, expect, it } from 'vitest';
+import { toTelegramActionErrorCode } from './errors';
+
+const USER = '550e8400-e29b-41d4-a716-446655440001';
+
+describe('toTelegramActionErrorCode', () => {
+  it.each([
+    [new TelegramNotAuthenticatedError(USER), 'NO_SESSION'],
+    [new TelegramNotProvisionedError(USER), 'NOT_PROVISIONED'],
+    [new TelegramMisconfiguredError(USER), 'MISCONFIGURED'],
+    [new TelegramLoginNotStartedError(USER), 'LOGIN_NOT_STARTED'],
+    [new TelegramInvalidCodeError(USER), 'INVALID_CODE'],
+    [new TelegramCodeExpiredError(USER), 'CODE_EXPIRED'],
+    [new TelegramSignUpRequiredError(USER), 'SIGNUP_REQUIRED'],
+    [new TelegramTwoFactorNotSupportedError(USER), 'TWO_FACTOR_UNSUPPORTED'],
+    [new TelegramSessionPersistError(USER), 'PERSIST_FAILED'],
+  ])('maps %s to its stable code', (error, expected) => {
+    expect(toTelegramActionErrorCode(error)).toBe(expected);
+  });
+
+  it('returns undefined for a non-Telegram error so the caller uses a generic message', () => {
+    expect(toTelegramActionErrorCode(new Error('random'))).toBeUndefined();
+    expect(toTelegramActionErrorCode('a string')).toBeUndefined();
+    expect(toTelegramActionErrorCode(null)).toBeUndefined();
+  });
+});

--- a/apps/backend/src/apps/gateway/telegram-actions/errors.test.ts
+++ b/apps/backend/src/apps/gateway/telegram-actions/errors.test.ts
@@ -1,5 +1,6 @@
 import {
   TelegramCodeExpiredError,
+  TelegramError,
   TelegramInvalidCodeError,
   TelegramLoginNotStartedError,
   TelegramMisconfiguredError,
@@ -33,5 +34,18 @@ describe('toTelegramActionErrorCode', () => {
     expect(toTelegramActionErrorCode(new Error('random'))).toBeUndefined();
     expect(toTelegramActionErrorCode('a string')).toBeUndefined();
     expect(toTelegramActionErrorCode(null)).toBeUndefined();
+  });
+
+  it('returns undefined for an unmapped TelegramError subclass — never leaks its class name', () => {
+    class TelegramSomethingNewError extends TelegramError {
+      constructor(userId: string) {
+        super('brand new failure', userId);
+        this.name = 'TelegramSomethingNewError';
+      }
+    }
+    // No entry in CODE_BY_ERROR → generic + logged, not the class name as a code.
+    expect(
+      toTelegramActionErrorCode(new TelegramSomethingNewError(USER)),
+    ).toBeUndefined();
   });
 });

--- a/apps/backend/src/apps/gateway/telegram-actions/errors.ts
+++ b/apps/backend/src/apps/gateway/telegram-actions/errors.ts
@@ -62,22 +62,24 @@ const CODE_BY_ERROR = new Map<new (...args: never[]) => TelegramError, string>([
 ]);
 
 /**
- * Map a thrown error to its stable action-error code, or `undefined` when it is
- * NOT a recognised TelegramError — the caller then falls back to a generic
- * failure message and error-logs the unexpected error. TelegramErrors are
- * expected control-flow (bad code, no session yet), so callers do not error-log
- * them; they carry only `userId`, never a secret.
+ * Map a thrown error to its stable action-error code, or `undefined` when it has
+ * no mapped code — either because it is NOT a TelegramError, or because it is an
+ * unmapped TelegramError subclass. In both cases the caller falls back to a
+ * generic failure message and error-logs the unexpected error, rather than
+ * leaking an ad-hoc class name the client can't branch on. Every current
+ * subclass is in `CODE_BY_ERROR`, so a `undefined` here means a new error type
+ * was added without a code — a bug that should surface as generic + logged.
+ * Mapped TelegramErrors are expected control-flow (bad code, no session yet), so
+ * callers do not error-log them; they carry only `userId`, never a secret.
  */
 const toTelegramActionErrorCode = (error: unknown): string | undefined => {
   if (!(error instanceof TelegramError)) {
     return undefined;
   }
-  return (
-    CODE_BY_ERROR.get(
-      error.constructor as new (
-        ...args: never[]
-      ) => TelegramError,
-    ) ?? error.name
+  return CODE_BY_ERROR.get(
+    error.constructor as new (
+      ...args: never[]
+    ) => TelegramError,
   );
 };
 

--- a/apps/backend/src/apps/gateway/telegram-actions/errors.ts
+++ b/apps/backend/src/apps/gateway/telegram-actions/errors.ts
@@ -1,0 +1,84 @@
+import {
+  TelegramCodeExpiredError,
+  TelegramError,
+  TelegramInvalidCodeError,
+  TelegramLoginNotStartedError,
+  TelegramMisconfiguredError,
+  TelegramNotAuthenticatedError,
+  TelegramNotProvisionedError,
+  TelegramSessionPersistError,
+  TelegramSignUpRequiredError,
+  TelegramTwoFactorNotSupportedError,
+} from 'src/services/telegram/errors';
+
+/**
+ * Stable machine-readable codes the action routes put in the response `message`
+ * on failure. The response contract (actions.graphql) says "dataObject is null on
+ * failure, message carries the reason", so `message` IS the channel the extension
+ * branches on — most importantly `NO_SESSION`, which tells the popup to show the
+ * login-code prompt instead of the video picker. Codes (not prose) so the client
+ * match is exact and refactor-safe; the extension maps them to friendly copy.
+ */
+const TelegramActionErrorCode = {
+  /** No authorized session yet — the popup shows the login-code prompt. */
+  NO_SESSION: 'NO_SESSION',
+  /** No credentials row at all — the owner must provision it out-of-band. */
+  NOT_PROVISIONED: 'NOT_PROVISIONED',
+  /** The provisioned row has a malformed api_id/api_hash/phone_number. */
+  MISCONFIGURED: 'MISCONFIGURED',
+  /** submitLoginCode with no preceding requestLoginCode. */
+  LOGIN_NOT_STARTED: 'LOGIN_NOT_STARTED',
+  /** Wrong/empty code — re-prompt against the same pending login. */
+  INVALID_CODE: 'INVALID_CODE',
+  /** Code aged out — the popup auto-requests a fresh one. */
+  CODE_EXPIRED: 'CODE_EXPIRED',
+  /** Telegram has no account for the provisioned phone. */
+  SIGNUP_REQUIRED: 'SIGNUP_REQUIRED',
+  /** Account has a 2FA password — deliberately unsupported this pass. */
+  TWO_FACTOR_UNSUPPORTED: 'TWO_FACTOR_UNSUPPORTED',
+  /** Login state could not be saved — request a fresh code and retry. */
+  PERSIST_FAILED: 'PERSIST_FAILED',
+} as const;
+
+type TelegramActionErrorCode =
+  (typeof TelegramActionErrorCode)[keyof typeof TelegramActionErrorCode];
+
+// One entry per concrete TelegramError subclass. Keyed on the class so a new
+// error type is a compile-visible addition here, not a silent fall-through to the
+// generic path.
+const CODE_BY_ERROR = new Map<new (...args: never[]) => TelegramError, string>([
+  [TelegramNotAuthenticatedError, TelegramActionErrorCode.NO_SESSION],
+  [TelegramNotProvisionedError, TelegramActionErrorCode.NOT_PROVISIONED],
+  [TelegramMisconfiguredError, TelegramActionErrorCode.MISCONFIGURED],
+  [TelegramLoginNotStartedError, TelegramActionErrorCode.LOGIN_NOT_STARTED],
+  [TelegramInvalidCodeError, TelegramActionErrorCode.INVALID_CODE],
+  [TelegramCodeExpiredError, TelegramActionErrorCode.CODE_EXPIRED],
+  [TelegramSignUpRequiredError, TelegramActionErrorCode.SIGNUP_REQUIRED],
+  [
+    TelegramTwoFactorNotSupportedError,
+    TelegramActionErrorCode.TWO_FACTOR_UNSUPPORTED,
+  ],
+  [TelegramSessionPersistError, TelegramActionErrorCode.PERSIST_FAILED],
+]);
+
+/**
+ * Map a thrown error to its stable action-error code, or `undefined` when it is
+ * NOT a recognised TelegramError — the caller then falls back to a generic
+ * failure message and error-logs the unexpected error. TelegramErrors are
+ * expected control-flow (bad code, no session yet), so callers do not error-log
+ * them; they carry only `userId`, never a secret.
+ */
+const toTelegramActionErrorCode = (error: unknown): string | undefined => {
+  if (!(error instanceof TelegramError)) {
+    return undefined;
+  }
+  return (
+    CODE_BY_ERROR.get(
+      error.constructor as new (
+        ...args: never[]
+      ) => TelegramError,
+    ) ?? error.name
+  );
+};
+
+export { TelegramActionErrorCode, toTelegramActionErrorCode };

--- a/apps/backend/src/apps/gateway/telegram-actions/index.ts
+++ b/apps/backend/src/apps/gateway/telegram-actions/index.ts
@@ -1,0 +1,53 @@
+import { Hono } from 'hono';
+import { importTelegramArchiveSchema } from 'src/schema/telegram/import';
+import { listTelegramChannelVideosSchema } from 'src/schema/telegram/list';
+import { requestTelegramLoginCodeSchema } from 'src/schema/telegram/request-login-code';
+import { submitTelegramLoginCodeSchema } from 'src/schema/telegram/submit-login-code';
+import { honoRequestHandler } from 'src/utils/requestHandler';
+import { honoValidateRequest } from 'src/utils/validators/request';
+import { importTelegramArchive } from './routes/import';
+import { listTelegramChannelVideos } from './routes/list';
+import { requestTelegramLoginCode } from './routes/request-login-code';
+import { submitTelegramLoginCode } from './routes/submit-login-code';
+
+/**
+ * Telegram MTProto Actions — session-authenticated (`x-hasura-user-id`), not
+ * webhook-signature-authenticated, same split as `videos-actions`/`storage`.
+ * Every route resolves a PER-USER client (SWO-491) from the caller's own
+ * credentials; `userId` is always read from `session_variables`, never the body.
+ *
+ * curl -X POST 'http://localhost:4000/telegram-actions/list' \
+ *   -H 'Content-Type: application/json' \
+ *   -d '{
+ *     "action": { "name": "listTelegramChannelVideos" },
+ *     "input": { "input": { "channelId": "-582839764" } },
+ *     "session_variables": { "x-hasura-user-id": "550e8400-e29b-41d4-a716-446655440001" }
+ *   }'
+ */
+const telegramActionsRouter = new Hono();
+
+telegramActionsRouter.post(
+  '/list',
+  honoValidateRequest(listTelegramChannelVideosSchema),
+  honoRequestHandler(listTelegramChannelVideos),
+);
+
+telegramActionsRouter.post(
+  '/import',
+  honoValidateRequest(importTelegramArchiveSchema),
+  honoRequestHandler(importTelegramArchive),
+);
+
+telegramActionsRouter.post(
+  '/request-login-code',
+  honoValidateRequest(requestTelegramLoginCodeSchema),
+  honoRequestHandler(requestTelegramLoginCode),
+);
+
+telegramActionsRouter.post(
+  '/submit-login-code',
+  honoValidateRequest(submitTelegramLoginCodeSchema),
+  honoRequestHandler(submitTelegramLoginCode),
+);
+
+export { telegramActionsRouter };

--- a/apps/backend/src/apps/gateway/telegram-actions/routes/import/index.test.ts
+++ b/apps/backend/src/apps/gateway/telegram-actions/routes/import/index.test.ts
@@ -64,7 +64,8 @@ describe('importTelegramArchive', () => {
       payload: {
         data: {
           channelId: '-582839764',
-          messageIds: ['3', '1', '2'],
+          // Normalized (deduped + sorted) before enqueue.
+          messageIds: ['1', '2', '3'],
           userId: USER_ID,
         },
       },
@@ -73,12 +74,21 @@ describe('importTelegramArchive', () => {
     expect(result.dataObject?.taskId).toBe('task-id-123');
   });
 
-  it('derives the idempotency entityId from a SORTED messageId set (order-independent)', async () => {
+  it('normalizes duplicate messageIds so the payload and idempotency key are canonical', async () => {
+    await callImport(buildContext({ messageIds: ['1', '2', '1'] }));
+
+    const taskConfig = vi.mocked(createCloudTasks).mock.calls[0][0];
+    expect(taskConfig).toMatchObject({
+      payload: { data: { messageIds: ['1', '2'] } },
+    });
+  });
+
+  it('derives the idempotency entityId from a deduped, SORTED messageId set (order- and duplicate-independent)', async () => {
     await callImport(buildContext({ messageIds: ['3', '1', '2'] }));
     const firstEntityId = vi.mocked(computeTaskId).mock.calls[0][0].entityId;
 
     vi.mocked(computeTaskId).mockClear();
-    await callImport(buildContext({ messageIds: ['1', '2', '3'] }));
+    await callImport(buildContext({ messageIds: ['1', '2', '3', '1'] }));
     const secondEntityId = vi.mocked(computeTaskId).mock.calls[0][0].entityId;
 
     expect(firstEntityId).toBe(secondEntityId);

--- a/apps/backend/src/apps/gateway/telegram-actions/routes/import/index.test.ts
+++ b/apps/backend/src/apps/gateway/telegram-actions/routes/import/index.test.ts
@@ -1,0 +1,108 @@
+import type { ImportTelegramArchiveOutput } from 'src/schema/telegram/import';
+import {
+  TaskEntityType,
+  TaskType,
+} from 'src/services/hasura/mutations/tasks/constants';
+import { computeTaskId, createCloudTasks } from 'src/utils/cloud-task';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { importTelegramArchive } from './index';
+
+const callImport = (context: unknown) =>
+  importTelegramArchive(context as any) as Promise<{
+    success: boolean;
+    message: string;
+    dataObject?: ImportTelegramArchiveOutput;
+  }>;
+
+vi.mock('src/utils/cloud-task', () => ({
+  createCloudTasks: vi.fn(),
+  computeTaskId: vi.fn(() => 'task-id-123'),
+}));
+
+vi.mock('src/utils/envConfig', () => ({
+  envConfig: { ioServiceUrl: 'https://io.example.test' },
+}));
+
+vi.mock('src/utils/logger', () => {
+  const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  return { getCurrentLogger: vi.fn(() => mockLogger) };
+});
+
+const USER_ID = '550e8400-e29b-41d4-a716-446655440001';
+
+const buildContext = (
+  overrides: Partial<{
+    channelId: string;
+    messageIds: string[];
+    userId: string;
+  }> = {},
+) => ({
+  validatedData: {
+    channelId: overrides.channelId ?? '-582839764',
+    messageIds: overrides.messageIds ?? ['3', '1', '2'],
+    userId: overrides.userId ?? USER_ID,
+  },
+});
+
+describe('importTelegramArchive', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(createCloudTasks).mockResolvedValue(undefined as any);
+    vi.mocked(computeTaskId).mockReturnValue('task-id-123');
+  });
+
+  it('enqueues a Cloud Task carrying the caller userId and returns its taskId', async () => {
+    const result = await callImport(buildContext());
+
+    expect(createCloudTasks).toHaveBeenCalledTimes(1);
+    const taskConfig = vi.mocked(createCloudTasks).mock.calls[0][0];
+    expect(taskConfig).toMatchObject({
+      audience: 'https://io.example.test',
+      url: 'https://io.example.test/telegram/import-handler',
+      entityType: TaskEntityType.TELEGRAM_ARCHIVE,
+      type: TaskType.IMPORT_TELEGRAM,
+      payload: {
+        data: {
+          channelId: '-582839764',
+          messageIds: ['3', '1', '2'],
+          userId: USER_ID,
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+    expect(result.dataObject?.taskId).toBe('task-id-123');
+  });
+
+  it('derives the idempotency entityId from a SORTED messageId set (order-independent)', async () => {
+    await callImport(buildContext({ messageIds: ['3', '1', '2'] }));
+    const firstEntityId = vi.mocked(computeTaskId).mock.calls[0][0].entityId;
+
+    vi.mocked(computeTaskId).mockClear();
+    await callImport(buildContext({ messageIds: ['1', '2', '3'] }));
+    const secondEntityId = vi.mocked(computeTaskId).mock.calls[0][0].entityId;
+
+    expect(firstEntityId).toBe(secondEntityId);
+  });
+
+  it('returns an error when the io service URL is missing', async () => {
+    const { envConfig } = await import('src/utils/envConfig');
+    (envConfig as { ioServiceUrl?: string }).ioServiceUrl = undefined;
+
+    const result = await callImport(buildContext());
+
+    expect(result.success).toBe(false);
+    expect(createCloudTasks).not.toHaveBeenCalled();
+
+    (envConfig as { ioServiceUrl?: string }).ioServiceUrl =
+      'https://io.example.test';
+  });
+
+  it('returns a failure when task creation throws', async () => {
+    vi.mocked(createCloudTasks).mockRejectedValue(new Error('queue down'));
+
+    const result = await callImport(buildContext());
+
+    expect(result.success).toBe(false);
+    expect(result.message).toBe('Failed to create import task');
+  });
+});

--- a/apps/backend/src/apps/gateway/telegram-actions/routes/import/index.ts
+++ b/apps/backend/src/apps/gateway/telegram-actions/routes/import/index.ts
@@ -33,6 +33,10 @@ const importTelegramArchive = async (
   }
 
   try {
+    // Canonicalize once: dedupe + sort so the same logical selection always maps
+    // to one idempotency key (['1','2','1'] and ['1','2'] must not diverge), and
+    // so we never forward duplicate IDs into the task payload.
+    const normalizedMessageIds = [...new Set(messageIds)].sort();
     // Idempotency key covers the exact message selection, not just the
     // channel — re-importing the same channel with a different set of
     // messageIds must NOT be deduped against a prior, unrelated import.
@@ -40,7 +44,7 @@ const importTelegramArchive = async (
       JSON.stringify({
         channelId,
         userId,
-        messageIds: [...messageIds].sort(),
+        messageIds: normalizedMessageIds,
       }),
       uuidNamespaces.cloudTask,
     );
@@ -60,7 +64,7 @@ const importTelegramArchive = async (
       audience: ioServiceUrl,
       queue: queues.telegramArchiveQueue,
       payload: {
-        data: { channelId, messageIds, userId },
+        data: { channelId, messageIds: normalizedMessageIds, userId },
         metadata,
       },
       url: `${ioServiceUrl}${IO_HANDLER_PATH}`,

--- a/apps/backend/src/apps/gateway/telegram-actions/routes/import/index.ts
+++ b/apps/backend/src/apps/gateway/telegram-actions/routes/import/index.ts
@@ -1,0 +1,84 @@
+import { nanoid } from 'nanoid';
+import type {
+  ImportTelegramArchiveOutput,
+  ImportTelegramArchiveRequest,
+} from 'src/schema/telegram/import';
+import {
+  TaskEntityType,
+  TaskType,
+} from 'src/services/hasura/mutations/tasks/constants';
+import {
+  type CreateCloudTasksParams,
+  computeTaskId,
+  createCloudTasks,
+} from 'src/utils/cloud-task';
+import { envConfig } from 'src/utils/envConfig';
+import { getCurrentLogger } from 'src/utils/logger';
+import type { HandlerContext } from 'src/utils/requestHandler';
+import { AppError, AppResponse } from 'src/utils/schema';
+import { queues, uuidNamespaces } from 'src/utils/systemConfig';
+import { v5 as uuidv5 } from 'uuid';
+
+const IO_HANDLER_PATH = '/telegram/import-handler';
+
+const importTelegramArchive = async (
+  context: HandlerContext<ImportTelegramArchiveRequest>,
+) => {
+  const logger = getCurrentLogger();
+  const { channelId, messageIds, userId } = context.validatedData;
+  const { ioServiceUrl } = envConfig;
+
+  if (!ioServiceUrl) {
+    return AppError('Missing io service URL');
+  }
+
+  try {
+    // Idempotency key covers the exact message selection, not just the
+    // channel — re-importing the same channel with a different set of
+    // messageIds must NOT be deduped against a prior, unrelated import.
+    const entityId = uuidv5(
+      JSON.stringify({
+        channelId,
+        userId,
+        messageIds: [...messageIds].sort(),
+      }),
+      uuidNamespaces.cloudTask,
+    );
+    const taskId = computeTaskId({
+      entityType: TaskEntityType.TELEGRAM_ARCHIVE,
+      entityId,
+      type: TaskType.IMPORT_TELEGRAM,
+    });
+
+    const metadata = {
+      id: nanoid(),
+      spanId: nanoid(),
+      traceId: nanoid(),
+    };
+
+    const taskConfig: CreateCloudTasksParams = {
+      audience: ioServiceUrl,
+      queue: queues.telegramArchiveQueue,
+      payload: {
+        data: { channelId, messageIds, userId },
+        metadata,
+      },
+      url: `${ioServiceUrl}${IO_HANDLER_PATH}`,
+      entityId,
+      entityType: TaskEntityType.TELEGRAM_ARCHIVE,
+      type: TaskType.IMPORT_TELEGRAM,
+    };
+
+    await createCloudTasks(taskConfig);
+
+    return AppResponse<ImportTelegramArchiveOutput>(true, 'ok', { taskId });
+  } catch (error) {
+    logger.error(
+      { error, channelId, messageIds },
+      '[importTelegramArchive] failed to create task',
+    );
+    return AppError('Failed to create import task');
+  }
+};
+
+export { importTelegramArchive };

--- a/apps/backend/src/apps/gateway/telegram-actions/routes/list/index.test.ts
+++ b/apps/backend/src/apps/gateway/telegram-actions/routes/list/index.test.ts
@@ -1,0 +1,176 @@
+import type { ListTelegramChannelVideosOutput } from 'src/schema/telegram/list';
+import { getTelegramClient } from 'src/services/telegram/client';
+import { TelegramNotAuthenticatedError } from 'src/services/telegram/errors';
+import { Api } from 'teleproto';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { listTelegramChannelVideos } from './index';
+
+// The handler's real return type is a union across its success/error branches;
+// narrowing it here keeps every `result.dataObject` access below type-safe.
+const callList = (context: unknown) =>
+  listTelegramChannelVideos(context as any) as Promise<{
+    success: boolean;
+    message: string;
+    dataObject?: ListTelegramChannelVideosOutput;
+  }>;
+
+const mockClient = {
+  getInputEntity: vi.fn(),
+  getMessages: vi.fn(),
+  downloadMedia: vi.fn(),
+  disconnect: vi.fn(),
+};
+
+vi.mock('src/services/telegram/client', () => ({
+  getTelegramClient: vi.fn(),
+}));
+
+vi.mock('src/utils/logger', () => {
+  const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  return { getCurrentLogger: vi.fn(() => mockLogger) };
+});
+
+const USER_ID = '550e8400-e29b-41d4-a716-446655440001';
+
+const buildVideoMessage = (overrides: Record<string, unknown> = {}) => ({
+  id: 1,
+  date: 1_700_000_000,
+  message: 'a caption',
+  video: {
+    size: 123_456n,
+    thumbs: [{}],
+    attributes: [
+      new Api.DocumentAttributeFilename({ fileName: 'clip.mp4' }),
+      new Api.DocumentAttributeVideo({
+        duration: 42.5,
+        w: 100,
+        h: 100,
+        supportsStreaming: true,
+      }),
+    ],
+  },
+  ...overrides,
+});
+
+const buildContext = (
+  overrides: Partial<{
+    channelId: string;
+    cursor: string;
+    userId: string;
+  }> = {},
+) => ({
+  validatedData: {
+    channelId: overrides.channelId ?? '-582839764',
+    cursor: overrides.cursor,
+    userId: overrides.userId ?? USER_ID,
+  },
+});
+
+describe('listTelegramChannelVideos', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getTelegramClient).mockResolvedValue(mockClient as any);
+    mockClient.getInputEntity.mockResolvedValue({ resolved: true });
+    mockClient.downloadMedia.mockResolvedValue(
+      Buffer.from('thumb-bytes', 'utf8'),
+    );
+    mockClient.disconnect.mockResolvedValue(undefined);
+  });
+
+  it('resolves the client from the session userId, maps videos, and derives a nextCursor when the page is full', async () => {
+    const messages = Array.from({ length: 20 }, (_, i) =>
+      buildVideoMessage({ id: i + 1 }),
+    );
+    mockClient.getMessages.mockResolvedValue(messages);
+
+    const result = await callList(buildContext());
+
+    // Per-user client — built from the session userId, never a request-body value.
+    expect(getTelegramClient).toHaveBeenCalledWith(USER_ID);
+    expect(mockClient.getInputEntity).toHaveBeenCalledWith('-582839764');
+    expect(mockClient.getMessages).toHaveBeenCalledWith(
+      { resolved: true },
+      expect.objectContaining({
+        limit: 20,
+        offsetId: undefined,
+        filter: expect.any(Api.InputMessagesFilterVideo),
+      }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.dataObject?.videos).toHaveLength(20);
+    expect(result.dataObject?.videos[0]).toMatchObject({
+      id: '1',
+      filename: 'clip.mp4',
+      caption: 'a caption',
+      durationSeconds: 42.5,
+      sizeBytes: 123456,
+      thumbnailDataUri: expect.stringMatching(/^data:image\/jpeg;base64,/),
+    });
+    expect(result.dataObject?.nextCursor).toBe('20');
+    // Connected client is always closed.
+    expect(mockClient.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits nextCursor when the page is not full and passes the cursor as offsetId', async () => {
+    mockClient.getMessages.mockResolvedValue([buildVideoMessage({ id: 7 })]);
+
+    const result = await callList(buildContext({ cursor: '99' }));
+
+    expect(mockClient.getMessages).toHaveBeenCalledWith(
+      { resolved: true },
+      expect.objectContaining({ offsetId: 99 }),
+    );
+    expect(result.dataObject?.nextCursor).toBeUndefined();
+  });
+
+  it('skips non-video messages and tolerates thumbnail-download failures', async () => {
+    mockClient.getMessages.mockResolvedValue([
+      buildVideoMessage({ id: 1 }),
+      { id: 2, date: 1_700_000_000, video: undefined },
+    ]);
+    mockClient.downloadMedia.mockRejectedValueOnce(new Error('thumb boom'));
+
+    const result = await callList(buildContext());
+
+    expect(result.success).toBe(true);
+    expect(result.dataObject?.videos).toHaveLength(1);
+    expect(result.dataObject?.videos[0].thumbnailDataUri).toBeUndefined();
+    expect(mockClient.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps a missing session to the NO_SESSION code so the popup shows the login prompt', async () => {
+    vi.mocked(getTelegramClient).mockRejectedValue(
+      new TelegramNotAuthenticatedError(USER_ID),
+    );
+
+    const result = await callList(buildContext());
+
+    expect(result.success).toBe(false);
+    expect(result.message).toBe('NO_SESSION');
+    expect(result.dataObject).toBeUndefined();
+    // No client was returned, so nothing to disconnect.
+    expect(mockClient.disconnect).not.toHaveBeenCalled();
+  });
+
+  it('returns a generic failure for an unexpected error and still disconnects', async () => {
+    mockClient.getMessages.mockRejectedValue(new Error('mtproto exploded'));
+
+    const result = await callList(buildContext());
+
+    expect(result.success).toBe(false);
+    expect(result.message).toBe('Failed to fetch channel videos');
+    expect(mockClient.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses each caller their OWN client — no cross-user leakage', async () => {
+    const otherUser = '660e8400-e29b-41d4-a716-446655440002';
+    mockClient.getMessages.mockResolvedValue([]);
+
+    await callList(buildContext());
+    await callList(buildContext({ userId: otherUser }));
+
+    expect(getTelegramClient).toHaveBeenNthCalledWith(1, USER_ID);
+    expect(getTelegramClient).toHaveBeenNthCalledWith(2, otherUser);
+  });
+});

--- a/apps/backend/src/apps/gateway/telegram-actions/routes/list/index.ts
+++ b/apps/backend/src/apps/gateway/telegram-actions/routes/list/index.ts
@@ -1,0 +1,129 @@
+import type {
+  ListTelegramChannelVideosOutput,
+  ListTelegramChannelVideosRequest,
+  TelegramVideoMessage,
+} from 'src/schema/telegram/list';
+import { getTelegramClient } from 'src/services/telegram/client';
+import { getCurrentLogger } from 'src/utils/logger';
+import type { HandlerContext } from 'src/utils/requestHandler';
+import { AppError, AppResponse } from 'src/utils/schema';
+import { Api, type TelegramClient } from 'teleproto';
+import { toTelegramActionErrorCode } from '../../errors';
+
+const PAGE_SIZE = 20;
+// Index into a document's `thumbs` array — 0 is Telegram's smallest embedded
+// preview, a few KB, cheap enough to fetch fresh on every list call.
+const THUMB_INDEX = 0;
+
+const buildVideoMessage = async (
+  client: TelegramClient,
+  message: Api.Message,
+): Promise<TelegramVideoMessage | null> => {
+  const video = message.video;
+  if (!video) {
+    return null;
+  }
+
+  const filenameAttr = video.attributes.find(
+    (attr): attr is Api.DocumentAttributeFilename =>
+      attr instanceof Api.DocumentAttributeFilename,
+  );
+  const videoAttr = video.attributes.find(
+    (attr): attr is Api.DocumentAttributeVideo =>
+      attr instanceof Api.DocumentAttributeVideo,
+  );
+
+  let thumbnailDataUri: string | undefined;
+  if (video.thumbs?.length) {
+    try {
+      const thumb = await client.downloadMedia(message, {
+        thumb: THUMB_INDEX,
+      });
+      if (Buffer.isBuffer(thumb)) {
+        thumbnailDataUri = `data:image/jpeg;base64,${thumb.toString('base64')}`;
+      }
+    } catch (error) {
+      getCurrentLogger().warn(
+        { error, messageId: message.id },
+        '[listTelegramChannelVideos] failed to fetch thumbnail',
+      );
+    }
+  }
+
+  return {
+    id: String(message.id),
+    filename: filenameAttr?.fileName,
+    caption: message.message || undefined,
+    date: new Date(message.date * 1000).toISOString(),
+    sizeBytes: video.size ? Number(video.size) : undefined,
+    durationSeconds: videoAttr?.duration,
+    thumbnailDataUri,
+  };
+};
+
+const listTelegramChannelVideos = async (
+  context: HandlerContext<ListTelegramChannelVideosRequest>,
+) => {
+  const logger = getCurrentLogger();
+  const { channelId, cursor, userId } = context.validatedData;
+
+  // Per-user client (SWO-491): built from the caller's OWN stored session and
+  // returned already connected — the caller owns disconnect(). userId comes from
+  // the validated session variables, never the request body.
+  let client: TelegramClient | undefined;
+  try {
+    // Bind to a non-optional local so the map closure below doesn't need a
+    // non-null assertion; `client` still holds the same instance for finally.
+    const connected = await getTelegramClient(userId);
+    client = connected;
+
+    // Resolves channelId the same way Telegram's own client libraries do —
+    // handles a numeric (possibly negative/"marked") peer id or a username
+    // string identically, so callers never need to know which form they hold.
+    const entity = await connected.getInputEntity(channelId);
+
+    const messages = await connected.getMessages(entity, {
+      limit: PAGE_SIZE,
+      offsetId: cursor ? Number(cursor) : undefined,
+      filter: new Api.InputMessagesFilterVideo(),
+    });
+
+    const videos = (
+      await Promise.all(
+        messages.map((message) => buildVideoMessage(connected, message)),
+      )
+    ).filter((video): video is TelegramVideoMessage => video !== null);
+
+    const nextCursor =
+      messages.length === PAGE_SIZE
+        ? String(messages[messages.length - 1].id)
+        : undefined;
+
+    return AppResponse<ListTelegramChannelVideosOutput>(true, 'ok', {
+      videos,
+      nextCursor,
+    });
+  } catch (error) {
+    // A recognised TelegramError is expected control-flow (most importantly
+    // NO_SESSION → the popup shows the login prompt); surface its stable code in
+    // `message` and don't error-log it. Anything else is unexpected — log and
+    // return a generic failure.
+    const code = toTelegramActionErrorCode(error);
+    if (code) {
+      return AppError(code);
+    }
+    logger.error(
+      { error, channelId },
+      '[listTelegramChannelVideos] failed to fetch channel videos',
+    );
+    return AppError('Failed to fetch channel videos');
+  } finally {
+    // getTelegramClient hands us a connected client to close; swallow a
+    // disconnect failure so it can't mask a real error from the try block.
+    if (client) {
+      await client.disconnect().catch(() => {});
+    }
+  }
+};
+
+export { listTelegramChannelVideos };

--- a/apps/backend/src/apps/gateway/telegram-actions/routes/request-login-code/index.test.ts
+++ b/apps/backend/src/apps/gateway/telegram-actions/routes/request-login-code/index.test.ts
@@ -1,0 +1,68 @@
+import {
+  TelegramMisconfiguredError,
+  TelegramNotProvisionedError,
+} from 'src/services/telegram/errors';
+import { requestLoginCode } from 'src/services/telegram/login';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { requestTelegramLoginCode } from './index';
+
+const call = (context: unknown) =>
+  requestTelegramLoginCode(context as any) as Promise<{
+    success: boolean;
+    message: string;
+  }>;
+
+vi.mock('src/services/telegram/login', () => ({
+  requestLoginCode: vi.fn(),
+}));
+
+vi.mock('src/utils/logger', () => {
+  const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  return { getCurrentLogger: vi.fn(() => mockLogger) };
+});
+
+const USER_ID = '550e8400-e29b-41d4-a716-446655440001';
+const ctx = (userId = USER_ID) => ({ validatedData: { userId } });
+
+describe('requestTelegramLoginCode', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('requests a login code for the session user and reports success', async () => {
+    vi.mocked(requestLoginCode).mockResolvedValue(undefined);
+
+    const result = await call(ctx());
+
+    expect(requestLoginCode).toHaveBeenCalledWith(USER_ID);
+    expect(result.success).toBe(true);
+  });
+
+  it('maps a missing credentials row to NOT_PROVISIONED', async () => {
+    vi.mocked(requestLoginCode).mockRejectedValue(
+      new TelegramNotProvisionedError(USER_ID),
+    );
+
+    const result = await call(ctx());
+
+    expect(result.success).toBe(false);
+    expect(result.message).toBe('NOT_PROVISIONED');
+  });
+
+  it('maps a malformed row to MISCONFIGURED', async () => {
+    vi.mocked(requestLoginCode).mockRejectedValue(
+      new TelegramMisconfiguredError(USER_ID),
+    );
+
+    const result = await call(ctx());
+
+    expect(result.message).toBe('MISCONFIGURED');
+  });
+
+  it('returns a generic failure for an unexpected error', async () => {
+    vi.mocked(requestLoginCode).mockRejectedValue(new Error('boom'));
+
+    const result = await call(ctx());
+
+    expect(result.success).toBe(false);
+    expect(result.message).toBe('Failed to request login code');
+  });
+});

--- a/apps/backend/src/apps/gateway/telegram-actions/routes/request-login-code/index.ts
+++ b/apps/backend/src/apps/gateway/telegram-actions/routes/request-login-code/index.ts
@@ -1,0 +1,30 @@
+import type { RequestTelegramLoginCodeRequest } from 'src/schema/telegram/request-login-code';
+import { requestLoginCode } from 'src/services/telegram/login';
+import { getCurrentLogger } from 'src/utils/logger';
+import type { HandlerContext } from 'src/utils/requestHandler';
+import { AppError, AppResponse } from 'src/utils/schema';
+import { toTelegramActionErrorCode } from '../../errors';
+
+// Step 1 of the in-product login: ask Telegram to send a code to the user's own
+// device. No dataObject — success just means "code requested" (the response type
+// is { success, message }); Telegram delivers the code out-of-band.
+const requestTelegramLoginCode = async (
+  context: HandlerContext<RequestTelegramLoginCodeRequest>,
+) => {
+  const logger = getCurrentLogger();
+  const { userId } = context.validatedData;
+
+  try {
+    await requestLoginCode(userId);
+    return AppResponse(true, 'Login code sent');
+  } catch (error) {
+    const code = toTelegramActionErrorCode(error);
+    if (code) {
+      return AppError(code);
+    }
+    logger.error({ error }, '[requestTelegramLoginCode] failed');
+    return AppError('Failed to request login code');
+  }
+};
+
+export { requestTelegramLoginCode };

--- a/apps/backend/src/apps/gateway/telegram-actions/routes/submit-login-code/index.test.ts
+++ b/apps/backend/src/apps/gateway/telegram-actions/routes/submit-login-code/index.test.ts
@@ -1,0 +1,74 @@
+import {
+  TelegramCodeExpiredError,
+  TelegramInvalidCodeError,
+  TelegramLoginNotStartedError,
+} from 'src/services/telegram/errors';
+import { submitLoginCode } from 'src/services/telegram/login';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { submitTelegramLoginCode } from './index';
+
+const call = (context: unknown) =>
+  submitTelegramLoginCode(context as any) as Promise<{
+    success: boolean;
+    message: string;
+  }>;
+
+vi.mock('src/services/telegram/login', () => ({
+  submitLoginCode: vi.fn(),
+}));
+
+vi.mock('src/utils/logger', () => {
+  const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  return { getCurrentLogger: vi.fn(() => mockLogger) };
+});
+
+const USER_ID = '550e8400-e29b-41d4-a716-446655440001';
+const ctx = (code = '12345', userId = USER_ID) => ({
+  validatedData: { code, userId },
+});
+
+describe('submitTelegramLoginCode', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('completes login for the session user with the submitted code', async () => {
+    vi.mocked(submitLoginCode).mockResolvedValue(undefined);
+
+    const result = await call(ctx('99887'));
+
+    expect(submitLoginCode).toHaveBeenCalledWith(USER_ID, '99887');
+    expect(result.success).toBe(true);
+  });
+
+  it('maps a wrong code to INVALID_CODE (re-promptable)', async () => {
+    vi.mocked(submitLoginCode).mockRejectedValue(
+      new TelegramInvalidCodeError(USER_ID),
+    );
+
+    const result = await call(ctx());
+
+    expect(result.success).toBe(false);
+    expect(result.message).toBe('INVALID_CODE');
+  });
+
+  it('maps an aged-out code to CODE_EXPIRED', async () => {
+    vi.mocked(submitLoginCode).mockRejectedValue(
+      new TelegramCodeExpiredError(USER_ID),
+    );
+
+    expect((await call(ctx())).message).toBe('CODE_EXPIRED');
+  });
+
+  it('maps submit-before-request to LOGIN_NOT_STARTED', async () => {
+    vi.mocked(submitLoginCode).mockRejectedValue(
+      new TelegramLoginNotStartedError(USER_ID),
+    );
+
+    expect((await call(ctx())).message).toBe('LOGIN_NOT_STARTED');
+  });
+
+  it('returns a generic failure for an unexpected error', async () => {
+    vi.mocked(submitLoginCode).mockRejectedValue(new Error('boom'));
+
+    expect((await call(ctx())).message).toBe('Failed to submit login code');
+  });
+});

--- a/apps/backend/src/apps/gateway/telegram-actions/routes/submit-login-code/index.ts
+++ b/apps/backend/src/apps/gateway/telegram-actions/routes/submit-login-code/index.ts
@@ -1,0 +1,31 @@
+import type { SubmitTelegramLoginCodeRequest } from 'src/schema/telegram/submit-login-code';
+import { submitLoginCode } from 'src/services/telegram/login';
+import { getCurrentLogger } from 'src/utils/logger';
+import type { HandlerContext } from 'src/utils/requestHandler';
+import { AppError, AppResponse } from 'src/utils/schema';
+import { toTelegramActionErrorCode } from '../../errors';
+
+// Step 2 of the in-product login: complete sign-in with the code the user
+// received. On success the caller's row becomes "ready" (session_string set) and
+// the popup switches to the picker. No dataObject — the response is
+// { success, message }; a wrong/expired code surfaces as a stable error code.
+const submitTelegramLoginCode = async (
+  context: HandlerContext<SubmitTelegramLoginCodeRequest>,
+) => {
+  const logger = getCurrentLogger();
+  const { code, userId } = context.validatedData;
+
+  try {
+    await submitLoginCode(userId, code);
+    return AppResponse(true, 'Logged in');
+  } catch (error) {
+    const errorCode = toTelegramActionErrorCode(error);
+    if (errorCode) {
+      return AppError(errorCode);
+    }
+    logger.error({ error }, '[submitTelegramLoginCode] failed');
+    return AppError('Failed to submit login code');
+  }
+};
+
+export { submitTelegramLoginCode };

--- a/apps/backend/src/gateway.test.ts
+++ b/apps/backend/src/gateway.test.ts
@@ -63,6 +63,10 @@ vi.mock('./apps/gateway/videos-actions', () => ({
   videoActionsRouter: 'mockVideoActionsRouter',
 }));
 
+vi.mock('./apps/gateway/telegram-actions', () => ({
+  telegramActionsRouter: 'mockTelegramActionsRouter',
+}));
+
 vi.mock('./apps/gateway/hashnode', () => ({
   hashnodeRouter: 'mockHashnodeRouter',
 }));
@@ -151,6 +155,10 @@ describe('Gateway Application', () => {
 
   it('should register all routers', () => {
     expect(mockRoute).toHaveBeenCalledWith('/videos', 'mockVideosRouter');
+    expect(mockRoute).toHaveBeenCalledWith(
+      '/telegram-actions',
+      'mockTelegramActionsRouter',
+    );
     expect(mockRoute).toHaveBeenCalledWith(
       '/videos-actions',
       'mockVideoActionsRouter',

--- a/apps/backend/src/gateway.ts
+++ b/apps/backend/src/gateway.ts
@@ -11,8 +11,9 @@ import { rateLimiter } from 'hono-rate-limiter';
 import { authRouter } from './apps/gateway/auth';
 import { hashnodeRouter } from './apps/gateway/hashnode';
 import { storageRouter } from './apps/gateway/storage';
-import { videoActionsRouter } from './apps/gateway/videos-actions';
+import { telegramActionsRouter } from './apps/gateway/telegram-actions';
 import { videosRouter } from './apps/gateway/videos';
+import { videoActionsRouter } from './apps/gateway/videos-actions';
 import { envConfig } from './utils/envConfig';
 import { createHonoLoggingMiddleware, getCurrentLogger } from './utils/logger';
 import type { Env } from './utils/types/context';
@@ -68,6 +69,7 @@ app.get('/hz', (c) => {
 
 app.route('/videos', videosRouter);
 app.route('/videos-actions', videoActionsRouter);
+app.route('/telegram-actions', telegramActionsRouter);
 app.route('/hashnode', hashnodeRouter);
 app.route('/auth', authRouter);
 app.route('/storage', storageRouter);

--- a/apps/backend/src/schema/telegram/import/index.ts
+++ b/apps/backend/src/schema/telegram/import/index.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+
+// Validates the Hasura action payload for `importTelegramArchive`. `userId` comes
+// from the session, never the request body — same rule as `setThumbnailAtTime`.
+const importTelegramArchiveSchema = z
+  .object({
+    body: z.object({
+      action: z.object({ name: z.string() }),
+      input: z.object({
+        input: z.object({
+          channelId: z.string().min(1),
+          messageIds: z.array(z.string().min(1)).min(1),
+        }),
+      }),
+      session_variables: z.looseObject({ 'x-hasura-user-id': z.guid() }),
+    }),
+  })
+  .transform((req) => ({
+    channelId: req.body.input.input.channelId,
+    messageIds: req.body.input.input.messageIds,
+    userId: req.body.session_variables['x-hasura-user-id'],
+  }));
+
+type ImportTelegramArchiveRequest = z.infer<typeof importTelegramArchiveSchema>;
+
+interface ImportTelegramArchiveOutput {
+  taskId: string;
+}
+
+export {
+  importTelegramArchiveSchema,
+  type ImportTelegramArchiveRequest,
+  type ImportTelegramArchiveOutput,
+};

--- a/apps/backend/src/schema/telegram/list/index.ts
+++ b/apps/backend/src/schema/telegram/list/index.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod';
+
+// Validates the Hasura action payload for `listTelegramChannelVideos`. Args arrive
+// under `input.input`; `userId` comes from the session, NEVER the request body —
+// the Telegram MTProto session used to fetch history is always the caller's own.
+const listTelegramChannelVideosSchema = z
+  .object({
+    body: z.object({
+      action: z.object({ name: z.string() }),
+      input: z.object({
+        input: z.object({
+          channelId: z.string().min(1),
+          cursor: z.string().optional(),
+        }),
+      }),
+      session_variables: z.looseObject({ 'x-hasura-user-id': z.guid() }),
+    }),
+  })
+  .transform((req) => ({
+    channelId: req.body.input.input.channelId,
+    cursor: req.body.input.input.cursor,
+    userId: req.body.session_variables['x-hasura-user-id'],
+  }));
+
+type ListTelegramChannelVideosRequest = z.infer<
+  typeof listTelegramChannelVideosSchema
+>;
+
+// Mirrors `TelegramVideoMessage` in sworld-hasura-v2's actions.graphql (SWO-493).
+interface TelegramVideoMessage {
+  id: string;
+  filename?: string;
+  caption?: string;
+  date: string;
+  sizeBytes?: number;
+  durationSeconds?: number;
+  thumbnailDataUri?: string;
+}
+
+interface ListTelegramChannelVideosOutput {
+  videos: TelegramVideoMessage[];
+  nextCursor?: string;
+}
+
+export {
+  listTelegramChannelVideosSchema,
+  type ListTelegramChannelVideosRequest,
+  type TelegramVideoMessage,
+  type ListTelegramChannelVideosOutput,
+};

--- a/apps/backend/src/schema/telegram/list/index.ts
+++ b/apps/backend/src/schema/telegram/list/index.ts
@@ -10,7 +10,13 @@ const listTelegramChannelVideosSchema = z
       input: z.object({
         input: z.object({
           channelId: z.string().min(1),
-          cursor: z.string().optional(),
+          // A Telegram message ID, forwarded as `offsetId` to getMessages. Must
+          // be a positive integer string — `Number('abc')` would otherwise hand
+          // NaN to the MTProto call.
+          cursor: z
+            .string()
+            .regex(/^[1-9]\d*$/)
+            .optional(),
         }),
       }),
       session_variables: z.looseObject({ 'x-hasura-user-id': z.guid() }),

--- a/apps/backend/src/schema/telegram/request-login-code/index.ts
+++ b/apps/backend/src/schema/telegram/request-login-code/index.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+// Validates the Hasura action payload for `requestTelegramLoginCode`. There is no
+// input beyond the caller: the phone/api_id/api_hash used for `sendCode` are read
+// from the calling user's own telegram_credentials row. `userId` comes from the
+// session, NEVER the request body — the login always targets the caller's account.
+const requestTelegramLoginCodeSchema = z
+  .object({
+    body: z.object({
+      action: z.object({ name: z.string() }),
+      session_variables: z.looseObject({ 'x-hasura-user-id': z.guid() }),
+    }),
+  })
+  .transform((req) => ({
+    userId: req.body.session_variables['x-hasura-user-id'],
+  }));
+
+type RequestTelegramLoginCodeRequest = z.infer<
+  typeof requestTelegramLoginCodeSchema
+>;
+
+export { requestTelegramLoginCodeSchema, type RequestTelegramLoginCodeRequest };

--- a/apps/backend/src/schema/telegram/submit-login-code/index.ts
+++ b/apps/backend/src/schema/telegram/submit-login-code/index.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+// Validates the Hasura action payload for `submitTelegramLoginCode`. The login
+// `code` arrives under `input.input` (the code Telegram sent to the user's own
+// device); `userId` comes from the session, NEVER the request body — the code is
+// only ever completed against the caller's own pending login.
+const submitTelegramLoginCodeSchema = z
+  .object({
+    body: z.object({
+      action: z.object({ name: z.string() }),
+      input: z.object({
+        input: z.object({
+          code: z.string().min(1),
+        }),
+      }),
+      session_variables: z.looseObject({ 'x-hasura-user-id': z.guid() }),
+    }),
+  })
+  .transform((req) => ({
+    code: req.body.input.input.code,
+    userId: req.body.session_variables['x-hasura-user-id'],
+  }));
+
+type SubmitTelegramLoginCodeRequest = z.infer<
+  typeof submitTelegramLoginCodeSchema
+>;
+
+export { submitTelegramLoginCodeSchema, type SubmitTelegramLoginCodeRequest };

--- a/apps/backend/src/schema/telegram/task-payload/index.ts
+++ b/apps/backend/src/schema/telegram/task-payload/index.ts
@@ -1,0 +1,38 @@
+import { taskHandlerHeaderSchema } from 'src/utils/cloud-task/schema';
+import { z } from 'zod';
+
+// Shared shape for the Cloud Task gateway's `import` route enqueues and io's
+// import handler validates — keeps both sides of the hop in lockstep.
+const telegramImportTaskDataSchema = z.object({
+  channelId: z.string().min(1),
+  messageIds: z.array(z.string().min(1)).min(1),
+  userId: z.guid(),
+});
+
+const telegramImportTaskMetadataSchema = z.object({
+  id: z.string(),
+  spanId: z.string(),
+  traceId: z.string(),
+});
+
+const telegramImportTaskPayloadSchema = z.object({
+  data: telegramImportTaskDataSchema,
+  metadata: telegramImportTaskMetadataSchema,
+});
+
+const telegramImportHandlerSchema = z.object({
+  headers: z.looseObject(taskHandlerHeaderSchema.shape),
+  body: telegramImportTaskPayloadSchema,
+});
+
+type TelegramImportTaskPayload = z.infer<
+  typeof telegramImportTaskPayloadSchema
+>;
+type TelegramImportHandlerRequest = z.infer<typeof telegramImportHandlerSchema>;
+
+export {
+  telegramImportTaskPayloadSchema,
+  telegramImportHandlerSchema,
+  type TelegramImportTaskPayload,
+  type TelegramImportHandlerRequest,
+};

--- a/apps/backend/src/utils/cloud-task.test.ts
+++ b/apps/backend/src/utils/cloud-task.test.ts
@@ -421,3 +421,30 @@ describe('createCloudTasks', () => {
     );
   });
 });
+
+describe('computeTaskId', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('hashes (entityType, entityId, type) under the cloudTask namespace', async () => {
+    const { v5 } = await import('uuid');
+    const { computeTaskId } = await import('./cloud-task');
+
+    const taskId = computeTaskId({
+      entityType: TaskEntityType.TELEGRAM_ARCHIVE,
+      entityId: 'entity-1',
+      type: TaskType.IMPORT_TELEGRAM,
+    });
+
+    expect(taskId).toBe('mock-uuid');
+    expect(v5).toHaveBeenCalledWith(
+      JSON.stringify({
+        entityType: TaskEntityType.TELEGRAM_ARCHIVE,
+        entityId: 'entity-1',
+        type: TaskType.IMPORT_TELEGRAM,
+      }),
+      'test-namespace',
+    );
+  });
+});

--- a/apps/backend/src/utils/cloud-task.ts
+++ b/apps/backend/src/utils/cloud-task.ts
@@ -53,6 +53,22 @@ interface CreateCloudTasksParams {
 
 type CloudTask = protos.google.cloud.tasks.v2.ITask;
 
+type ComputeTaskIdParams = Pick<
+  CreateCloudTasksParams,
+  'entityType' | 'entityId' | 'type'
+>;
+
+/**
+ * Derives the same deterministic task id `createCloudTasks` uses internally —
+ * lets a caller learn the id up front (e.g. to return it from an Action's
+ * response) without duplicating the hashing formula.
+ */
+const computeTaskId = ({ entityType, entityId, type }: ComputeTaskIdParams) =>
+  uuidv5(
+    JSON.stringify({ entityType, entityId, type }),
+    uuidNamespaces.cloudTask,
+  );
+
 /**
  * Creates a new Cloud Task with the specified parameters
  * @param {CreateCloudTasksParams} params - Parameters for creating the task
@@ -87,10 +103,7 @@ const createCloudTasks = async (
 
   const client = getCloudTasksClient();
   const parent = client.queuePath(projectId, location, queue);
-  const taskId = uuidv5(
-    JSON.stringify({ entityType, entityId, type }),
-    uuidNamespaces.cloudTask,
-  );
+  const taskId = computeTaskId({ entityType, entityId, type });
 
   try {
     const dbTask = await createTask({
@@ -171,4 +184,4 @@ const createCloudTasks = async (
   }
 };
 
-export { type CreateCloudTasksParams, createCloudTasks };
+export { type CreateCloudTasksParams, createCloudTasks, computeTaskId };

--- a/apps/backend/src/utils/validators/request.test.ts
+++ b/apps/backend/src/utils/validators/request.test.ts
@@ -236,4 +236,45 @@ describe('honoValidateRequest', () => {
     expect(logged.result.data.code).toBe('[REDACTED]');
     expect(logged.result.data.userId).toBe('user-123');
   });
+
+  it('redacts standard credential fields even when nested, leaving other fields intact', async () => {
+    mockLogger.info.mockClear();
+    // Passthrough schema so the deep-nested secrets survive into result.data.
+    const passthroughSchema = z.object({
+      headers: z.looseObject({}),
+      body: z.looseObject({}),
+      params: z.record(z.string(), z.string()),
+      query: z.record(z.string(), z.any()),
+    });
+
+    const mockContext = {
+      req: {
+        json: vi.fn().mockResolvedValue({
+          user: { name: 'ok', accessToken: 'at-secret' },
+          nested: { deep: { refresh_token: 'rt-secret' } },
+        }),
+        url: 'http://example.com',
+        raw: {
+          headers: new Headers({
+            authorization: 'Bearer super-secret',
+            cookie: 'session=abc',
+            'x-request-id': 'keep-me',
+          }),
+        },
+        param: () => ({}),
+      },
+      json: vi.fn(),
+      set: vi.fn(),
+    } as unknown as Context;
+
+    await honoValidateRequest(passthroughSchema)(mockContext, vi.fn() as Next);
+
+    const logged = mockLogger.info.mock.calls[0][0].result.data;
+    expect(logged.headers.authorization).toBe('[REDACTED]');
+    expect(logged.headers.cookie).toBe('[REDACTED]');
+    expect(logged.headers['x-request-id']).toBe('keep-me');
+    expect(logged.body.user.accessToken).toBe('[REDACTED]');
+    expect(logged.body.user.name).toBe('ok');
+    expect(logged.body.nested.deep.refresh_token).toBe('[REDACTED]');
+  });
 });

--- a/apps/backend/src/utils/validators/request.test.ts
+++ b/apps/backend/src/utils/validators/request.test.ts
@@ -7,6 +7,11 @@ import {
   type ValidationContext,
 } from './request';
 
+const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+vi.mock('../logger', () => ({
+  getCurrentLogger: () => mockLogger,
+}));
+
 describe('validateData', () => {
   const testSchema = z.object({
     body: z.object({
@@ -198,5 +203,37 @@ describe('honoValidateRequest', () => {
       },
       400,
     );
+  });
+
+  it('redacts secret-keyed fields (a login code) from the log but keeps them in validatedData', async () => {
+    mockLogger.info.mockClear();
+    // Mirrors the submit-login-code schema: transform emits { code, userId }.
+    const secretSchema = z
+      .object({ body: z.object({ code: z.string() }) })
+      .transform((req) => ({ code: req.body.code, userId: 'user-123' }));
+
+    const mockContext = {
+      req: {
+        json: vi.fn().mockResolvedValue({ code: '12345' }),
+        url: 'http://example.com',
+        raw: { headers: new Headers() },
+        param: () => ({}),
+      },
+      json: vi.fn(),
+      set: vi.fn(),
+    } as unknown as Context;
+
+    const mockNext = vi.fn() as Next;
+    await honoValidateRequest(secretSchema)(mockContext, mockNext);
+
+    // The handler still receives the real code…
+    expect(mockContext.set).toHaveBeenCalledWith('validatedData', {
+      code: '12345',
+      userId: 'user-123',
+    });
+    // …but the logged copy masks it.
+    const logged = mockLogger.info.mock.calls[0][0];
+    expect(logged.result.data.code).toBe('[REDACTED]');
+    expect(logged.result.data.userId).toBe('user-123');
   });
 });

--- a/apps/backend/src/utils/validators/request.ts
+++ b/apps/backend/src/utils/validators/request.ts
@@ -83,14 +83,26 @@ const formatZodError = (error: ZodError): string => {
 // untouched. Matched case-insensitively so `code`, `sessionString`, `api_hash`
 // etc. are all covered.
 const SENSITIVE_KEYS = new Set([
+  'authorization',
+  'cookie',
+  'set-cookie',
   'code',
+  'phonecodehash',
+  'phone_code_hash',
   'sessionstring',
   'session_string',
   'pendingsessionstring',
   'pending_session_string',
   'apihash',
   'api_hash',
+  'apikey',
+  'api_key',
   'password',
+  'token',
+  'accesstoken',
+  'access_token',
+  'refreshtoken',
+  'refresh_token',
 ]);
 
 // Deep-clone `value`, replacing any secret-keyed field with a redaction marker.

--- a/apps/backend/src/utils/validators/request.ts
+++ b/apps/backend/src/utils/validators/request.ts
@@ -76,6 +76,41 @@ const formatZodError = (error: ZodError): string => {
     .join(', ');
 };
 
+// Keys whose values are secrets and must never reach the logs. The validated
+// payload is logged for debugging (see below); a login `code` is a live Telegram
+// OTP and `sessionString`/`apiHash` are password-equivalent, so they are masked
+// in the logged copy only — the real `validatedData` handed to the handler is
+// untouched. Matched case-insensitively so `code`, `sessionString`, `api_hash`
+// etc. are all covered.
+const SENSITIVE_KEYS = new Set([
+  'code',
+  'sessionstring',
+  'session_string',
+  'pendingsessionstring',
+  'pending_session_string',
+  'apihash',
+  'api_hash',
+  'password',
+]);
+
+// Deep-clone `value`, replacing any secret-keyed field with a redaction marker.
+// Used only to build the copy that gets logged — never mutates the input.
+const redactSensitive = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(redactSensitive);
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, val]) =>
+        SENSITIVE_KEYS.has(key.toLowerCase())
+          ? [key, '[REDACTED]']
+          : [key, redactSensitive(val)],
+      ),
+    );
+  }
+  return value;
+};
+
 // Hono wrapper
 const honoValidateRequest = <T>(schema: z.ZodType<T>) => {
   return async (c: Context, next: Next) => {
@@ -99,7 +134,7 @@ const honoValidateRequest = <T>(schema: z.ZodType<T>) => {
 
       logger.info({
         message: 'Validation result',
-        result,
+        result: redactSensitive(result),
       });
 
       if (result.success) {


### PR DESCRIPTION
## Summary

No user-facing changes yet. Adds the gateway `telegram-actions` router — the backend half of the Telegram archive feature (parent SWO-490). Four session-authenticated Hasura Actions, each resolving a **per-user** Telegram client (SWO-491) from the caller's own credentials: `list` (channel videos, paginated), `import` (enqueue a Cloud Task), `request-login-code`, `submit-login-code`. `userId` is always read from `session_variables['x-hasura-user-id']`, never the request body. Also redacts secret-keyed fields (the login OTP) from the shared validator's info logs.

Refs SWO-494. Builds on #527 (SWO-491 per-user client) and #526/#528 (pendingSessionString). End-to-end verification is blocked until the backend deploy pipeline is restored (SWO-546); logic is covered by unit tests.

## Test plan

- [ ] Backend test suite passes (943 tests, incl. per-user isolation, error-code mapping, Cloud Task enqueue, OTP log redaction)
- [ ] `tsc --noEmit` clean; Biome clean
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Telegram actions for requesting and submitting login codes.
  * Added browsing of channel videos with pagination and optional thumbnails.
  * Added Telegram archive imports with background task tracking.
  * Added session-based validation for Telegram requests.
* **Bug Fixes**
  * Improved Telegram error messages with consistent, actionable codes.
  * Prevented sensitive login codes from appearing in validation logs.
  * Improved import reliability and duplicate-request handling.
* **Tests**
  * Added coverage for Telegram actions, error handling, task creation, and sensitive-data redaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->