### PR TITLE
[WIP] fix(backend): route Telegram import to the existing io queue

### DIFF
--- a/apps/backend/src/apps/gateway/telegram-actions/routes/import/index.test.ts
+++ b/apps/backend/src/apps/gateway/telegram-actions/routes/import/index.test.ts
@@ -59,6 +59,8 @@ describe('importTelegramArchive', () => {
     expect(taskConfig).toMatchObject({
       audience: 'https://io.example.test',
       url: 'https://io.example.test/telegram/import-handler',
+      // Runs on the io service → shares the existing io queue.
+      queue: 'stream-video',
       entityType: TaskEntityType.TELEGRAM_ARCHIVE,
       type: TaskType.IMPORT_TELEGRAM,
       payload: {

--- a/apps/backend/src/apps/gateway/telegram-actions/routes/import/index.ts
+++ b/apps/backend/src/apps/gateway/telegram-actions/routes/import/index.ts
@@ -62,7 +62,10 @@ const importTelegramArchive = async (
 
     const taskConfig: CreateCloudTasksParams = {
       audience: ioServiceUrl,
-      queue: queues.telegramArchiveQueue,
+      // The import runs on the io service (download from Telegram → stream to
+      // GCS: light I/O, not ffmpeg), so it shares the existing io queue rather
+      // than a dedicated one — same queue the other io handlers use.
+      queue: queues.streamVideoQueue,
       payload: {
         data: { channelId, messageIds: normalizedMessageIds, userId },
         metadata,

--- a/apps/backend/src/utils/systemConfig.ts
+++ b/apps/backend/src/utils/systemConfig.ts
@@ -9,13 +9,11 @@ const uuidNamespaces = {
 enum QueueName {
   StreamVideo = 'stream-video',
   ConvertVideo = 'convert-video',
-  TelegramArchive = 'telegram-archive',
 }
 
 const queues = {
   streamVideoQueue: QueueName.StreamVideo,
   convertVideoQueue: QueueName.ConvertVideo,
-  telegramArchiveQueue: QueueName.TelegramArchive,
 };
 type Queues = typeof queues;
 


### PR DESCRIPTION
## Summary

No user-facing changes. Fixes the Telegram video import failing at the very last step. The import job was being sent to a background queue named `telegram-archive` that was never created, so every import failed with "Failed to create import task" (`5 NOT_FOUND: Queue does not exist`).

The import work runs on the **io** service (downloading from Telegram and streaming to storage — light I/O, not video re-encoding), so it now shares the existing **io queue** (`stream-video`) that the other io jobs already use, instead of needing a dedicated queue. Only the queue reference changes — the job still targets the same io handler. Removes the now-unused queue entry.

Found while testing #531 (SWO-496). Refs SWO-603.

## Test plan

- [ ] Type checks pass
- [ ] Backend tests pass (gateway import route asserts the job goes to the `stream-video` queue)
- [ ] After the gateway redeploys: selecting videos in the extension and pressing Import no longer errors, and a task is enqueued
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Telegram archive imports by routing processing through the appropriate video-processing queue.
  * Removed the unused Telegram archive queue configuration.
  * Updated validation to ensure import tasks use the correct queue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->