### PR TITLE
[WIP] fix(extension): persist Telegram login step across popup reopen

### DIFF
--- a/apps/extension/src/components/TelegramLogin.test.tsx
+++ b/apps/extension/src/components/TelegramLogin.test.tsx
@@ -8,14 +8,36 @@ const sendMessage = vi.fn((msg: { type: string }, cb: (r: unknown) => void) =>
   cb(responses[msg.type]),
 );
 
+// In-memory stand-in for chrome.storage.local, backing the persisted "code sent"
+// step (SWO-604). Reset per test so cases don't leak the flag into each other.
+let store: Record<string, string>;
+
 beforeEach(() => {
   responses = {
     TELEGRAM_REQUEST_LOGIN_CODE: { success: true, message: 'sent' },
     TELEGRAM_SUBMIT_LOGIN_CODE: { success: true, message: 'ok' },
   };
   sendMessage.mockClear();
+  store = {};
   global.chrome = {
     runtime: { id: 'test-ext', sendMessage },
+    storage: {
+      local: {
+        get: vi.fn(async (keys: string[]) => {
+          const out: Record<string, string> = {};
+          for (const key of keys) {
+            if (key in store) out[key] = store[key];
+          }
+          return out;
+        }),
+        set: vi.fn(async (items: Record<string, string>) => {
+          Object.assign(store, items);
+        }),
+        remove: vi.fn(async (keys: string[]) => {
+          for (const key of keys) delete store[key];
+        }),
+      },
+    },
   } as unknown as typeof chrome;
 });
 
@@ -29,8 +51,11 @@ describe('TelegramLogin', () => {
     render(<TelegramLogin onAuthenticated={onAuthenticated} />);
 
     // Step 1: send code — the code field only appears after that succeeds.
+    const sendButton = await screen.findByRole('button', {
+      name: 'Send login code',
+    });
     expect(screen.queryByLabelText('Login code')).toBeNull();
-    fireEvent.click(screen.getByRole('button', { name: 'Send login code' }));
+    fireEvent.click(sendButton);
 
     const codeInput = await screen.findByLabelText('Login code');
     fireEvent.change(codeInput, { target: { value: '12345' } });
@@ -46,6 +71,56 @@ describe('TelegramLogin', () => {
     );
   });
 
+  it('restores the code-entry step when a code was already sent', async () => {
+    // Simulate the popup being reopened after the user left to read the code:
+    // the persisted flag must take them straight to the code field, without
+    // re-requesting a code.
+    store.telegramLoginCodeSent = 'true';
+    render(<TelegramLogin onAuthenticated={vi.fn()} />);
+
+    expect(await screen.findByLabelText('Login code')).toBeTruthy();
+    expect(
+      screen.queryByRole('button', { name: 'Send login code' }),
+    ).toBeNull();
+    expect(sendMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'TELEGRAM_REQUEST_LOGIN_CODE' }),
+      expect.any(Function),
+    );
+  });
+
+  it('persists the sent step and clears it once login succeeds', async () => {
+    const onAuthenticated = vi.fn();
+    render(<TelegramLogin onAuthenticated={onAuthenticated} />);
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Send login code' }),
+    );
+
+    const codeInput = await screen.findByLabelText('Login code');
+    await waitFor(() => expect(store.telegramLoginCodeSent).toBe('true'));
+
+    fireEvent.change(codeInput, { target: { value: '12345' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => expect(onAuthenticated).toHaveBeenCalledTimes(1));
+    expect(store.telegramLoginCodeSent).toBeUndefined();
+  });
+
+  it('returns to the send step and clears the flag when asked for a new code', async () => {
+    store.telegramLoginCodeSent = 'true';
+    render(<TelegramLogin onAuthenticated={vi.fn()} />);
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Send a new code' }),
+    );
+
+    expect(
+      await screen.findByRole('button', { name: 'Send login code' }),
+    ).toBeTruthy();
+    expect(screen.queryByLabelText('Login code')).toBeNull();
+    expect(store.telegramLoginCodeSent).toBeUndefined();
+  });
+
   it('shows an error and stays on the code step when the code is rejected', async () => {
     responses.TELEGRAM_SUBMIT_LOGIN_CODE = {
       success: false,
@@ -54,7 +129,9 @@ describe('TelegramLogin', () => {
     const onAuthenticated = vi.fn();
     render(<TelegramLogin onAuthenticated={onAuthenticated} />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Send login code' }));
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Send login code' }),
+    );
     const codeInput = await screen.findByLabelText('Login code');
     fireEvent.change(codeInput, { target: { value: '00000' } });
     fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
@@ -70,7 +147,9 @@ describe('TelegramLogin', () => {
     };
     render(<TelegramLogin onAuthenticated={vi.fn()} />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Send login code' }));
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Send login code' }),
+    );
 
     expect(await screen.findByText('MISCONFIGURED')).toBeTruthy();
     expect(screen.queryByLabelText('Login code')).toBeNull();

--- a/apps/extension/src/components/TelegramLogin.test.tsx
+++ b/apps/extension/src/components/TelegramLogin.test.tsx
@@ -106,6 +106,25 @@ describe('TelegramLogin', () => {
     expect(store.telegramLoginCodeSent).toBeUndefined();
   });
 
+  it('still notifies the parent when the post-login cleanup write fails', async () => {
+    // The login already succeeded server-side, so a rejected storage cleanup
+    // must not swallow that success and strand the user on the code step.
+    (chrome.storage.local.remove as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('storage unavailable'),
+    );
+    const onAuthenticated = vi.fn();
+    render(<TelegramLogin onAuthenticated={onAuthenticated} />);
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Send login code' }),
+    );
+    const codeInput = await screen.findByLabelText('Login code');
+    fireEvent.change(codeInput, { target: { value: '12345' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => expect(onAuthenticated).toHaveBeenCalledTimes(1));
+  });
+
   it('returns to the send step and clears the flag when asked for a new code', async () => {
     store.telegramLoginCodeSent = 'true';
     render(<TelegramLogin onAuthenticated={vi.fn()} />);

--- a/apps/extension/src/components/TelegramLogin.tsx
+++ b/apps/extension/src/components/TelegramLogin.tsx
@@ -1,5 +1,18 @@
-import { Alert, Box, Button, TextField, Typography } from '@mui/material';
-import { useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Link,
+  TextField,
+  Typography,
+} from '@mui/material';
+import {
+  getItems,
+  removeItems,
+  setItem,
+} from 'core/universal/extension/storage';
+import { useEffect, useState } from 'react';
 import { requestLoginCode, submitLoginCode } from './telegramRequests';
 
 interface TelegramLoginProps {
@@ -7,18 +20,46 @@ interface TelegramLoginProps {
   onAuthenticated: () => void;
 }
 
+// A Chrome popup is destroyed the instant it loses focus — which is exactly what
+// happens when the user leaves to read the code Telegram sent. Persisting "a code
+// has been sent" in chrome.storage lets the reopened popup return straight to the
+// code-entry step instead of the send button, so the still-valid pending login
+// (held server-side in telegram_credentials) can actually be completed. Cleared
+// once login succeeds or the user asks for a fresh code (SWO-604).
+const CODE_SENT_KEY = 'telegramLoginCodeSent';
+
 /**
  * First-time, per-user Telegram login inside the popup (SWO-494/496). Step 1:
  * "Send login code" → `requestTelegramLoginCode`; Telegram delivers the code to
  * the user's own device. Step 2: enter it → `submitTelegramLoginCode`; on success
  * the parent swaps to the picker. Mirrors `AuthPanel`'s status/alert states plus
  * `ClipboardTab`'s input + button idiom.
+ *
+ * The current step survives the popup closing (SWO-604): `requestLoginCode` has
+ * already persisted the pending session server-side, so on reopen we restore the
+ * code-entry step from chrome.storage rather than dropping back to "Send login
+ * code" — where re-sending would waste that pending session and risk FLOOD_WAIT.
  */
 const TelegramLogin = ({ onAuthenticated }: TelegramLoginProps) => {
+  // Gate the first paint on the async storage read so a persisted "code sent"
+  // doesn't flash the send-code step before it's restored.
+  const [hydrated, setHydrated] = useState(false);
   const [codeSent, setCodeSent] = useState(false);
   const [code, setCode] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    getItems([CODE_SENT_KEY]).then((items) => {
+      if (!active) return;
+      setCodeSent(items[CODE_SENT_KEY] === 'true');
+      setHydrated(true);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
 
   const handleSendCode = async () => {
     setBusy(true);
@@ -27,9 +68,20 @@ const TelegramLogin = ({ onAuthenticated }: TelegramLoginProps) => {
     setBusy(false);
     if (res?.success) {
       setCodeSent(true);
+      await setItem(CODE_SENT_KEY, 'true');
     } else {
       setError(res?.message ?? 'Could not send the login code.');
     }
+  };
+
+  // Escape hatch back to step 1. The persisted step can outlive the pending login
+  // (e.g. the code expired), which would otherwise trap the user on a code field
+  // that only rejects — this lets them request a fresh code.
+  const handleResend = async () => {
+    setError(null);
+    setCode('');
+    setCodeSent(false);
+    await removeItems([CODE_SENT_KEY]);
   };
 
   const handleSubmit = async () => {
@@ -39,11 +91,20 @@ const TelegramLogin = ({ onAuthenticated }: TelegramLoginProps) => {
     const res = await submitLoginCode(code.trim());
     setBusy(false);
     if (res?.success) {
+      await removeItems([CODE_SENT_KEY]);
       onAuthenticated();
     } else {
       setError(res?.message ?? 'That code was not accepted.');
     }
   };
+
+  if (!hydrated) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
 
   return (
     <Box sx={{ p: 2 }}>
@@ -90,6 +151,17 @@ const TelegramLogin = ({ onAuthenticated }: TelegramLoginProps) => {
           >
             Submit
           </Button>
+          <Typography variant="body2" sx={{ textAlign: 'center', mt: 2 }}>
+            <Link
+              component="button"
+              type="button"
+              underline="hover"
+              disabled={busy}
+              onClick={handleResend}
+            >
+              Send a new code
+            </Link>
+          </Typography>
         </>
       )}
     </Box>

--- a/apps/extension/src/components/TelegramLogin.tsx
+++ b/apps/extension/src/components/TelegramLogin.tsx
@@ -65,23 +65,30 @@ const TelegramLogin = ({ onAuthenticated }: TelegramLoginProps) => {
     setBusy(true);
     setError(null);
     const res = await requestLoginCode();
-    setBusy(false);
     if (res?.success) {
-      setCodeSent(true);
+      // Persist first, then reveal the code step: the popup is destroyed the
+      // instant the user leaves to fetch the code, so the visible step must
+      // never get ahead of the write that lets a reopen restore it.
       await setItem(CODE_SENT_KEY, 'true');
+      setCodeSent(true);
     } else {
       setError(res?.message ?? 'Could not send the login code.');
     }
+    setBusy(false);
   };
 
   // Escape hatch back to step 1. The persisted step can outlive the pending login
   // (e.g. the code expired), which would otherwise trap the user on a code field
   // that only rejects — this lets them request a fresh code.
   const handleResend = async () => {
+    setBusy(true);
     setError(null);
+    // Clear the persisted step before dropping back to send-code, so a reopen
+    // mid-flight can't rehydrate the stale code step.
+    await removeItems([CODE_SENT_KEY]);
     setCode('');
     setCodeSent(false);
-    await removeItems([CODE_SENT_KEY]);
+    setBusy(false);
   };
 
   const handleSubmit = async () => {
@@ -89,13 +96,15 @@ const TelegramLogin = ({ onAuthenticated }: TelegramLoginProps) => {
     setBusy(true);
     setError(null);
     const res = await submitLoginCode(code.trim());
-    setBusy(false);
     if (res?.success) {
-      await removeItems([CODE_SENT_KEY]);
+      // Login already succeeded server-side; a failed cleanup must not swallow
+      // that success and trap the user on the code step.
+      await removeItems([CODE_SENT_KEY]).catch(() => {});
       onAuthenticated();
-    } else {
-      setError(res?.message ?? 'That code was not accepted.');
+      return;
     }
+    setError(res?.message ?? 'That code was not accepted.');
+    setBusy(false);
   };
 
   if (!hydrated) {

--- a/apps/extension/src/components/TelegramPanel.test.tsx
+++ b/apps/extension/src/components/TelegramPanel.test.tsx
@@ -22,6 +22,15 @@ beforeEach(() => {
   sendMessage.mockClear();
   global.chrome = {
     runtime: { id: 'test-ext', sendMessage },
+    // The nested TelegramLogin restores its step from chrome.storage on mount
+    // (SWO-604); an empty store just means "no code sent yet".
+    storage: {
+      local: {
+        get: vi.fn(async () => ({})),
+        set: vi.fn(async () => {}),
+        remove: vi.fn(async () => {}),
+      },
+    },
   } as unknown as typeof chrome;
 });
 


### PR DESCRIPTION
## Summary

First-time Telegram login in the extension was **impossible to finish**. The popup shows a "Send login code" button; the user clicks it, then leaves to read the code Telegram sent — which closes the popup. On reopen it was back at "Send login code" with nowhere to type the code, so login could never complete. Re-clicking "Send" also risked a Telegram rate-limit (`FLOOD_WAIT`).

The pending login is already stored server-side, so the code stays valid — only the popup's step was lost. This persists that step in `chrome.storage` so a reopened popup returns straight to the code field, and adds a "Send a new code" escape hatch for when a persisted step outlives an expired code.

## Test plan

- [x] `pnpm typecheck`, `biome lint`, full extension `vitest` (125 passing)
- [ ] Manual: connect Telegram → click "Send login code" → close popup → reopen → **lands on the code field**, enter the code Telegram sent → login completes
- [ ] Manual: on the code step, "Send a new code" returns to the send button; a fresh user still starts at "Send login code"

Refs SWO-604


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Login progress is now preserved when reopening the extension popup.
  * Added a “Send a new code” option to restart the login-code flow.
  * Login state is cleared automatically after successful authentication.

* **Bug Fixes**
  * Prevented the login screen from briefly showing the wrong step while saved progress loads.
  * Improved handling of code resend and login error flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->