### PR TITLE
[WIP] feat(extension): Telegram channel video picker + per-user login

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -26,6 +26,8 @@
     "@crxjs/vite-plugin": "^2.0.3",
     "@dotenvx/dotenvx": "^1.75.1",
     "@graphql-codegen/cli": "^5.0.3",
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/react": "^16.1.0",
     "@types/chrome": "^0.0.268",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",

--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -1,6 +1,7 @@
 import type {
   PageContent,
   PdfMetadata,
+  TelegramChannelMetadata,
   VideoMetadata,
 } from 'core/universal/extension/communication/types';
 import { removeItems, setItem } from 'core/universal/extension/storage';
@@ -8,6 +9,12 @@ import { config } from '../config';
 import { getToken, isAuthenticated, logout } from './background/auth';
 import { createImportRecord, updateImportStatus } from './background/imports';
 import { importBook } from './background/library';
+import {
+  importTelegramArchive,
+  listTelegramChannelVideos,
+  requestTelegramLoginCode,
+  submitTelegramLoginCode,
+} from './background/telegram';
 import { importVideo } from './background/watch';
 
 console.log('Background script starting...');
@@ -15,6 +22,7 @@ console.log('Background script starting...');
 let currentPageContent: PageContent | null = null;
 let currentPdfMetadata: PdfMetadata | null = null;
 let storedVideoMetadata: VideoMetadata | null = null;
+let storedTelegramMetadata: TelegramChannelMetadata | null = null;
 
 const importBookAsync = async (metadata: PdfMetadata): Promise<void> => {
   const record = createImportRecord('library', metadata.title);
@@ -136,6 +144,19 @@ chrome.runtime.onMessage.addListener(async (message, _sender, sendResponse) => {
       return;
     }
 
+    case 'TELEGRAM_CHANNEL_DETECTED': {
+      storedTelegramMetadata = message.payload as TelegramChannelMetadata;
+      // Surface a telegram PageContent so the popup routes to the Telegram
+      // section (the content script sends ONLY this message for a telegram tab).
+      currentPageContent = {
+        url: storedTelegramMetadata.url,
+        title: 'Telegram channel',
+        pageType: 'telegram',
+      };
+      sendResponse({ received: true });
+      return;
+    }
+
     case 'REQUEST_TAB_CONTENT': {
       chrome.runtime.sendMessage({
         source: 'background',
@@ -194,6 +215,48 @@ chrome.runtime.onMessage.addListener(async (message, _sender, sendResponse) => {
       }
 
       sendResponse({ started: false, error: 'Unsupported target app' });
+      return;
+    }
+
+    // Telegram picker actions — the popup calls these; the background owns the
+    // channelId (from the detected tab) so the popup never handles it.
+    case 'TELEGRAM_LIST_VIDEOS': {
+      const channelId = storedTelegramMetadata?.channelId;
+      if (!channelId) {
+        sendResponse({
+          success: false,
+          message: 'No Telegram channel detected',
+          videos: [],
+        });
+        return;
+      }
+      const cursor = message.payload?.cursor as string | undefined;
+      sendResponse(await listTelegramChannelVideos(channelId, cursor));
+      return;
+    }
+
+    case 'TELEGRAM_IMPORT': {
+      const channelId = storedTelegramMetadata?.channelId;
+      if (!channelId) {
+        sendResponse({
+          success: false,
+          message: 'No Telegram channel detected',
+        });
+        return;
+      }
+      const messageIds = (message.payload?.messageIds as string[]) ?? [];
+      sendResponse(await importTelegramArchive(channelId, messageIds));
+      return;
+    }
+
+    case 'TELEGRAM_REQUEST_LOGIN_CODE': {
+      sendResponse(await requestTelegramLoginCode());
+      return;
+    }
+
+    case 'TELEGRAM_SUBMIT_LOGIN_CODE': {
+      const code = (message.payload?.code as string) ?? '';
+      sendResponse(await submitTelegramLoginCode(code));
       return;
     }
   }

--- a/apps/extension/src/background/telegram.test.ts
+++ b/apps/extension/src/background/telegram.test.ts
@@ -117,6 +117,17 @@ describe('background/telegram actions', () => {
       expect(result.success).toBe(false);
       expect(result.message).toBe('offline');
     });
+
+    it('sends an abort signal and reports a timeout instead of hanging', async () => {
+      mockFetch.mockRejectedValue(
+        new DOMException('signal timed out', 'TimeoutError'),
+      );
+      const result = await listTelegramChannelVideos('-123');
+      expect(result.success).toBe(false);
+      expect(result.message).toBe('The request timed out. Try again.');
+      // The fetch carries an abort signal so a stalled request can't hang forever.
+      expect(mockFetch.mock.calls[0][1].signal).toBeInstanceOf(AbortSignal);
+    });
   });
 
   describe('importTelegramArchive', () => {

--- a/apps/extension/src/background/telegram.test.ts
+++ b/apps/extension/src/background/telegram.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getToken } from './auth';
+import {
+  importTelegramArchive,
+  listTelegramChannelVideos,
+  requestTelegramLoginCode,
+  submitTelegramLoginCode,
+} from './telegram';
+
+vi.mock('./auth', () => ({ getToken: vi.fn() }));
+vi.mock('../../envConfig', () => ({
+  hasuraConfig: { url: 'https://hasura.test/v1/graphql' },
+}));
+
+const mockFetch = vi.fn();
+
+// Build a fetch response whose json() resolves to `body`.
+const jsonResponse = (body: unknown) => ({ json: async () => body });
+
+describe('background/telegram actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getToken).mockResolvedValue('jwt-token');
+    global.fetch = mockFetch as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('listTelegramChannelVideos', () => {
+    it('sends the bridged token and returns videos + nextCursor on success', async () => {
+      mockFetch.mockResolvedValue(
+        jsonResponse({
+          data: {
+            listTelegramChannelVideos: {
+              success: true,
+              message: 'ok',
+              dataObject: {
+                videos: [
+                  { id: '10', filename: 'a.mp4', date: '2024-01-01T00:00:00Z' },
+                ],
+                nextCursor: '9',
+              },
+            },
+          },
+        }),
+      );
+
+      const result = await listTelegramChannelVideos('-123', '20');
+
+      // Auth header + endpoint + variables are all correct.
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://hasura.test/v1/graphql',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            Authorization: 'Bearer jwt-token',
+          }),
+        }),
+      );
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.variables).toEqual({
+        input: { channelId: '-123', cursor: '20' },
+      });
+
+      expect(result).toEqual({
+        success: true,
+        message: 'ok',
+        videos: [{ id: '10', filename: 'a.mp4', date: '2024-01-01T00:00:00Z' }],
+        nextCursor: '9',
+      });
+    });
+
+    it('passes NO_SESSION through so the popup can show the login prompt', async () => {
+      mockFetch.mockResolvedValue(
+        jsonResponse({
+          data: {
+            listTelegramChannelVideos: {
+              success: false,
+              message: 'NO_SESSION',
+              dataObject: null,
+            },
+          },
+        }),
+      );
+
+      const result = await listTelegramChannelVideos('-123');
+      expect(result).toEqual({
+        success: false,
+        message: 'NO_SESSION',
+        videos: [],
+        nextCursor: undefined,
+      });
+    });
+
+    it('returns Not authenticated without calling fetch when there is no token', async () => {
+      vi.mocked(getToken).mockResolvedValue(null);
+      const result = await listTelegramChannelVideos('-123');
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(result.success).toBe(false);
+      expect(result.message).toBe('Not authenticated');
+    });
+
+    it('surfaces a GraphQL error message', async () => {
+      mockFetch.mockResolvedValue(
+        jsonResponse({ errors: [{ message: 'permission denied' }] }),
+      );
+      const result = await listTelegramChannelVideos('-123');
+      expect(result.success).toBe(false);
+      expect(result.message).toBe('permission denied');
+    });
+
+    it('surfaces a network error', async () => {
+      mockFetch.mockRejectedValue(new Error('offline'));
+      const result = await listTelegramChannelVideos('-123');
+      expect(result.success).toBe(false);
+      expect(result.message).toBe('offline');
+    });
+  });
+
+  describe('importTelegramArchive', () => {
+    it('returns the taskId on success', async () => {
+      mockFetch.mockResolvedValue(
+        jsonResponse({
+          data: {
+            importTelegramArchive: {
+              success: true,
+              message: 'ok',
+              dataObject: { taskId: 'task-1' },
+            },
+          },
+        }),
+      );
+
+      const result = await importTelegramArchive('-123', ['10', '11']);
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.variables).toEqual({
+        input: { channelId: '-123', messageIds: ['10', '11'] },
+      });
+      expect(result).toEqual({
+        success: true,
+        message: 'ok',
+        taskId: 'task-1',
+      });
+    });
+  });
+
+  describe('login actions', () => {
+    it('requestTelegramLoginCode returns the success envelope', async () => {
+      mockFetch.mockResolvedValue(
+        jsonResponse({
+          data: {
+            requestTelegramLoginCode: { success: true, message: 'sent' },
+          },
+        }),
+      );
+      const result = await requestTelegramLoginCode();
+      expect(result).toEqual({ success: true, message: 'sent' });
+    });
+
+    it('submitTelegramLoginCode sends the code and returns the envelope', async () => {
+      mockFetch.mockResolvedValue(
+        jsonResponse({
+          data: { submitTelegramLoginCode: { success: true, message: 'ok' } },
+        }),
+      );
+      const result = await submitTelegramLoginCode('12345');
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.variables).toEqual({ input: { code: '12345' } });
+      expect(result).toEqual({ success: true, message: 'ok' });
+    });
+
+    it('maps an invalid code failure through the message', async () => {
+      mockFetch.mockResolvedValue(
+        jsonResponse({
+          data: {
+            submitTelegramLoginCode: {
+              success: false,
+              message: 'INVALID_CODE',
+            },
+          },
+        }),
+      );
+      const result = await submitTelegramLoginCode('00000');
+      expect(result).toEqual({ success: false, message: 'INVALID_CODE' });
+    });
+  });
+});

--- a/apps/extension/src/background/telegram.ts
+++ b/apps/extension/src/background/telegram.ts
@@ -30,12 +30,20 @@ interface ActionEnvelope<T> {
   dataObject?: T | null;
 }
 
+// A stalled request must never hang the popup forever: without a deadline a
+// dead connection leaves the `await` in the background handler unresolved, so
+// `sendResponse` never fires and the spinner spins indefinitely. The ceiling
+// sits above Hasura's own 30s Action timeout so a genuinely slow-but-alive
+// backend still returns its real error rather than being cut off here.
+const REQUEST_TIMEOUT_MS = 35_000;
+
 /**
  * Call a Telegram Hasura Action from the background with the bridged Auth0 token,
  * exactly like `watch.ts`/`library.ts` — raw fetch to the GraphQL endpoint, the
  * action invoked as a mutation field. Normalizes every failure (no token,
- * transport/GraphQL error) into the same `{ success:false, message }` envelope so
- * callers branch on one shape. `actionField` is the mutation field name to unwrap.
+ * transport/GraphQL error, timeout) into the same `{ success:false, message }`
+ * envelope so callers branch on one shape. `actionField` is the mutation field
+ * name to unwrap.
  */
 const callTelegramAction = async <T>(
   actionField: string,
@@ -55,6 +63,7 @@ const callTelegramAction = async <T>(
         Authorization: `Bearer ${token}`,
       },
       body: JSON.stringify({ query, variables }),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     });
 
     const json = await response.json();
@@ -72,9 +81,15 @@ const callTelegramAction = async <T>(
     }
     return result;
   } catch (error) {
+    const timedOut =
+      error instanceof DOMException && error.name === 'TimeoutError';
     return {
       success: false,
-      message: error instanceof Error ? error.message : 'Network error',
+      message: timedOut
+        ? 'The request timed out. Try again.'
+        : error instanceof Error
+          ? error.message
+          : 'Network error',
       dataObject: null,
     };
   }

--- a/apps/extension/src/background/telegram.ts
+++ b/apps/extension/src/background/telegram.ts
@@ -1,0 +1,179 @@
+import { hasuraConfig } from '../../envConfig';
+import { getToken } from './auth';
+
+// One row of the picker — mirrors `TelegramVideoMessage` in the Hasura action
+// schema (apps/hasura actions.graphql / SWO-493). `thumbnailDataUri` is an inline
+// data: URI so the popup renders a preview with no extra fetch; `caption` is often
+// the only human-readable label when a raw video attachment has no `filename`.
+interface TelegramVideoMessage {
+  id: string;
+  filename?: string;
+  caption?: string;
+  date: string;
+  sizeBytes?: number;
+  durationSeconds?: number;
+  thumbnailDataUri?: string;
+}
+
+// The stable `message` code the gateway `list` route returns when the user has no
+// authorized Telegram session yet — the popup's cue to show the login prompt
+// instead of the picker (SWO-494). Kept as a shared constant so the background
+// and popup agree on the exact string.
+const NO_SESSION = 'NO_SESSION';
+
+// Every Telegram action returns this envelope (`{ success, message, dataObject }`).
+// `dataObject` is null on failure, and `message` carries the reason — including
+// `NO_SESSION`.
+interface ActionEnvelope<T> {
+  success: boolean;
+  message: string;
+  dataObject?: T | null;
+}
+
+/**
+ * Call a Telegram Hasura Action from the background with the bridged Auth0 token,
+ * exactly like `watch.ts`/`library.ts` — raw fetch to the GraphQL endpoint, the
+ * action invoked as a mutation field. Normalizes every failure (no token,
+ * transport/GraphQL error) into the same `{ success:false, message }` envelope so
+ * callers branch on one shape. `actionField` is the mutation field name to unwrap.
+ */
+const callTelegramAction = async <T>(
+  actionField: string,
+  query: string,
+  variables: Record<string, unknown>,
+): Promise<ActionEnvelope<T>> => {
+  try {
+    const token = await getToken();
+    if (!token) {
+      return { success: false, message: 'Not authenticated', dataObject: null };
+    }
+
+    const response = await fetch(hasuraConfig.url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ query, variables }),
+    });
+
+    const json = await response.json();
+    if (json.errors) {
+      return {
+        success: false,
+        message: json.errors[0]?.message ?? 'Request failed',
+        dataObject: null,
+      };
+    }
+
+    const result = json.data?.[actionField] as ActionEnvelope<T> | undefined;
+    if (!result) {
+      return { success: false, message: 'Empty response', dataObject: null };
+    }
+    return result;
+  } catch (error) {
+    return {
+      success: false,
+      message: error instanceof Error ? error.message : 'Network error',
+      dataObject: null,
+    };
+  }
+};
+
+interface ListResult {
+  success: boolean;
+  message: string;
+  videos: TelegramVideoMessage[];
+  nextCursor?: string;
+}
+
+const LIST_QUERY = `
+  mutation ListTelegramChannelVideos($input: ListTelegramChannelVideosInput!) {
+    listTelegramChannelVideos(input: $input) {
+      success
+      message
+      dataObject {
+        videos { id filename caption date sizeBytes durationSeconds thumbnailDataUri }
+        nextCursor
+      }
+    }
+  }
+`;
+
+const listTelegramChannelVideos = async (
+  channelId: string,
+  cursor?: string,
+): Promise<ListResult> => {
+  const res = await callTelegramAction<{
+    videos: TelegramVideoMessage[];
+    nextCursor?: string | null;
+  }>('listTelegramChannelVideos', LIST_QUERY, { input: { channelId, cursor } });
+
+  return {
+    success: res.success,
+    message: res.message,
+    videos: res.dataObject?.videos ?? [],
+    nextCursor: res.dataObject?.nextCursor ?? undefined,
+  };
+};
+
+const IMPORT_QUERY = `
+  mutation ImportTelegramArchive($input: ImportTelegramArchiveInput!) {
+    importTelegramArchive(input: $input) {
+      success
+      message
+      dataObject { taskId }
+    }
+  }
+`;
+
+const importTelegramArchive = async (
+  channelId: string,
+  messageIds: string[],
+): Promise<{ success: boolean; message: string; taskId?: string }> => {
+  const res = await callTelegramAction<{ taskId: string }>(
+    'importTelegramArchive',
+    IMPORT_QUERY,
+    { input: { channelId, messageIds } },
+  );
+  return {
+    success: res.success,
+    message: res.message,
+    taskId: res.dataObject?.taskId,
+  };
+};
+
+const REQUEST_LOGIN_CODE_QUERY = `
+  mutation RequestTelegramLoginCode {
+    requestTelegramLoginCode { success message }
+  }
+`;
+
+const requestTelegramLoginCode = (): Promise<{
+  success: boolean;
+  message: string;
+}> =>
+  callTelegramAction('requestTelegramLoginCode', REQUEST_LOGIN_CODE_QUERY, {});
+
+const SUBMIT_LOGIN_CODE_QUERY = `
+  mutation SubmitTelegramLoginCode($input: SubmitTelegramLoginCodeInput!) {
+    submitTelegramLoginCode(input: $input) { success message }
+  }
+`;
+
+const submitTelegramLoginCode = (
+  code: string,
+): Promise<{ success: boolean; message: string }> =>
+  callTelegramAction('submitTelegramLoginCode', SUBMIT_LOGIN_CODE_QUERY, {
+    input: { code },
+  });
+
+export {
+  NO_SESSION,
+  listTelegramChannelVideos,
+  importTelegramArchive,
+  requestTelegramLoginCode,
+  submitTelegramLoginCode,
+  type TelegramVideoMessage,
+  type ListResult,
+};

--- a/apps/extension/src/components/AutoDetectTab.tsx
+++ b/apps/extension/src/components/AutoDetectTab.tsx
@@ -1,6 +1,7 @@
 import { Box, CircularProgress, Typography } from '@mui/material';
 import type { PageContent } from 'core/universal/extension/communication/types';
 import { ActionCard } from './ActionCard';
+import { TelegramPanel } from './TelegramPanel';
 
 interface AutoDetectTabProps {
   content: PageContent | null;
@@ -29,6 +30,12 @@ const AutoDetectTab = ({
         </Typography>
       </Box>
     );
+  }
+
+  // Telegram gets its own multi-video picker (with a login step) rather than the
+  // single-item ActionCard the other page types use.
+  if (content.pageType === 'telegram') {
+    return <TelegramPanel />;
   }
 
   const isVideo = ['youtube', 'vimeo', 'video-generic'].includes(

--- a/apps/extension/src/components/TelegramLogin.test.tsx
+++ b/apps/extension/src/components/TelegramLogin.test.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TelegramLogin } from './TelegramLogin';
+
+// Route each background action type to a canned response.
+let responses: Record<string, unknown>;
+const sendMessage = vi.fn((msg: { type: string }, cb: (r: unknown) => void) =>
+  cb(responses[msg.type]),
+);
+
+beforeEach(() => {
+  responses = {
+    TELEGRAM_REQUEST_LOGIN_CODE: { success: true, message: 'sent' },
+    TELEGRAM_SUBMIT_LOGIN_CODE: { success: true, message: 'ok' },
+  };
+  sendMessage.mockClear();
+  global.chrome = {
+    runtime: { id: 'test-ext', sendMessage },
+  } as unknown as typeof chrome;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('TelegramLogin', () => {
+  it('sends a code, then accepts a submitted code and notifies the parent', async () => {
+    const onAuthenticated = vi.fn();
+    render(<TelegramLogin onAuthenticated={onAuthenticated} />);
+
+    // Step 1: send code — the code field only appears after that succeeds.
+    expect(screen.queryByLabelText('Login code')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Send login code' }));
+
+    const codeInput = await screen.findByLabelText('Login code');
+    fireEvent.change(codeInput, { target: { value: '12345' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => expect(onAuthenticated).toHaveBeenCalledTimes(1));
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'TELEGRAM_SUBMIT_LOGIN_CODE',
+        payload: { code: '12345' },
+      }),
+      expect.any(Function),
+    );
+  });
+
+  it('shows an error and stays on the code step when the code is rejected', async () => {
+    responses.TELEGRAM_SUBMIT_LOGIN_CODE = {
+      success: false,
+      message: 'INVALID_CODE',
+    };
+    const onAuthenticated = vi.fn();
+    render(<TelegramLogin onAuthenticated={onAuthenticated} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Send login code' }));
+    const codeInput = await screen.findByLabelText('Login code');
+    fireEvent.change(codeInput, { target: { value: '00000' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    expect(await screen.findByText('INVALID_CODE')).toBeTruthy();
+    expect(onAuthenticated).not.toHaveBeenCalled();
+  });
+
+  it('shows an error when the code could not be sent', async () => {
+    responses.TELEGRAM_REQUEST_LOGIN_CODE = {
+      success: false,
+      message: 'MISCONFIGURED',
+    };
+    render(<TelegramLogin onAuthenticated={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Send login code' }));
+
+    expect(await screen.findByText('MISCONFIGURED')).toBeTruthy();
+    expect(screen.queryByLabelText('Login code')).toBeNull();
+  });
+});

--- a/apps/extension/src/components/TelegramLogin.tsx
+++ b/apps/extension/src/components/TelegramLogin.tsx
@@ -1,0 +1,99 @@
+import { Alert, Box, Button, TextField, Typography } from '@mui/material';
+import { useState } from 'react';
+import { requestLoginCode, submitLoginCode } from './telegramRequests';
+
+interface TelegramLoginProps {
+  // Called once a code is accepted, so the parent can switch to the picker.
+  onAuthenticated: () => void;
+}
+
+/**
+ * First-time, per-user Telegram login inside the popup (SWO-494/496). Step 1:
+ * "Send login code" → `requestTelegramLoginCode`; Telegram delivers the code to
+ * the user's own device. Step 2: enter it → `submitTelegramLoginCode`; on success
+ * the parent swaps to the picker. Mirrors `AuthPanel`'s status/alert states plus
+ * `ClipboardTab`'s input + button idiom.
+ */
+const TelegramLogin = ({ onAuthenticated }: TelegramLoginProps) => {
+  const [codeSent, setCodeSent] = useState(false);
+  const [code, setCode] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSendCode = async () => {
+    setBusy(true);
+    setError(null);
+    const res = await requestLoginCode();
+    setBusy(false);
+    if (res?.success) {
+      setCodeSent(true);
+    } else {
+      setError(res?.message ?? 'Could not send the login code.');
+    }
+  };
+
+  const handleSubmit = async () => {
+    if (!code.trim()) return;
+    setBusy(true);
+    setError(null);
+    const res = await submitLoginCode(code.trim());
+    setBusy(false);
+    if (res?.success) {
+      onAuthenticated();
+    } else {
+      setError(res?.message ?? 'That code was not accepted.');
+    }
+  };
+
+  return (
+    <Box sx={{ p: 2 }}>
+      <Typography variant="subtitle2" sx={{ fontWeight: 'bold', mb: 1 }}>
+        Connect your Telegram
+      </Typography>
+      <Typography variant="body2" sx={{ color: 'text.secondary', mb: 2 }}>
+        {codeSent
+          ? 'Enter the login code Telegram just sent to your device.'
+          : 'Send a login code to your Telegram account to import its videos.'}
+      </Typography>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
+
+      {!codeSent ? (
+        <Button
+          variant="contained"
+          fullWidth
+          onClick={handleSendCode}
+          disabled={busy}
+        >
+          Send login code
+        </Button>
+      ) : (
+        <>
+          <TextField
+            fullWidth
+            label="Login code"
+            placeholder="12345"
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+            disabled={busy}
+          />
+          <Button
+            variant="contained"
+            fullWidth
+            onClick={handleSubmit}
+            disabled={busy || !code.trim()}
+            sx={{ mt: 1 }}
+          >
+            Submit
+          </Button>
+        </>
+      )}
+    </Box>
+  );
+};
+
+export { TelegramLogin };

--- a/apps/extension/src/components/TelegramPanel.test.tsx
+++ b/apps/extension/src/components/TelegramPanel.test.tsx
@@ -1,0 +1,144 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TelegramPanel } from './TelegramPanel';
+
+// Per-type canned responses; each test tweaks `responses` before rendering.
+let responses: Record<string, unknown>;
+const sendMessage = vi.fn((msg: { type: string }, cb: (r: unknown) => void) =>
+  cb(responses[msg.type]),
+);
+
+beforeEach(() => {
+  responses = {
+    TELEGRAM_LIST_VIDEOS: {
+      success: true,
+      message: 'ok',
+      videos: [{ id: '10', caption: 'A clip', date: '2024-01-01T00:00:00Z' }],
+      nextCursor: undefined,
+    },
+    TELEGRAM_REQUEST_LOGIN_CODE: { success: true, message: 'sent' },
+    TELEGRAM_SUBMIT_LOGIN_CODE: { success: true, message: 'ok' },
+  };
+  sendMessage.mockClear();
+  global.chrome = {
+    runtime: { id: 'test-ext', sendMessage },
+  } as unknown as typeof chrome;
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('TelegramPanel', () => {
+  it('shows the picker when the channel lists videos', async () => {
+    render(<TelegramPanel />);
+    expect(await screen.findByText('A clip')).toBeTruthy();
+    expect(
+      screen.getByRole('button', { name: /Import 0 selected/ }),
+    ).toBeTruthy();
+  });
+
+  it('shows the login prompt when the list returns NO_SESSION', async () => {
+    responses.TELEGRAM_LIST_VIDEOS = {
+      success: false,
+      message: 'NO_SESSION',
+      videos: [],
+    };
+    render(<TelegramPanel />);
+    expect(
+      await screen.findByRole('button', { name: 'Send login code' }),
+    ).toBeTruthy();
+  });
+
+  it('switches from the login prompt to the picker after a successful login', async () => {
+    responses.TELEGRAM_LIST_VIDEOS = {
+      success: false,
+      message: 'NO_SESSION',
+      videos: [],
+    };
+    render(<TelegramPanel />);
+
+    // Login shows first; complete it, then the panel re-lists.
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Send login code' }),
+    );
+    // Now the session exists — the next list call returns videos.
+    responses.TELEGRAM_LIST_VIDEOS = {
+      success: true,
+      message: 'ok',
+      videos: [{ id: '10', caption: 'A clip', date: '2024-01-01T00:00:00Z' }],
+      nextCursor: undefined,
+    };
+    fireEvent.change(await screen.findByLabelText('Login code'), {
+      target: { value: '12345' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    expect(await screen.findByText('A clip')).toBeTruthy();
+  });
+
+  it('keeps the loaded list when a "Load more" page fails', async () => {
+    responses.TELEGRAM_LIST_VIDEOS = {
+      success: true,
+      message: 'ok',
+      videos: [{ id: '10', caption: 'Page one clip', date: '2024-01-01' }],
+      nextCursor: '9',
+    };
+    render(<TelegramPanel />);
+
+    const loadMore = await screen.findByRole('button', { name: 'Load more' });
+    // The second page fails — the first page (and its selection) must survive.
+    responses.TELEGRAM_LIST_VIDEOS = {
+      success: false,
+      message: 'Could not fetch more.',
+      videos: [],
+    };
+    fireEvent.click(loadMore);
+
+    expect(await screen.findByText('Could not fetch more.')).toBeTruthy();
+    // Still the picker: page-one video present, not swapped for a full-panel
+    // error or the login prompt.
+    expect(screen.getByText('Page one clip')).toBeTruthy();
+    expect(
+      screen.queryByRole('button', { name: 'Send login code' }),
+    ).toBeNull();
+  });
+
+  it('shows an error state when the list fails for another reason', async () => {
+    responses.TELEGRAM_LIST_VIDEOS = {
+      success: false,
+      message: 'Something broke',
+      videos: [],
+    };
+    render(<TelegramPanel />);
+    expect(await screen.findByText('Something broke')).toBeTruthy();
+  });
+
+  it('shows an error when the background is unreachable', async () => {
+    responses.TELEGRAM_LIST_VIDEOS = undefined;
+    render(<TelegramPanel />);
+    await waitFor(() =>
+      expect(
+        screen.getByText(/could not reach the background service/),
+      ).toBeTruthy(),
+    );
+  });
+
+  it('shows an error (not a hang) when sendMessage throws synchronously', async () => {
+    // "Extension context invalidated" — sendMessage throws before the callback
+    // ever fires. The request wrapper must swallow it into `undefined` so the
+    // panel lands in error rather than spinning forever.
+    global.chrome = {
+      runtime: {
+        id: 'test-ext',
+        sendMessage: vi.fn(() => {
+          throw new Error('Extension context invalidated.');
+        }),
+      },
+    } as unknown as typeof chrome;
+    render(<TelegramPanel />);
+    await waitFor(() =>
+      expect(
+        screen.getByText(/could not reach the background service/),
+      ).toBeTruthy(),
+    );
+  });
+});

--- a/apps/extension/src/components/TelegramPanel.tsx
+++ b/apps/extension/src/components/TelegramPanel.tsx
@@ -1,0 +1,111 @@
+import { Alert, Box, CircularProgress } from '@mui/material';
+import { useCallback, useEffect, useState } from 'react';
+import { NO_SESSION, type TelegramVideoMessage } from '../background/telegram';
+import { TelegramLogin } from './TelegramLogin';
+import { TelegramPicker } from './TelegramPicker';
+import { listVideos } from './telegramRequests';
+
+type Mode = 'loading' | 'login' | 'picker' | 'error';
+
+/**
+ * The Telegram section of the popup, shown when the active tab is a Telegram
+ * channel. Lists the channel's videos; if the user has no authorized session yet
+ * the `list` action returns `NO_SESSION` (SWO-494) and we show the login prompt
+ * instead — on success we re-list, switching to the picker without a page reload.
+ * The background owns the channelId, so this component only asks for "the current
+ * channel's videos".
+ */
+const TelegramPanel = () => {
+  const [mode, setMode] = useState<Mode>('loading');
+  const [videos, setVideos] = useState<TelegramVideoMessage[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | undefined>(undefined);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [loadMoreError, setLoadMoreError] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // `cursor` undefined = first page (replaces the list); a cursor appends the
+  // next page. Only the first page flips the whole panel into the loading/error
+  // state — an append-page failure must never tear down the already-loaded
+  // picker (and the user's in-progress selection), so those branches surface a
+  // non-destructive inline error and leave the picker in place.
+  const load = useCallback(async (cursor?: string) => {
+    if (cursor) {
+      setLoadingMore(true);
+      setLoadMoreError(null);
+    } else {
+      setMode('loading');
+    }
+
+    const res = await listVideos(cursor);
+
+    if (cursor) {
+      setLoadingMore(false);
+    }
+
+    if (!res) {
+      if (cursor) {
+        setLoadMoreError('Could not load more videos. Try again.');
+        return;
+      }
+      setError('The extension could not reach the background service.');
+      setMode('error');
+      return;
+    }
+
+    if (res.success) {
+      setVideos((prev) => (cursor ? [...prev, ...res.videos] : res.videos));
+      setNextCursor(res.nextCursor);
+      setMode('picker');
+      return;
+    }
+
+    if (cursor) {
+      setLoadMoreError(res.message || 'Could not load more videos. Try again.');
+      return;
+    }
+
+    if (res.message === NO_SESSION) {
+      setMode('login');
+      return;
+    }
+
+    setError(res.message || 'Could not load this channel.');
+    setMode('error');
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  if (mode === 'loading') {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (mode === 'login') {
+    return <TelegramLogin onAuthenticated={() => load()} />;
+  }
+
+  if (mode === 'error') {
+    return (
+      <Box sx={{ p: 2 }}>
+        <Alert severity="error">{error}</Alert>
+      </Box>
+    );
+  }
+
+  return (
+    <TelegramPicker
+      videos={videos}
+      nextCursor={nextCursor}
+      loadingMore={loadingMore}
+      loadMoreError={loadMoreError}
+      onLoadMore={() => load(nextCursor)}
+    />
+  );
+};
+
+export { TelegramPanel };

--- a/apps/extension/src/components/TelegramPicker.test.tsx
+++ b/apps/extension/src/components/TelegramPicker.test.tsx
@@ -1,0 +1,171 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TelegramVideoMessage } from '../background/telegram';
+import { formatDuration, labelFor, TelegramPicker } from './TelegramPicker';
+
+let importResponse: unknown;
+const sendMessage = vi.fn((_msg, cb: (r: unknown) => void) =>
+  cb(importResponse),
+);
+
+const videos: TelegramVideoMessage[] = [
+  {
+    id: '10',
+    filename: 'first.mp4',
+    caption: 'A holiday clip',
+    date: '2024-01-01T00:00:00Z',
+    durationSeconds: 42,
+    thumbnailDataUri: 'data:image/jpeg;base64,AAAA',
+  },
+  {
+    id: '11',
+    date: '2024-02-02T00:00:00Z',
+    durationSeconds: 3725,
+  },
+];
+
+beforeEach(() => {
+  importResponse = { success: true, message: 'ok', taskId: 'task-1' };
+  sendMessage.mockClear();
+  global.chrome = {
+    runtime: { id: 'test-ext', sendMessage },
+  } as unknown as typeof chrome;
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('formatDuration', () => {
+  it('formats seconds as mm:ss and h:mm:ss', () => {
+    expect(formatDuration(42)).toBe('0:42');
+    expect(formatDuration(125)).toBe('2:05');
+    expect(formatDuration(3725)).toBe('1:02:05');
+    expect(formatDuration(undefined)).toBeUndefined();
+  });
+});
+
+describe('labelFor', () => {
+  it('prefers caption, then filename, then the date', () => {
+    expect(labelFor(videos[0])).toBe('A holiday clip');
+    expect(
+      labelFor({ id: 'x', filename: 'clip.mp4', date: '2024-01-01' }),
+    ).toBe('clip.mp4');
+    expect(labelFor({ id: 'x', date: '2024-01-01T00:00:00Z' })).toBe(
+      new Date('2024-01-01T00:00:00Z').toLocaleDateString(),
+    );
+  });
+
+  it('skips whitespace-only caption and filename', () => {
+    expect(
+      labelFor({
+        id: 'x',
+        caption: '   ',
+        filename: '  ',
+        date: '2024-01-01T00:00:00Z',
+      }),
+    ).toBe(new Date('2024-01-01T00:00:00Z').toLocaleDateString());
+  });
+
+  it('falls back to a generic label when the date is unparseable', () => {
+    expect(labelFor({ id: 'x', date: '' })).toBe('Untitled video');
+    expect(labelFor({ id: 'x', date: 'not-a-date' })).toBe('Untitled video');
+  });
+});
+
+describe('TelegramPicker', () => {
+  const renderPicker = (props = {}) =>
+    render(
+      <TelegramPicker
+        videos={videos}
+        nextCursor={undefined}
+        loadingMore={false}
+        onLoadMore={vi.fn()}
+        {...props}
+      />,
+    );
+
+  it('renders each video with a thumbnail, label, and formatted duration', () => {
+    renderPicker();
+    expect(screen.getByText('A holiday clip')).toBeTruthy();
+    expect(screen.getByText('0:42')).toBeTruthy();
+    expect(screen.getByText('1:02:05')).toBeTruthy();
+    const thumb = document.querySelector(
+      'img[src="data:image/jpeg;base64,AAAA"]',
+    );
+    expect(thumb).not.toBeNull();
+  });
+
+  it('imports exactly the selected messageIds and shows success feedback', async () => {
+    renderPicker();
+
+    fireEvent.click(screen.getByText('A holiday clip'));
+    fireEvent.click(screen.getByRole('button', { name: 'Import 1 selected' }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/Import started for 1 video/)).toBeTruthy(),
+    );
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'TELEGRAM_IMPORT',
+        payload: { messageIds: ['10'] },
+      }),
+      expect.any(Function),
+    );
+  });
+
+  it('surfaces an import failure', async () => {
+    importResponse = { success: false, message: 'Could not start the import.' };
+    renderPicker();
+
+    fireEvent.click(screen.getByText('A holiday clip'));
+    fireEvent.click(screen.getByRole('button', { name: 'Import 1 selected' }));
+
+    expect(await screen.findByText('Could not start the import.')).toBeTruthy();
+  });
+
+  it('shows a Load more button only when there is a next cursor', () => {
+    const { rerender } = renderPicker();
+    expect(screen.queryByRole('button', { name: 'Load more' })).toBeNull();
+
+    rerender(
+      <TelegramPicker
+        videos={videos}
+        nextCursor="9"
+        loadingMore={false}
+        onLoadMore={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Load more' })).toBeTruthy();
+  });
+
+  it('renders an empty state when there are no videos', () => {
+    render(
+      <TelegramPicker
+        videos={[]}
+        nextCursor={undefined}
+        loadingMore={false}
+        onLoadMore={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('No videos found in this channel.')).toBeTruthy();
+    // Nothing to import and nowhere to page to.
+    expect(screen.queryByRole('button', { name: 'Load more' })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Import/ })).toBeNull();
+  });
+
+  it('keeps Load more reachable when a page is empty but a cursor remains', () => {
+    const onLoadMore = vi.fn();
+    render(
+      <TelegramPicker
+        videos={[]}
+        nextCursor="9"
+        loadingMore={false}
+        onLoadMore={onLoadMore}
+      />,
+    );
+    // An empty page must not dead-end: the next page may hold videos.
+    expect(screen.getByText('No videos found in this channel.')).toBeTruthy();
+    const loadMore = screen.getByRole('button', { name: 'Load more' });
+    fireEvent.click(loadMore);
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/extension/src/components/TelegramPicker.tsx
+++ b/apps/extension/src/components/TelegramPicker.tsx
@@ -1,0 +1,192 @@
+import {
+  Alert,
+  Avatar,
+  Box,
+  Button,
+  Checkbox,
+  List,
+  ListItem,
+  ListItemAvatar,
+  ListItemButton,
+  ListItemText,
+  Typography,
+} from '@mui/material';
+import { useState } from 'react';
+import type { TelegramVideoMessage } from '../background/telegram';
+import { importArchive } from './telegramRequests';
+
+interface TelegramPickerProps {
+  videos: TelegramVideoMessage[];
+  nextCursor?: string;
+  loadingMore: boolean;
+  loadMoreError?: string | null;
+  onLoadMore: () => void;
+}
+
+// Seconds → `mm:ss` (or `h:mm:ss` past an hour). `undefined` → no duration shown.
+const formatDuration = (seconds?: number): string | undefined => {
+  if (seconds === undefined) return undefined;
+  const total = Math.round(seconds);
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  const mm = h > 0 ? String(m).padStart(2, '0') : String(m);
+  const ss = String(s).padStart(2, '0');
+  return h > 0 ? `${h}:${mm}:${ss}` : `${mm}:${ss}`;
+};
+
+// Best human-readable label: caption, else filename, else the date. Both text
+// fields are trimmed so a whitespace-only value falls through, and an
+// unparseable date falls back to a generic label rather than "Invalid Date".
+const labelFor = (video: TelegramVideoMessage): string => {
+  const caption = video.caption?.trim();
+  if (caption) return caption;
+  const filename = video.filename?.trim();
+  if (filename) return filename;
+  const date = new Date(video.date);
+  return Number.isNaN(date.getTime())
+    ? 'Untitled video'
+    : date.toLocaleDateString();
+};
+
+/**
+ * Paginated, checkable list of a Telegram channel's videos. The list itself
+ * (and pagination) is owned by `TelegramPanel`; this component owns selection and
+ * the import trigger + its success/pending feedback. Mirrors `RecentTab`'s
+ * List/ListItem structure, swapping the secondary action for a `Checkbox`.
+ */
+const TelegramPicker = ({
+  videos,
+  nextCursor,
+  loadingMore,
+  loadMoreError,
+  onLoadMore,
+}: TelegramPickerProps) => {
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [importing, setImporting] = useState(false);
+  const [feedback, setFeedback] = useState<{
+    severity: 'success' | 'error';
+    text: string;
+  } | null>(null);
+
+  const toggle = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const handleImport = async () => {
+    if (selected.size === 0) return;
+    // Snapshot the selection at click time: the user can toggle items while the
+    // request is in flight, so the count in the message and the ids we clear on
+    // success must be exactly what was imported — not the live set.
+    const ids = [...selected];
+    setImporting(true);
+    setFeedback(null);
+    const res = await importArchive(ids);
+    setImporting(false);
+    if (res?.success) {
+      setFeedback({
+        severity: 'success',
+        text: `Import started for ${ids.length} video(s).`,
+      });
+      setSelected((prev) => {
+        const next = new Set(prev);
+        for (const id of ids) next.delete(id);
+        return next;
+      });
+    } else {
+      setFeedback({
+        severity: 'error',
+        text: res?.message ?? 'Could not start the import.',
+      });
+    }
+  };
+
+  return (
+    <Box sx={{ p: 2 }}>
+      {feedback && (
+        <Alert severity={feedback.severity} sx={{ mb: 1 }}>
+          {feedback.text}
+        </Alert>
+      )}
+      {videos.length === 0 ? (
+        // Empty page — but a `nextCursor` may still point at a later page with
+        // videos, so keep "Load more" below reachable rather than dead-ending.
+        <Typography align="center" sx={{ color: 'text.secondary', py: 2 }}>
+          No videos found in this channel.
+        </Typography>
+      ) : (
+        <List disablePadding>
+          {videos.map((video) => {
+            const duration = formatDuration(video.durationSeconds);
+            return (
+              <ListItem key={video.id} disablePadding divider>
+                <ListItemButton onClick={() => toggle(video.id)} dense>
+                  <Checkbox
+                    edge="start"
+                    checked={selected.has(video.id)}
+                    tabIndex={-1}
+                    disableRipple
+                    slotProps={{ input: { 'aria-label': labelFor(video) } }}
+                  />
+                  {video.thumbnailDataUri && (
+                    <ListItemAvatar>
+                      <Avatar
+                        variant="rounded"
+                        src={video.thumbnailDataUri}
+                        alt=""
+                      />
+                    </ListItemAvatar>
+                  )}
+                  <ListItemText
+                    primary={labelFor(video)}
+                    secondary={duration}
+                    slotProps={{ primary: { noWrap: true } }}
+                  />
+                </ListItemButton>
+              </ListItem>
+            );
+          })}
+        </List>
+      )}
+
+      {loadMoreError && (
+        <Alert severity="error" sx={{ mt: 1 }}>
+          {loadMoreError}
+        </Alert>
+      )}
+
+      {nextCursor && (
+        <Button
+          fullWidth
+          onClick={onLoadMore}
+          disabled={loadingMore}
+          sx={{ mt: 1 }}
+        >
+          Load more
+        </Button>
+      )}
+
+      {videos.length > 0 && (
+        <Button
+          variant="contained"
+          fullWidth
+          onClick={handleImport}
+          disabled={importing || selected.size === 0}
+          sx={{ mt: 1 }}
+        >
+          {`Import ${selected.size} selected`}
+        </Button>
+      )}
+    </Box>
+  );
+};
+
+export { TelegramPicker, formatDuration, labelFor };

--- a/apps/extension/src/components/telegramRequests.ts
+++ b/apps/extension/src/components/telegramRequests.ts
@@ -1,0 +1,59 @@
+import type { ListResult } from '../background/telegram';
+
+// Popup → background request/response over `chrome.runtime.sendMessage`, promisified
+// so the Telegram components can `await` a background action's result. Mirrors how
+// `AuthPanel` calls `GET_AUTH_STATUS` with a callback, wrapped for async/await.
+// The availability check is at call time (not module load) so it reflects the
+// current `chrome` global rather than whatever existed when this module loaded.
+const sendTelegramMessage = <T>(
+  type: string,
+  payload?: Record<string, unknown>,
+): Promise<T | undefined> =>
+  new Promise((resolve) => {
+    if (typeof chrome === 'undefined' || !chrome.runtime?.id) {
+      resolve(undefined);
+      return;
+    }
+    // `sendMessage` can throw *synchronously* ("Extension context invalidated")
+    // when the service worker is torn down while the popup is open — the
+    // `runtime.id` check above doesn't cover that. Without this guard the throw
+    // rejects the promise and the awaiting component hangs on its busy flag.
+    try {
+      chrome.runtime.sendMessage({ type, payload }, (response: T) => {
+        // Touch `lastError` so Chrome doesn't log an "Unchecked runtime.lastError"
+        // warning when the port closed before responding; callers treat the
+        // resulting `undefined` as an unreachable-background error.
+        void chrome.runtime.lastError;
+        resolve(response);
+      });
+    } catch {
+      resolve(undefined);
+    }
+  });
+
+interface Envelope {
+  success: boolean;
+  message: string;
+}
+
+const listVideos = (cursor?: string) =>
+  sendTelegramMessage<ListResult>('TELEGRAM_LIST_VIDEOS', { cursor });
+
+const importArchive = (messageIds: string[]) =>
+  sendTelegramMessage<Envelope & { taskId?: string }>('TELEGRAM_IMPORT', {
+    messageIds,
+  });
+
+const requestLoginCode = () =>
+  sendTelegramMessage<Envelope>('TELEGRAM_REQUEST_LOGIN_CODE');
+
+const submitLoginCode = (code: string) =>
+  sendTelegramMessage<Envelope>('TELEGRAM_SUBMIT_LOGIN_CODE', { code });
+
+export {
+  listVideos,
+  importArchive,
+  requestLoginCode,
+  submitLoginCode,
+  type Envelope,
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,6 +296,12 @@ importers:
       '@graphql-codegen/cli':
         specifier: ^5.0.3
         version: 5.0.5(@parcel/watcher@2.5.1)(@types/node@24.13.2)(enquirer@2.4.1)(graphql@16.10.0)(typescript@5.8.2)
+      '@testing-library/dom':
+        specifier: 10.4.0
+        version: 10.4.0
+      '@testing-library/react':
+        specifier: ^16.1.0
+        version: 16.2.0(@testing-library/dom@10.4.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/chrome':
         specifier: ^0.0.268
         version: 0.0.268
@@ -1199,10 +1205,6 @@ packages:
 
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.25.9':
-    resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.29.7':
@@ -13521,8 +13523,6 @@ snapshots:
 
   '@babel/helper-string-parser@7.29.7': {}
 
-  '@babel/helper-validator-identifier@7.25.9': {}
-
   '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/helper-validator-option@7.29.7': {}
@@ -14599,7 +14599,7 @@ snapshots:
   '@babel/types@7.26.10':
     dependencies:
       '@babel/helper-string-parser': 7.25.9
-      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@babel/types@7.29.7':
     dependencies:


### PR DESCRIPTION
## Summary

Adds the Telegram section of the browser-extension popup. When you're on a Telegram channel page, the popup now lists that channel's videos, lets you tick the ones you want, and imports them into your library. First-time users get a login step right in the popup — tap **Send login code**, enter the code Telegram sends to your device, and the picker appears. Completes the Telegram feature (backend gateway Actions #529, io import handler #530).

Refs SWO-496 (parent SWO-490).

The extension bridges your sign-in token to the server and lets the server decide who you are — the popup never sends your user id, and the login code is never logged or stored. A failed "Load more" keeps the videos already on screen, and if the background is unreachable the popup shows an error instead of spinning forever.

## Test plan

Note: the full import round-trip (Telegram → library) can't be exercised until the backend deploy pipeline / Cloud Tasks is restored (SWO-546). The checks below cover the popup behaviour, which is unit-tested (121 tests) and verifiable once the backend is deployed.

- [ ] Open a **Telegram channel** page with the extension; the popup shows the channel's videos with thumbnails, titles, and durations (not the generic "Import" card).
- [ ] With no Telegram session yet, the popup shows **Connect your Telegram** → **Send login code**; entering the code swaps to the video picker without reloading.
- [ ] Tick some videos and press **Import N selected**; a success message appears and the ticks clear.
- [ ] On a channel with more videos than one page, **Load more** appends the next page; if that page fails, the list you already had stays put with an inline error.
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Telegram channel detection and a dedicated extension workflow.
  * Added Telegram login with verification-code authentication.
  * Added a paginated video picker with thumbnails, selection, and archive import.
  * Added loading, empty, success, and error states with actionable feedback.

* **Bug Fixes**
  * Improved handling of unavailable sessions, network errors, and disconnected extension contexts.

* **Tests**
  * Added comprehensive coverage for Telegram login, browsing, pagination, selection, and import flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->