### PR TITLE
fix(listen): show current track in the browser tab title

### DIFF
--- a/packages/ui/src/listen/minimalism/listening-screen/index.tsx
+++ b/packages/ui/src/listen/minimalism/listening-screen/index.tsx
@@ -82,6 +82,15 @@ const ListeningScreen = (props: ListeningScreenProps) => {
   const [createOpen, setCreateOpen] = useState(false);
   const [activeFeelingId, setActiveFeelingId] = useState('');
 
+  // The browser-tab title follows the URL's active track (`?audio=`), which the
+  // player keeps in sync with what's playing. Song-first so it stays readable
+  // when the tab strip truncates from the right; the static title when nothing
+  // is selected yet.
+  const activeAudio = (audios as { id: string; name: string }[]).find(
+    (audio) => audio.id === activeAudioId,
+  );
+  const tabTitle = activeAudio ? `${activeAudio.name} · Flow` : 'Flow - Listen';
+
   const onProfileClick = () => {
     if (user) {
       setSettingOpen(true);
@@ -97,6 +106,8 @@ const ListeningScreen = (props: ListeningScreenProps) => {
 
   return (
     <FullWidthContainer>
+      {/* React 19 hoists this into <head>. */}
+      <title>{tabTitle}</title>
       <Header
         user={user}
         onAvatarClick={onProfileClick}


### PR DESCRIPTION
## Summary

When you play a song in Listen, the browser tab kept reading `Flow - Listen` regardless of what was playing — only the address bar changed. Now the tab shows the track you're actually listening to, so you can spot the Listen tab among many and see what's on without switching to it.

The name goes first (`Guren No Yumiya · Flow`) because browser tabs truncate from the right — song-first keeps the useful part visible when the tab is narrow. When nothing is selected yet, it falls back to the original `Flow - Listen`.

## Test plan

- [ ] Open Listen, play a track → the browser tab title reads `<song name> · Flow`.
- [ ] Skip to the next/previous track → the tab title updates to match.
- [ ] Reload with no track selected (clean `/`) → the tab title is `Flow - Listen`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)