### PR TITLE
[WIP] feat(backend): io Cloud Task handler for Telegram archive import

### DIFF
--- a/apps/backend/src/apps/io/telegram/index.ts
+++ b/apps/backend/src/apps/io/telegram/index.ts
@@ -1,0 +1,20 @@
+import { Hono } from 'hono';
+import { telegramImportHandlerSchema } from 'src/schema/telegram/task-payload';
+import { honoRequestHandler } from 'src/utils/requestHandler';
+import { honoValidateRequest } from 'src/utils/validators/request';
+import { importTelegramArchiveHandler } from './routes/import';
+
+/**
+ * io Telegram routes — Cloud Task handlers delivered by GCP (OIDC-authenticated
+ * at the queue, so no session/webhook middleware here). Mounted at `/telegram`
+ * in `io.ts`; the gateway `import` action enqueues to `/telegram/import-handler`.
+ */
+const telegramRouter = new Hono();
+
+telegramRouter.post(
+  '/import-handler',
+  honoValidateRequest(telegramImportHandlerSchema),
+  honoRequestHandler(importTelegramArchiveHandler),
+);
+
+export { telegramRouter };

--- a/apps/backend/src/apps/io/telegram/routes/import/index.test.ts
+++ b/apps/backend/src/apps/io/telegram/routes/import/index.test.ts
@@ -1,0 +1,182 @@
+import { completeTask } from 'src/services/hasura/mutations/tasks';
+import {
+  fileExists,
+  streamFile,
+} from 'src/services/videos/helpers/gcp-cloud-storage';
+import { getTelegramClient } from 'src/services/telegram/client';
+import { Api } from 'teleproto';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { importTelegramArchiveHandler } from './index';
+
+vi.mock('src/services/telegram/client', () => ({
+  getTelegramClient: vi.fn(),
+}));
+
+vi.mock('src/services/videos/helpers/gcp-cloud-storage', () => ({
+  fileExists: vi.fn(),
+  streamFile: vi.fn(),
+  getDownloadUrl: vi.fn((p: string) => `https://cdn.test/${p}`),
+}));
+
+vi.mock('src/services/hasura/mutations/tasks', () => ({
+  completeTask: vi.fn(),
+}));
+
+vi.mock('src/utils/logger', () => {
+  const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  return { getCurrentLogger: vi.fn(() => mockLogger) };
+});
+
+const USER_ID = '550e8400-e29b-41d4-a716-446655440001';
+const TASK_ID = '9f8b7c6d-0000-4a1b-8c2d-1e2f3a4b5c6d';
+const CHANNEL_ID = '-582839764';
+
+const mockClient = {
+  getInputEntity: vi.fn(),
+  getMessages: vi.fn(),
+  downloadMedia: vi.fn(),
+  disconnect: vi.fn(),
+};
+
+const buildVideoMessage = (id: number, fileName = 'clip.mp4') => ({
+  id,
+  video: {
+    mimeType: 'video/mp4',
+    attributes: [new Api.DocumentAttributeFilename({ fileName })],
+  },
+});
+
+const buildContext = (
+  overrides: Partial<{
+    channelId: string;
+    messageIds: string[];
+    userId: string;
+    taskId: string;
+  }> = {},
+) => ({
+  validatedData: {
+    headers: { 'x-task-id': overrides.taskId ?? TASK_ID },
+    body: {
+      data: {
+        channelId: overrides.channelId ?? CHANNEL_ID,
+        messageIds: overrides.messageIds ?? ['10', '11'],
+        userId: overrides.userId ?? USER_ID,
+      },
+      metadata: { id: 'evt-1', spanId: 's1', traceId: 't1' },
+    },
+  },
+});
+
+const call = (context: unknown) =>
+  importTelegramArchiveHandler(context as any) as Promise<{
+    success: boolean;
+    message: string;
+    dataObject?: { uploaded: number; skipped: number };
+  }>;
+
+describe('importTelegramArchiveHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getTelegramClient).mockResolvedValue(mockClient as any);
+    mockClient.getInputEntity.mockResolvedValue({ resolved: true });
+    mockClient.downloadMedia.mockResolvedValue(Buffer.from('video-bytes'));
+    mockClient.disconnect.mockResolvedValue(undefined);
+    vi.mocked(fileExists).mockResolvedValue(false);
+    vi.mocked(streamFile).mockResolvedValue(undefined as any);
+    vi.mocked(completeTask).mockResolvedValue(1 as any);
+  });
+
+  it('downloads each video, uploads to the per-user channel path, and completes the task', async () => {
+    mockClient.getMessages.mockResolvedValue([
+      buildVideoMessage(10, 'first.mp4'),
+      buildVideoMessage(11, 'second.mp4'),
+    ]);
+
+    const result = await call(buildContext());
+
+    // Client is resolved from the task's userId and asked for exactly these ids.
+    expect(getTelegramClient).toHaveBeenCalledWith(USER_ID);
+    expect(mockClient.getInputEntity).toHaveBeenCalledWith(CHANNEL_ID);
+    expect(mockClient.getMessages).toHaveBeenCalledWith(
+      { resolved: true },
+      { ids: [10, 11] },
+    );
+
+    // Uploaded to telegram-archive/<userId>/<channelSlug>/<messageId>-<filename>.
+    expect(streamFile).toHaveBeenCalledTimes(2);
+    const paths = vi.mocked(streamFile).mock.calls.map((c) => c[0].storagePath);
+    expect(paths).toEqual([
+      `telegram-archive/${USER_ID}/582839764/10-first.mp4`,
+      `telegram-archive/${USER_ID}/582839764/11-second.mp4`,
+    ]);
+    expect(vi.mocked(streamFile).mock.calls[0][0].options).toMatchObject({
+      contentType: 'video/mp4',
+    });
+
+    expect(completeTask).toHaveBeenCalledWith({ taskId: TASK_ID });
+    expect(mockClient.disconnect).toHaveBeenCalledTimes(1);
+    expect(result.success).toBe(true);
+    expect(result.dataObject).toEqual({ uploaded: 2, skipped: 0 });
+  });
+
+  it('skips files already in storage (idempotent re-run) without re-downloading', async () => {
+    mockClient.getMessages.mockResolvedValue([
+      buildVideoMessage(10),
+      buildVideoMessage(11),
+    ]);
+    vi.mocked(fileExists).mockResolvedValueOnce(true); // first already uploaded
+
+    const result = await call(buildContext());
+
+    expect(mockClient.downloadMedia).toHaveBeenCalledTimes(1); // only the second
+    expect(streamFile).toHaveBeenCalledTimes(1);
+    expect(completeTask).toHaveBeenCalledWith({ taskId: TASK_ID });
+    expect(result.dataObject).toEqual({ uploaded: 1, skipped: 1 });
+  });
+
+  it('skips a requested message that has no video', async () => {
+    mockClient.getMessages.mockResolvedValue([
+      buildVideoMessage(10),
+      { id: 11, video: undefined },
+    ]);
+
+    const result = await call(buildContext());
+
+    expect(streamFile).toHaveBeenCalledTimes(1);
+    expect(result.dataObject).toEqual({ uploaded: 1, skipped: 0 });
+    expect(completeTask).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses each caller their OWN credentials — no cross-user leakage', async () => {
+    const otherUser = '660e8400-e29b-41d4-a716-446655440002';
+    mockClient.getMessages.mockResolvedValue([]);
+
+    await call(buildContext());
+    await call(buildContext({ userId: otherUser }));
+
+    expect(getTelegramClient).toHaveBeenNthCalledWith(1, USER_ID);
+    expect(getTelegramClient).toHaveBeenNthCalledWith(2, otherUser);
+  });
+
+  it('re-throws on upload failure (so Cloud Tasks retries) and does NOT complete the task', async () => {
+    mockClient.getMessages.mockResolvedValue([buildVideoMessage(10)]);
+    vi.mocked(streamFile).mockRejectedValue(new Error('gcs down'));
+
+    await expect(call(buildContext())).rejects.toThrow('gcs down');
+
+    expect(completeTask).not.toHaveBeenCalled();
+    expect(mockClient.disconnect).toHaveBeenCalledTimes(1); // still cleaned up
+  });
+
+  it('falls back to a default filename when the video has no filename attribute', async () => {
+    mockClient.getMessages.mockResolvedValue([
+      { id: 10, video: { mimeType: 'video/mp4', attributes: [] } },
+    ]);
+
+    await call(buildContext({ messageIds: ['10'] }));
+
+    expect(vi.mocked(streamFile).mock.calls[0][0].storagePath).toBe(
+      `telegram-archive/${USER_ID}/582839764/10-video.mp4`,
+    );
+  });
+});

--- a/apps/backend/src/apps/io/telegram/routes/import/index.test.ts
+++ b/apps/backend/src/apps/io/telegram/routes/import/index.test.ts
@@ -179,4 +179,28 @@ describe('importTelegramArchiveHandler', () => {
       `telegram-archive/${USER_ID}/582839764/10-video.mp4`,
     );
   });
+
+  it('sanitizes an attacker-influenced filename so it stays inside the user prefix', async () => {
+    mockClient.getMessages.mockResolvedValue([
+      {
+        id: 10,
+        video: {
+          mimeType: 'video/mp4',
+          attributes: [
+            new Api.DocumentAttributeFilename({
+              fileName: '../../etc/passwd\n.mp4',
+            }),
+          ],
+        },
+      },
+    ]);
+
+    await call(buildContext({ messageIds: ['10'] }));
+
+    // Path components dropped (basename), unsafe chars replaced, leading dots
+    // stripped — the key still begins with the user's prefix.
+    const path = vi.mocked(streamFile).mock.calls[0][0].storagePath;
+    expect(path).toBe(`telegram-archive/${USER_ID}/582839764/10-passwd_.mp4`);
+    expect(path.startsWith(`telegram-archive/${USER_ID}/`)).toBe(true);
+  });
 });

--- a/apps/backend/src/apps/io/telegram/routes/import/index.ts
+++ b/apps/backend/src/apps/io/telegram/routes/import/index.ts
@@ -1,0 +1,151 @@
+import { Readable } from 'node:stream';
+import type { TelegramImportHandlerRequest } from 'src/schema/telegram/task-payload';
+import { completeTask } from 'src/services/hasura/mutations/tasks';
+import { getTelegramClient } from 'src/services/telegram/client';
+import {
+  fileExists,
+  getDownloadUrl,
+  streamFile,
+} from 'src/services/videos/helpers/gcp-cloud-storage';
+import { getCurrentLogger } from 'src/utils/logger';
+import type { HandlerContext } from 'src/utils/requestHandler';
+import { AppResponse } from 'src/utils/schema';
+import { Api, type TelegramClient } from 'teleproto';
+
+const STORAGE_ROOT = 'telegram-archive';
+const DEFAULT_VIDEO_MIME = 'video/mp4';
+// Filename used when a message's video document carries no filename attribute.
+const FALLBACK_FILENAME = 'video.mp4';
+
+/**
+ * Stable, filesystem-safe slug for the channel segment of the storage path.
+ * Derived from `channelId` (not the channel title) because the id is the stable
+ * identity carried end-to-end from list → import — a title could change between
+ * runs and break idempotency. Lowercased, non-alphanumerics collapsed to '-'.
+ */
+const toChannelSlug = (channelId: string): string =>
+  channelId
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'channel';
+
+const filenameOf = (video: Api.Document): string => {
+  const filenameAttr = video.attributes.find(
+    (attr): attr is Api.DocumentAttributeFilename =>
+      attr instanceof Api.DocumentAttributeFilename,
+  );
+  return filenameAttr?.fileName ?? FALLBACK_FILENAME;
+};
+
+/**
+ * io Cloud Task handler for a Telegram archive import (SWO-495). Downloads each
+ * selected message's video and uploads it to GCS under
+ * `telegram-archive/<userId>/<channelSlug>/<messageId>-<filename>`.
+ *
+ * Runs against the TRIGGERING user's own Telegram credentials — `userId` comes
+ * from the task payload, which SWO-494's gateway `import` route stamped from the
+ * caller's session (never the request body), so this handler can only ever act
+ * as that user. Deliberately NOT wrapped in `withVideoFailureReport`: that is
+ * scoped to video-entity handlers (`markVideoFailed`), and there is no video row
+ * here. On any failure we log and re-throw so the thrown 5xx lets Cloud Tasks
+ * retry, rather than silently swallowing. Re-runs are idempotent: a file already
+ * in GCS is skipped, so a retry after a partial upload only does the missing work.
+ */
+const importTelegramArchiveHandler = async (
+  context: HandlerContext<TelegramImportHandlerRequest>,
+) => {
+  const logger = getCurrentLogger();
+  const { body, headers } = context.validatedData;
+  const { data, metadata } = body;
+  const taskId = headers['x-task-id'];
+  const { channelId, messageIds, userId } = data;
+
+  logger.info(
+    { ...metadata, taskId, channelId, count: messageIds.length },
+    '[telegram/import-handler] start',
+  );
+
+  // Per-user client (SWO-491): returned already connected, we own disconnect().
+  let client: TelegramClient | undefined;
+  try {
+    const connected = await getTelegramClient(userId);
+    client = connected;
+
+    const entity = await connected.getInputEntity(channelId);
+    const messages = await connected.getMessages(entity, {
+      ids: messageIds.map(Number),
+    });
+
+    const channelSlug = toChannelSlug(channelId);
+    let uploaded = 0;
+    let skipped = 0;
+
+    for (const message of messages) {
+      const video = message?.video;
+      if (!video) {
+        // A requested id that isn't a video (deleted, or a non-video message).
+        logger.warn(
+          { taskId, messageId: message?.id },
+          '[telegram/import-handler] skipping message with no video',
+        );
+        continue;
+      }
+
+      const filename = filenameOf(video);
+      const storagePath = `${STORAGE_ROOT}/${userId}/${channelSlug}/${message.id}-${filename}`;
+
+      if (await fileExists(storagePath)) {
+        skipped += 1;
+        logger.info(
+          { taskId, storagePath },
+          '[telegram/import-handler] already uploaded, skipping',
+        );
+        continue;
+      }
+
+      const media = await connected.downloadMedia(message);
+      if (!Buffer.isBuffer(media)) {
+        // downloadMedia returns undefined/string only when there's nothing to
+        // pull — treat as nothing to upload rather than a hard failure.
+        logger.warn(
+          { taskId, messageId: message.id },
+          '[telegram/import-handler] no media bytes for message',
+        );
+        continue;
+      }
+
+      await streamFile({
+        stream: Readable.from(media),
+        storagePath,
+        options: { contentType: video.mimeType ?? DEFAULT_VIDEO_MIME },
+      });
+      uploaded += 1;
+      logger.info(
+        { taskId, storagePath, url: getDownloadUrl(storagePath) },
+        '[telegram/import-handler] uploaded',
+      );
+    }
+
+    await completeTask({ taskId });
+
+    logger.info(
+      { taskId, uploaded, skipped },
+      '[telegram/import-handler] done',
+    );
+    return AppResponse(true, 'ok', { uploaded, skipped });
+  } catch (error) {
+    // Re-throw so Cloud Tasks retries (the whole run is idempotent). No
+    // withVideoFailureReport / task 'failed' state here — that's video-only.
+    logger.error(
+      { error, taskId, channelId },
+      '[telegram/import-handler] import failed',
+    );
+    throw error;
+  } finally {
+    if (client) {
+      await client.disconnect().catch(() => {});
+    }
+  }
+};
+
+export { importTelegramArchiveHandler };

--- a/apps/backend/src/apps/io/telegram/routes/import/index.ts
+++ b/apps/backend/src/apps/io/telegram/routes/import/index.ts
@@ -29,12 +29,29 @@ const toChannelSlug = (channelId: string): string =>
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '') || 'channel';
 
+/**
+ * Sanitize the message's filename before it goes into the GCS object key. The
+ * value comes from Telegram's `DocumentAttributeFilename` — attacker-influenced
+ * (the channel owner sets it) — so drop any path components and restrict to a
+ * safe charset. It can't escape the `telegram-archive/<userId>/<slug>/<id>-`
+ * prefix even raw (GCS is a flat namespace, the id-prefix precedes it), but a
+ * `..` or control char would otherwise leak into `getDownloadUrl`, which a
+ * CDN/browser WOULD normalize — pointing a would-be public URL at a different
+ * object than the bytes written.
+ */
+const SAFE_FILENAME = /[^a-zA-Z0-9._-]/g;
+const safeFilename = (raw: string): string => {
+  const base = raw.split(/[\\/]/).pop() ?? '';
+  const cleaned = base.replace(SAFE_FILENAME, '_').replace(/^\.+/, '');
+  return cleaned || FALLBACK_FILENAME;
+};
+
 const filenameOf = (video: Api.Document): string => {
   const filenameAttr = video.attributes.find(
     (attr): attr is Api.DocumentAttributeFilename =>
       attr instanceof Api.DocumentAttributeFilename,
   );
-  return filenameAttr?.fileName ?? FALLBACK_FILENAME;
+  return safeFilename(filenameAttr?.fileName ?? FALLBACK_FILENAME);
 };
 
 /**

--- a/apps/backend/src/io.test.ts
+++ b/apps/backend/src/io.test.ts
@@ -69,6 +69,10 @@ vi.mock('./apps/io/crawler', () => ({
   crawlerRouter: 'mockCrawlerRouter',
 }));
 
+vi.mock('./apps/io/telegram', () => ({
+  telegramRouter: 'mockTelegramRouter',
+}));
+
 // Mock sentry
 vi.mock('@hono/sentry', () => ({
   sentry: () => vi.fn(),
@@ -144,6 +148,7 @@ describe('IO Application', () => {
   it('should register all routers', () => {
     expect(mockRoute).toHaveBeenCalledWith('videos', 'mockVideosRouter');
     expect(mockRoute).toHaveBeenCalledWith('crawlers', 'mockCrawlerRouter');
+    expect(mockRoute).toHaveBeenCalledWith('telegram', 'mockTelegramRouter');
   });
 
   it('should set up error handling', () => {

--- a/apps/backend/src/io.ts
+++ b/apps/backend/src/io.ts
@@ -6,6 +6,7 @@ import { contextStorage } from 'hono/context-storage';
 import { requestId } from 'hono/request-id';
 import { rateLimiter } from 'hono-rate-limiter';
 import { crawlerRouter } from './apps/io/crawler';
+import { telegramRouter } from './apps/io/telegram';
 import { videosRouter } from './apps/io/videos';
 import { envConfig } from './utils/envConfig';
 import { createHonoLoggingMiddleware, getCurrentLogger } from './utils/logger';
@@ -62,6 +63,7 @@ app.get('/hz', (c) => {
 
 app.route('videos', videosRouter);
 app.route('crawlers', crawlerRouter);
+app.route('telegram', telegramRouter);
 
 app.onError((e, c) => {
   const logger = getCurrentLogger();

--- a/apps/backend/src/schema/telegram/import/index.ts
+++ b/apps/backend/src/schema/telegram/import/index.ts
@@ -9,7 +9,10 @@ const importTelegramArchiveSchema = z
       input: z.object({
         input: z.object({
           channelId: z.string().min(1),
-          messageIds: z.array(z.string().min(1)).min(1),
+          // Telegram message IDs — positive integer strings. The io import
+          // handler does `Number(id)`, so reject non-numeric values here rather
+          // than let them become NaN downstream.
+          messageIds: z.array(z.string().regex(/^[1-9]\d*$/)).min(1),
         }),
       }),
       session_variables: z.looseObject({ 'x-hasura-user-id': z.guid() }),

--- a/apps/backend/src/schema/telegram/task-payload/index.ts
+++ b/apps/backend/src/schema/telegram/task-payload/index.ts
@@ -5,7 +5,10 @@ import { z } from 'zod';
 // import handler validates — keeps both sides of the hop in lockstep.
 const telegramImportTaskDataSchema = z.object({
   channelId: z.string().min(1),
-  messageIds: z.array(z.string().min(1)).min(1),
+  // Positive integer strings — the io handler does `Number(id)` before
+  // getMessages, so a non-numeric id would become NaN. Kept in lockstep with the
+  // gateway `import` action input schema.
+  messageIds: z.array(z.string().regex(/^[1-9]\d*$/)).min(1),
   userId: z.guid(),
 });
 

--- a/apps/backend/src/services/videos/helpers/gcp-cloud-storage/index.test.ts
+++ b/apps/backend/src/services/videos/helpers/gcp-cloud-storage/index.test.ts
@@ -5,6 +5,7 @@ import {
   getSignedUploadUrl,
   uploadFile,
   DEFAULT_UPLOAD_OPTIONS,
+  fileExists,
   streamFile,
   uploadFolderParallel,
 } from '.';
@@ -102,6 +103,7 @@ const mockTransferManager = {
 };
 const mockFile = {
   delete: vi.fn(),
+  exists: vi.fn().mockResolvedValue([false]),
   getSignedUrl: vi.fn().mockResolvedValue(['https://signed.example/put']),
   createWriteStream: vi.fn(() => {
     const writeStream = new PassThrough();
@@ -156,6 +158,18 @@ describe('gcp-cloud-storage-helpers', () => {
 
       expect(getDownloadUrl(outputPath)).toBe(expected);
       expect(storageMock).toHaveBeenCalled();
+    });
+  });
+
+  describe('fileExists', () => {
+    it('returns true when the object exists', async () => {
+      mockFile.exists.mockResolvedValueOnce([true]);
+      expect(await fileExists('telegram-archive/u/c/1-a.mp4')).toBe(true);
+    });
+
+    it('returns false when the object does not exist', async () => {
+      mockFile.exists.mockResolvedValueOnce([false]);
+      expect(await fileExists('telegram-archive/u/c/2-b.mp4')).toBe(false);
     });
   });
 

--- a/apps/backend/src/services/videos/helpers/gcp-cloud-storage/index.ts
+++ b/apps/backend/src/services/videos/helpers/gcp-cloud-storage/index.ts
@@ -200,6 +200,17 @@ const streamFile = async (params: StreamFileParams) => {
   });
 };
 
+/**
+ * Whether an object already exists in the default bucket. Lets a re-run skip
+ * work it already did (idempotent imports) instead of re-uploading.
+ * @param storagePath Relative object path (e.g. 'telegram-archive/<user>/<chan>/<id>-file.mp4').
+ */
+const fileExists = async (storagePath: string): Promise<boolean> => {
+  const bucket = getDefaultBucket();
+  const [exists] = await bucket.file(storagePath).exists();
+  return exists;
+};
+
 /** Default lifetime of a generated V4 signed upload URL. */
 const SIGNED_UPLOAD_URL_TTL_MS = 15 * 60 * 1000; // 15 minutes
 
@@ -262,6 +273,7 @@ const getSignedUploadUrl = async ({
 export {
   DEFAULT_UPLOAD_OPTIONS,
   SIGNED_UPLOAD_URL_TTL_MS,
+  fileExists,
   getDownloadUrl,
   getSignedUploadUrl,
   uploadFile,


### PR DESCRIPTION
## Summary

No user-facing changes yet. Adds the `io`-service Cloud Task handler that does the actual Telegram archive import — the download/upload half of the feature (parent SWO-490). It receives the task SWO-494's gateway `import` action enqueues, resolves the **triggering user's own** Telegram client (SWO-491, `userId` from the task payload — never the request body), downloads each selected video, and uploads it to Cloud Storage under `telegram-archive/<userId>/<channel>/<messageId>-<filename>`.

Idempotent: files already in storage are skipped, so a retry only does the missing work. On failure it re-throws so Cloud Tasks retries. Adds a small `fileExists` storage helper; hardens the shared `messageIds` schema to positive-integer strings and sanitizes the Telegram-supplied filename before it enters the object key.

Refs SWO-495. Builds on #527 (per-user client) and #529 (task-payload schema). End-to-end verification is blocked until the backend deploy pipeline is restored (SWO-546); logic is covered by unit tests.

## Test plan

- [ ] Backend test suite passes (955 tests — incl. per-user isolation across two users, idempotent skip, no-video skip, re-throw-on-failure, and filename sanitization)
- [ ] `tsc --noEmit` clean; Biome clean
- [ ] CI green