### PR TITLE
[WIP] fix(extension): reflect the active tab in the popup, not a stale global

### DIFF
--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -91,8 +91,20 @@ chrome.tabs.onUpdated.addListener((_tabId, changeInfo, tab) => {
 // stored video metadata only when it belongs to this exact tab — never a
 // different one. Anything else has nothing importable, so returns null.
 const resolveActiveTabContent = async (): Promise<PageContent | null> => {
-  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-  const url = tab?.url;
+  // A rejected query must never leave the popup spinning: this is the message
+  // that clears its loading state, so on any failure we fall through to a null
+  // payload ("nothing detected") rather than never replying.
+  let url: string | undefined;
+  try {
+    const [tab] = await chrome.tabs.query({
+      active: true,
+      currentWindow: true,
+    });
+    url = tab?.url;
+  } catch (error) {
+    console.error('Failed to query the active tab', error);
+    return null;
+  }
   if (!url) {
     return null;
   }

--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -16,6 +16,8 @@ import {
   submitTelegramLoginCode,
 } from './background/telegram';
 import { importVideo } from './background/watch';
+import { detectPageType } from './content-scripts/parsers/detector';
+import { telegramMetadataFromUrl } from './content-scripts/parsers/telegram';
 
 console.log('Background script starting...');
 
@@ -79,6 +81,56 @@ chrome.tabs.onUpdated.addListener((_tabId, changeInfo, tab) => {
     detectPdfTab(tab.url);
   }
 });
+
+// Derive the popup's content from the tab the user is ON RIGHT NOW, rather than a
+// module-global left behind by whichever tab last fired a content-script
+// detection (SWO-605). The page type is derived from the active tab's URL;
+// telegram and pdf are fully URL-derivable so we rebuild them fresh (this also
+// tracks web.telegram.org's in-app hash navigation, which the load-time content
+// script can't see). youtube/vimeo titles need the page DOM, so we trust the
+// stored video metadata only when it belongs to this exact tab — never a
+// different one. Anything else has nothing importable, so returns null.
+const resolveActiveTabContent = async (): Promise<PageContent | null> => {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  const url = tab?.url;
+  if (!url) {
+    return null;
+  }
+
+  const pageType = detectPageType(url);
+
+  if (pageType === 'telegram') {
+    storedTelegramMetadata = telegramMetadataFromUrl(url);
+    currentPageContent = {
+      url,
+      title: 'Telegram channel',
+      pageType: 'telegram',
+    };
+    return currentPageContent;
+  }
+
+  if (pageType === 'pdf') {
+    const fileName = url.split('/').pop() || url;
+    const title =
+      decodeURIComponent(fileName.replace(/\.pdf$/i, '')) || fileName;
+    currentPdfMetadata = { url, title, pageCount: 0 };
+    currentPageContent = { url, title, pageType: 'pdf' };
+    return currentPageContent;
+  }
+
+  if (pageType === 'youtube' || pageType === 'vimeo') {
+    if (storedVideoMetadata?.url === url) {
+      return {
+        url,
+        title: storedVideoMetadata.title ?? 'Video',
+        pageType,
+      };
+    }
+    return null;
+  }
+
+  return null;
+};
 
 chrome.runtime.onMessageExternal.addListener(
   async (message, sender, sendResponse) => {
@@ -158,11 +210,12 @@ chrome.runtime.onMessage.addListener(async (message, _sender, sendResponse) => {
     }
 
     case 'REQUEST_TAB_CONTENT': {
+      const payload = await resolveActiveTabContent();
       chrome.runtime.sendMessage({
         source: 'background',
         target: 'popup',
         type: 'CURRENT_TAB_CONTENT',
-        payload: currentPageContent ?? storedVideoMetadata ?? null,
+        payload,
       });
       return;
     }

--- a/apps/extension/src/content-scripts/parsers/telegram.test.ts
+++ b/apps/extension/src/content-scripts/parsers/telegram.test.ts
@@ -5,6 +5,7 @@ import {
   getChannelIdFromHash,
   getVariant,
   isTmeHostname,
+  telegramMetadataFromUrl,
 } from './telegram';
 
 describe('getVariant', () => {
@@ -103,6 +104,57 @@ describe('getChannelFromTmePath', () => {
 
   it('should return empty object for root path', () => {
     expect(getChannelFromTmePath('/')).toEqual({});
+  });
+});
+
+describe('telegramMetadataFromUrl', () => {
+  it('extracts username channel and variant from a /k/ hash URL', () => {
+    const metadata = telegramMetadataFromUrl(
+      'https://web.telegram.org/k/#@somechannel',
+    );
+    expect(metadata.source).toBe('web-app');
+    expect(metadata.channelId).toBe('@somechannel');
+    expect(metadata.variant).toBe('k');
+  });
+
+  it('extracts a negative numeric channel from a /a/ hash URL', () => {
+    const metadata = telegramMetadataFromUrl(
+      'https://web.telegram.org/a/#-582839764',
+    );
+    expect(metadata.channelId).toBe('-582839764');
+    expect(metadata.variant).toBe('a');
+  });
+
+  it('does not detect a channel for a personal chat', () => {
+    expect(
+      telegramMetadataFromUrl('https://web.telegram.org/a/#8115119658')
+        .channelId,
+    ).toBeUndefined();
+  });
+
+  it('does not detect a channel for the chat list (no hash)', () => {
+    expect(
+      telegramMetadataFromUrl('https://web.telegram.org/k/').channelId,
+    ).toBeUndefined();
+  });
+
+  it('extracts a bare username channel from a t.me link', () => {
+    const metadata = telegramMetadataFromUrl('https://t.me/ngocmaicutiiii');
+    expect(metadata.source).toBe('share-link');
+    expect(metadata.channelId).toBe('ngocmaicutiiii');
+    expect(metadata.messageId).toBeUndefined();
+  });
+
+  it('extracts channel and message id from a t.me single-post link', () => {
+    const metadata = telegramMetadataFromUrl('https://t.me/ngocmaicutiiii/s/3');
+    expect(metadata.channelId).toBe('ngocmaicutiiii');
+    expect(metadata.messageId).toBe('3');
+  });
+
+  it('returns an empty web-app payload for an unparseable URL', () => {
+    const metadata = telegramMetadataFromUrl('not a url');
+    expect(metadata.source).toBe('web-app');
+    expect(metadata.channelId).toBeUndefined();
   });
 });
 

--- a/apps/extension/src/content-scripts/parsers/telegram.ts
+++ b/apps/extension/src/content-scripts/parsers/telegram.ts
@@ -108,12 +108,21 @@ const getChannelFromTmePath = (pathname: string): TmeChannel => {
 const isTmeHostname = (hostname: string): boolean =>
   hostname === 't.me' || hostname === 'www.t.me';
 
-const extractTelegramMetadata = (): TelegramChannelMetadata => {
-  if (typeof window === 'undefined') {
-    return { url: '', source: 'web-app' };
+// Derive the channel metadata from a URL string alone — no DOM. Everything the
+// content-script path reads (hostname/pathname/hash) lives in the URL, so the
+// background can reconcile the popup against the ACTIVE tab's URL without a
+// content script (SWO-605), which is also what tracks in-app hash navigation
+// between channels on web.telegram.org. An unparseable URL yields an empty
+// web-app payload (no channelId), matching a page that identifies no channel.
+const telegramMetadataFromUrl = (url: string): TelegramChannelMetadata => {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { url, source: 'web-app' };
   }
 
-  const { hostname, pathname, hash, href } = window.location;
+  const { hostname, pathname, hash, href } = parsed;
 
   if (isTmeHostname(hostname)) {
     const { channelId, messageId } = getChannelFromTmePath(pathname);
@@ -126,8 +135,17 @@ const extractTelegramMetadata = (): TelegramChannelMetadata => {
   return { url: href, source: 'web-app', channelId, variant };
 };
 
+const extractTelegramMetadata = (): TelegramChannelMetadata => {
+  if (typeof window === 'undefined') {
+    return { url: '', source: 'web-app' };
+  }
+
+  return telegramMetadataFromUrl(window.location.href);
+};
+
 export {
   extractTelegramMetadata,
+  telegramMetadataFromUrl,
   getChannelFromTmePath,
   getChannelIdFromHash,
   getVariant,


### PR DESCRIPTION
## Summary

The extension popup is meant to show what's on the tab you're looking at, but after switching tabs it kept showing the **previous** tab's content — e.g. open a Telegram tab, switch to another tab, open the popup, and it still shows Telegram. You had to reload the page to fix it.

Cause: the background kept a single global set only when a content script fires on page load, so switching to an already-loaded tab re-detected nothing. This resolves the popup's content from the **active tab's URL** on each open: Telegram and PDF are rebuilt fresh from the URL (which also tracks web.telegram.org's in-app channel navigation), and YouTube/Vimeo metadata is trusted only when it belongs to the active tab. Adds `telegramMetadataFromUrl` as the URL-only counterpart to `extractTelegramMetadata`.

## Test plan

- [x] `pnpm typecheck`, `biome lint`, full extension `vitest` (129 passing), `vite build`
- [ ] Manual: open a Telegram channel tab → switch to a non-Telegram tab → open popup → shows the active tab, **not** Telegram
- [ ] Manual: navigate between channels inside web.telegram.org (no reload) → popup lists the currently-open channel
- [ ] Manual: PDF tab and a YouTube tab each resolve correctly when active

Refs SWO-605
