### PR TITLE
[WIP] feat(core): add Look read layer (photos timeline, detail, albums)

### DIFF
--- a/packages/core/schema.graphql
+++ b/packages/core/schema.graphql
@@ -3903,6 +3903,17 @@ type mutation_root {
   """
   delete_notifications_by_pk(id: uuid!): notifications
   """
+  delete data from the table: "photos"
+  """
+  delete_photos(
+    """filter the rows which have to be deleted"""
+    where: photos_bool_exp!
+  ): photos_mutation_response
+  """
+  delete single row from the table: "photos"
+  """
+  delete_photos_by_pk(id: uuid!): photos
+  """
   delete data from the table: "playlist"
   """
   delete_playlist(
@@ -3924,6 +3935,17 @@ type mutation_root {
   delete single row from the table: "playlist"
   """
   delete_playlist_by_pk(id: uuid!): playlist
+  """
+  delete data from the table: "playlist_photos"
+  """
+  delete_playlist_photos(
+    """filter the rows which have to be deleted"""
+    where: playlist_photos_bool_exp!
+  ): playlist_photos_mutation_response
+  """
+  delete single row from the table: "playlist_photos"
+  """
+  delete_playlist_photos_by_pk(photo_id: uuid!, playlist_id: uuid!): playlist_photos
   """
   delete data from the table: "playlist_videos"
   """
@@ -4307,6 +4329,24 @@ type mutation_root {
     on_conflict: notifications_on_conflict
   ): notifications
   """
+  insert data into the table: "photos"
+  """
+  insert_photos(
+    """the rows to be inserted"""
+    objects: [photos_insert_input!]!
+    """upsert condition"""
+    on_conflict: photos_on_conflict
+  ): photos_mutation_response
+  """
+  insert a single row into the table: "photos"
+  """
+  insert_photos_one(
+    """the row to be inserted"""
+    object: photos_insert_input!
+    """upsert condition"""
+    on_conflict: photos_on_conflict
+  ): photos
+  """
   insert data into the table: "playlist"
   """
   insert_playlist(
@@ -4342,6 +4382,24 @@ type mutation_root {
     """upsert condition"""
     on_conflict: playlist_on_conflict
   ): playlist
+  """
+  insert data into the table: "playlist_photos"
+  """
+  insert_playlist_photos(
+    """the rows to be inserted"""
+    objects: [playlist_photos_insert_input!]!
+    """upsert condition"""
+    on_conflict: playlist_photos_on_conflict
+  ): playlist_photos_mutation_response
+  """
+  insert a single row into the table: "playlist_photos"
+  """
+  insert_playlist_photos_one(
+    """the row to be inserted"""
+    object: playlist_photos_insert_input!
+    """upsert condition"""
+    on_conflict: playlist_photos_on_conflict
+  ): playlist_photos
   """
   insert data into the table: "playlist_videos"
   """
@@ -5023,6 +5081,34 @@ type mutation_root {
     updates: [notifications_updates!]!
   ): [notifications_mutation_response]
   """
+  update data of the table: "photos"
+  """
+  update_photos(
+    """increments the numeric columns with given value of the filtered values"""
+    _inc: photos_inc_input
+    """sets the columns of the filtered rows to the given values"""
+    _set: photos_set_input
+    """filter the rows which have to be updated"""
+    where: photos_bool_exp!
+  ): photos_mutation_response
+  """
+  update single row of the table: "photos"
+  """
+  update_photos_by_pk(
+    """increments the numeric columns with given value of the filtered values"""
+    _inc: photos_inc_input
+    """sets the columns of the filtered rows to the given values"""
+    _set: photos_set_input
+    pk_columns: photos_pk_columns_input!
+  ): photos
+  """
+  update multiples rows of table: "photos"
+  """
+  update_photos_many(
+    """updates to execute, in order"""
+    updates: [photos_updates!]!
+  ): [photos_mutation_response]
+  """
   update data of the table: "playlist"
   """
   update_playlist(
@@ -5106,6 +5192,34 @@ type mutation_root {
     """updates to execute, in order"""
     updates: [playlist_updates!]!
   ): [playlist_mutation_response]
+  """
+  update data of the table: "playlist_photos"
+  """
+  update_playlist_photos(
+    """increments the numeric columns with given value of the filtered values"""
+    _inc: playlist_photos_inc_input
+    """sets the columns of the filtered rows to the given values"""
+    _set: playlist_photos_set_input
+    """filter the rows which have to be updated"""
+    where: playlist_photos_bool_exp!
+  ): playlist_photos_mutation_response
+  """
+  update single row of the table: "playlist_photos"
+  """
+  update_playlist_photos_by_pk(
+    """increments the numeric columns with given value of the filtered values"""
+    _inc: playlist_photos_inc_input
+    """sets the columns of the filtered rows to the given values"""
+    _set: playlist_photos_set_input
+    pk_columns: playlist_photos_pk_columns_input!
+  ): playlist_photos
+  """
+  update multiples rows of table: "playlist_photos"
+  """
+  update_playlist_photos_many(
+    """updates to execute, in order"""
+    updates: [playlist_photos_updates!]!
+  ): [playlist_photos_mutation_response]
   """
   update data of the table: "playlist_videos"
   """
@@ -6007,6 +6121,391 @@ enum order_by {
   desc_nulls_last
 }
 
+"""Image metadata for the Look app"""
+type photos {
+  blurHash: String
+  createdAt: timestamptz!
+  height: Int
+  id: uuid!
+  mediumUrl: String
+  """An array relationship"""
+  playlist_photos(
+    """distinct select on columns"""
+    distinct_on: [playlist_photos_select_column!]
+    """limit the number of rows returned"""
+    limit: Int
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+    """sort the rows by one or more columns"""
+    order_by: [playlist_photos_order_by!]
+    """filter the rows returned"""
+    where: playlist_photos_bool_exp
+  ): [playlist_photos!]!
+  """An aggregate relationship"""
+  playlist_photos_aggregate(
+    """distinct select on columns"""
+    distinct_on: [playlist_photos_select_column!]
+    """limit the number of rows returned"""
+    limit: Int
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+    """sort the rows by one or more columns"""
+    order_by: [playlist_photos_order_by!]
+    """filter the rows returned"""
+    where: playlist_photos_bool_exp
+  ): playlist_photos_aggregate!
+  public: Boolean!
+  slug: String
+  source: String!
+  takenAt: timestamptz
+  thumbnailUrl: String
+  updatedAt: timestamptz!
+  """An object relationship"""
+  user: users!
+  user_id: uuid!
+  width: Int
+}
+
+"""
+aggregated selection of "photos"
+"""
+type photos_aggregate {
+  aggregate: photos_aggregate_fields
+  nodes: [photos!]!
+}
+
+"""
+aggregate fields of "photos"
+"""
+type photos_aggregate_fields {
+  avg: photos_avg_fields
+  count(columns: [photos_select_column!], distinct: Boolean): Int!
+  max: photos_max_fields
+  min: photos_min_fields
+  stddev: photos_stddev_fields
+  stddev_pop: photos_stddev_pop_fields
+  stddev_samp: photos_stddev_samp_fields
+  sum: photos_sum_fields
+  var_pop: photos_var_pop_fields
+  var_samp: photos_var_samp_fields
+  variance: photos_variance_fields
+}
+
+"""aggregate avg on columns"""
+type photos_avg_fields {
+  height: Float
+  width: Float
+}
+
+"""
+Boolean expression to filter rows from the table "photos". All fields are combined with a logical 'AND'.
+"""
+input photos_bool_exp {
+  _and: [photos_bool_exp!]
+  _not: photos_bool_exp
+  _or: [photos_bool_exp!]
+  blurHash: String_comparison_exp
+  createdAt: timestamptz_comparison_exp
+  height: Int_comparison_exp
+  id: uuid_comparison_exp
+  mediumUrl: String_comparison_exp
+  playlist_photos: playlist_photos_bool_exp
+  playlist_photos_aggregate: playlist_photos_aggregate_bool_exp
+  public: Boolean_comparison_exp
+  slug: String_comparison_exp
+  source: String_comparison_exp
+  takenAt: timestamptz_comparison_exp
+  thumbnailUrl: String_comparison_exp
+  updatedAt: timestamptz_comparison_exp
+  user: users_bool_exp
+  user_id: uuid_comparison_exp
+  width: Int_comparison_exp
+}
+
+"""
+unique or primary key constraints on table "photos"
+"""
+enum photos_constraint {
+  """
+  unique or primary key constraint on columns "id"
+  """
+  photos_pkey
+}
+
+"""
+input type for incrementing numeric columns in table "photos"
+"""
+input photos_inc_input {
+  height: Int
+  width: Int
+}
+
+"""
+input type for inserting data into table "photos"
+"""
+input photos_insert_input {
+  blurHash: String
+  createdAt: timestamptz
+  height: Int
+  id: uuid
+  mediumUrl: String
+  playlist_photos: playlist_photos_arr_rel_insert_input
+  public: Boolean
+  slug: String
+  source: String
+  takenAt: timestamptz
+  thumbnailUrl: String
+  updatedAt: timestamptz
+  user: users_obj_rel_insert_input
+  user_id: uuid
+  width: Int
+}
+
+"""aggregate max on columns"""
+type photos_max_fields {
+  blurHash: String
+  createdAt: timestamptz
+  height: Int
+  id: uuid
+  mediumUrl: String
+  slug: String
+  source: String
+  takenAt: timestamptz
+  thumbnailUrl: String
+  updatedAt: timestamptz
+  user_id: uuid
+  width: Int
+}
+
+"""aggregate min on columns"""
+type photos_min_fields {
+  blurHash: String
+  createdAt: timestamptz
+  height: Int
+  id: uuid
+  mediumUrl: String
+  slug: String
+  source: String
+  takenAt: timestamptz
+  thumbnailUrl: String
+  updatedAt: timestamptz
+  user_id: uuid
+  width: Int
+}
+
+"""
+response of any mutation on the table "photos"
+"""
+type photos_mutation_response {
+  """number of rows affected by the mutation"""
+  affected_rows: Int!
+  """data from the rows affected by the mutation"""
+  returning: [photos!]!
+}
+
+"""
+input type for inserting object relation for remote table "photos"
+"""
+input photos_obj_rel_insert_input {
+  data: photos_insert_input!
+  """upsert condition"""
+  on_conflict: photos_on_conflict
+}
+
+"""
+on_conflict condition type for table "photos"
+"""
+input photos_on_conflict {
+  constraint: photos_constraint!
+  update_columns: [photos_update_column!]! = []
+  where: photos_bool_exp
+}
+
+"""Ordering options when selecting data from "photos"."""
+input photos_order_by {
+  blurHash: order_by
+  createdAt: order_by
+  height: order_by
+  id: order_by
+  mediumUrl: order_by
+  playlist_photos_aggregate: playlist_photos_aggregate_order_by
+  public: order_by
+  slug: order_by
+  source: order_by
+  takenAt: order_by
+  thumbnailUrl: order_by
+  updatedAt: order_by
+  user: users_order_by
+  user_id: order_by
+  width: order_by
+}
+
+"""primary key columns input for table: photos"""
+input photos_pk_columns_input {
+  id: uuid!
+}
+
+"""
+select columns of table "photos"
+"""
+enum photos_select_column {
+  """column name"""
+  blurHash
+  """column name"""
+  createdAt
+  """column name"""
+  height
+  """column name"""
+  id
+  """column name"""
+  mediumUrl
+  """column name"""
+  public
+  """column name"""
+  slug
+  """column name"""
+  source
+  """column name"""
+  takenAt
+  """column name"""
+  thumbnailUrl
+  """column name"""
+  updatedAt
+  """column name"""
+  user_id
+  """column name"""
+  width
+}
+
+"""
+input type for updating data in table "photos"
+"""
+input photos_set_input {
+  blurHash: String
+  createdAt: timestamptz
+  height: Int
+  id: uuid
+  mediumUrl: String
+  public: Boolean
+  slug: String
+  source: String
+  takenAt: timestamptz
+  thumbnailUrl: String
+  updatedAt: timestamptz
+  user_id: uuid
+  width: Int
+}
+
+"""aggregate stddev on columns"""
+type photos_stddev_fields {
+  height: Float
+  width: Float
+}
+
+"""aggregate stddev_pop on columns"""
+type photos_stddev_pop_fields {
+  height: Float
+  width: Float
+}
+
+"""aggregate stddev_samp on columns"""
+type photos_stddev_samp_fields {
+  height: Float
+  width: Float
+}
+
+"""
+Streaming cursor of the table "photos"
+"""
+input photos_stream_cursor_input {
+  """Stream column input with initial value"""
+  initial_value: photos_stream_cursor_value_input!
+  """cursor ordering"""
+  ordering: cursor_ordering
+}
+
+"""Initial value of the column from where the streaming should start"""
+input photos_stream_cursor_value_input {
+  blurHash: String
+  createdAt: timestamptz
+  height: Int
+  id: uuid
+  mediumUrl: String
+  public: Boolean
+  slug: String
+  source: String
+  takenAt: timestamptz
+  thumbnailUrl: String
+  updatedAt: timestamptz
+  user_id: uuid
+  width: Int
+}
+
+"""aggregate sum on columns"""
+type photos_sum_fields {
+  height: Int
+  width: Int
+}
+
+"""
+update columns of table "photos"
+"""
+enum photos_update_column {
+  """column name"""
+  blurHash
+  """column name"""
+  createdAt
+  """column name"""
+  height
+  """column name"""
+  id
+  """column name"""
+  mediumUrl
+  """column name"""
+  public
+  """column name"""
+  slug
+  """column name"""
+  source
+  """column name"""
+  takenAt
+  """column name"""
+  thumbnailUrl
+  """column name"""
+  updatedAt
+  """column name"""
+  user_id
+  """column name"""
+  width
+}
+
+input photos_updates {
+  """increments the numeric columns with given value of the filtered values"""
+  _inc: photos_inc_input
+  """sets the columns of the filtered rows to the given values"""
+  _set: photos_set_input
+  """filter the rows which have to be updated"""
+  where: photos_bool_exp!
+}
+
+"""aggregate var_pop on columns"""
+type photos_var_pop_fields {
+  height: Float
+  width: Float
+}
+
+"""aggregate var_samp on columns"""
+type photos_var_samp_fields {
+  height: Float
+  width: Float
+}
+
+"""aggregate variance on columns"""
+type photos_variance_fields {
+  height: Float
+  width: Float
+}
+
 """Playlist contain set of videos or audios"""
 type playlist {
   createdAt: timestamptz!
@@ -6038,6 +6537,32 @@ type playlist {
     """filter the rows returned"""
     where: playlist_audios_bool_exp
   ): playlist_audios_aggregate!
+  """An array relationship"""
+  playlist_photos(
+    """distinct select on columns"""
+    distinct_on: [playlist_photos_select_column!]
+    """limit the number of rows returned"""
+    limit: Int
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+    """sort the rows by one or more columns"""
+    order_by: [playlist_photos_order_by!]
+    """filter the rows returned"""
+    where: playlist_photos_bool_exp
+  ): [playlist_photos!]!
+  """An aggregate relationship"""
+  playlist_photos_aggregate(
+    """distinct select on columns"""
+    distinct_on: [playlist_photos_select_column!]
+    """limit the number of rows returned"""
+    limit: Int
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+    """sort the rows by one or more columns"""
+    order_by: [playlist_photos_order_by!]
+    """filter the rows returned"""
+    where: playlist_photos_bool_exp
+  ): playlist_photos_aggregate!
   """An array relationship"""
   playlist_videos(
     """distinct select on columns"""
@@ -6567,6 +7092,8 @@ input playlist_bool_exp {
   id: uuid_comparison_exp
   playlist_audios: playlist_audios_bool_exp
   playlist_audios_aggregate: playlist_audios_aggregate_bool_exp
+  playlist_photos: playlist_photos_bool_exp
+  playlist_photos_aggregate: playlist_photos_aggregate_bool_exp
   playlist_videos: playlist_videos_bool_exp
   playlist_videos_aggregate: playlist_videos_aggregate_bool_exp
   public: Boolean_comparison_exp
@@ -6652,6 +7179,7 @@ input playlist_insert_input {
   description: String
   id: uuid
   playlist_audios: playlist_audios_arr_rel_insert_input
+  playlist_photos: playlist_photos_arr_rel_insert_input
   playlist_videos: playlist_videos_arr_rel_insert_input
   public: Boolean
   """Short id like Youtube video id"""
@@ -6772,6 +7300,7 @@ input playlist_order_by {
   description: order_by
   id: order_by
   playlist_audios_aggregate: playlist_audios_aggregate_order_by
+  playlist_photos_aggregate: playlist_photos_aggregate_order_by
   playlist_videos_aggregate: playlist_videos_aggregate_order_by
   public: order_by
   sId: order_by
@@ -6785,6 +7314,370 @@ input playlist_order_by {
   updatedAt: order_by
   user: users_order_by
   user_id: order_by
+}
+
+"""Junction table between photos and playlist"""
+type playlist_photos {
+  createdAt: timestamptz!
+  """An object relationship"""
+  photo: photos!
+  photo_id: uuid!
+  """An object relationship"""
+  playlist: playlist!
+  playlist_id: uuid!
+  position: Int!
+  updatedAt: timestamptz!
+}
+
+"""
+aggregated selection of "playlist_photos"
+"""
+type playlist_photos_aggregate {
+  aggregate: playlist_photos_aggregate_fields
+  nodes: [playlist_photos!]!
+}
+
+input playlist_photos_aggregate_bool_exp {
+  count: playlist_photos_aggregate_bool_exp_count
+}
+
+input playlist_photos_aggregate_bool_exp_count {
+  arguments: [playlist_photos_select_column!]
+  distinct: Boolean
+  filter: playlist_photos_bool_exp
+  predicate: Int_comparison_exp!
+}
+
+"""
+aggregate fields of "playlist_photos"
+"""
+type playlist_photos_aggregate_fields {
+  avg: playlist_photos_avg_fields
+  count(columns: [playlist_photos_select_column!], distinct: Boolean): Int!
+  max: playlist_photos_max_fields
+  min: playlist_photos_min_fields
+  stddev: playlist_photos_stddev_fields
+  stddev_pop: playlist_photos_stddev_pop_fields
+  stddev_samp: playlist_photos_stddev_samp_fields
+  sum: playlist_photos_sum_fields
+  var_pop: playlist_photos_var_pop_fields
+  var_samp: playlist_photos_var_samp_fields
+  variance: playlist_photos_variance_fields
+}
+
+"""
+order by aggregate values of table "playlist_photos"
+"""
+input playlist_photos_aggregate_order_by {
+  avg: playlist_photos_avg_order_by
+  count: order_by
+  max: playlist_photos_max_order_by
+  min: playlist_photos_min_order_by
+  stddev: playlist_photos_stddev_order_by
+  stddev_pop: playlist_photos_stddev_pop_order_by
+  stddev_samp: playlist_photos_stddev_samp_order_by
+  sum: playlist_photos_sum_order_by
+  var_pop: playlist_photos_var_pop_order_by
+  var_samp: playlist_photos_var_samp_order_by
+  variance: playlist_photos_variance_order_by
+}
+
+"""
+input type for inserting array relation for remote table "playlist_photos"
+"""
+input playlist_photos_arr_rel_insert_input {
+  data: [playlist_photos_insert_input!]!
+  """upsert condition"""
+  on_conflict: playlist_photos_on_conflict
+}
+
+"""aggregate avg on columns"""
+type playlist_photos_avg_fields {
+  position: Float
+}
+
+"""
+order by avg() on columns of table "playlist_photos"
+"""
+input playlist_photos_avg_order_by {
+  position: order_by
+}
+
+"""
+Boolean expression to filter rows from the table "playlist_photos". All fields are combined with a logical 'AND'.
+"""
+input playlist_photos_bool_exp {
+  _and: [playlist_photos_bool_exp!]
+  _not: playlist_photos_bool_exp
+  _or: [playlist_photos_bool_exp!]
+  createdAt: timestamptz_comparison_exp
+  photo: photos_bool_exp
+  photo_id: uuid_comparison_exp
+  playlist: playlist_bool_exp
+  playlist_id: uuid_comparison_exp
+  position: Int_comparison_exp
+  updatedAt: timestamptz_comparison_exp
+}
+
+"""
+unique or primary key constraints on table "playlist_photos"
+"""
+enum playlist_photos_constraint {
+  """
+  unique or primary key constraint on columns "photo_id", "playlist_id"
+  """
+  playlist_photos_pkey
+}
+
+"""
+input type for incrementing numeric columns in table "playlist_photos"
+"""
+input playlist_photos_inc_input {
+  position: Int
+}
+
+"""
+input type for inserting data into table "playlist_photos"
+"""
+input playlist_photos_insert_input {
+  createdAt: timestamptz
+  photo: photos_obj_rel_insert_input
+  photo_id: uuid
+  playlist: playlist_obj_rel_insert_input
+  playlist_id: uuid
+  position: Int
+  updatedAt: timestamptz
+}
+
+"""aggregate max on columns"""
+type playlist_photos_max_fields {
+  createdAt: timestamptz
+  photo_id: uuid
+  playlist_id: uuid
+  position: Int
+  updatedAt: timestamptz
+}
+
+"""
+order by max() on columns of table "playlist_photos"
+"""
+input playlist_photos_max_order_by {
+  createdAt: order_by
+  photo_id: order_by
+  playlist_id: order_by
+  position: order_by
+  updatedAt: order_by
+}
+
+"""aggregate min on columns"""
+type playlist_photos_min_fields {
+  createdAt: timestamptz
+  photo_id: uuid
+  playlist_id: uuid
+  position: Int
+  updatedAt: timestamptz
+}
+
+"""
+order by min() on columns of table "playlist_photos"
+"""
+input playlist_photos_min_order_by {
+  createdAt: order_by
+  photo_id: order_by
+  playlist_id: order_by
+  position: order_by
+  updatedAt: order_by
+}
+
+"""
+response of any mutation on the table "playlist_photos"
+"""
+type playlist_photos_mutation_response {
+  """number of rows affected by the mutation"""
+  affected_rows: Int!
+  """data from the rows affected by the mutation"""
+  returning: [playlist_photos!]!
+}
+
+"""
+on_conflict condition type for table "playlist_photos"
+"""
+input playlist_photos_on_conflict {
+  constraint: playlist_photos_constraint!
+  update_columns: [playlist_photos_update_column!]! = []
+  where: playlist_photos_bool_exp
+}
+
+"""Ordering options when selecting data from "playlist_photos"."""
+input playlist_photos_order_by {
+  createdAt: order_by
+  photo: photos_order_by
+  photo_id: order_by
+  playlist: playlist_order_by
+  playlist_id: order_by
+  position: order_by
+  updatedAt: order_by
+}
+
+"""primary key columns input for table: playlist_photos"""
+input playlist_photos_pk_columns_input {
+  photo_id: uuid!
+  playlist_id: uuid!
+}
+
+"""
+select columns of table "playlist_photos"
+"""
+enum playlist_photos_select_column {
+  """column name"""
+  createdAt
+  """column name"""
+  photo_id
+  """column name"""
+  playlist_id
+  """column name"""
+  position
+  """column name"""
+  updatedAt
+}
+
+"""
+input type for updating data in table "playlist_photos"
+"""
+input playlist_photos_set_input {
+  createdAt: timestamptz
+  photo_id: uuid
+  playlist_id: uuid
+  position: Int
+  updatedAt: timestamptz
+}
+
+"""aggregate stddev on columns"""
+type playlist_photos_stddev_fields {
+  position: Float
+}
+
+"""
+order by stddev() on columns of table "playlist_photos"
+"""
+input playlist_photos_stddev_order_by {
+  position: order_by
+}
+
+"""aggregate stddev_pop on columns"""
+type playlist_photos_stddev_pop_fields {
+  position: Float
+}
+
+"""
+order by stddev_pop() on columns of table "playlist_photos"
+"""
+input playlist_photos_stddev_pop_order_by {
+  position: order_by
+}
+
+"""aggregate stddev_samp on columns"""
+type playlist_photos_stddev_samp_fields {
+  position: Float
+}
+
+"""
+order by stddev_samp() on columns of table "playlist_photos"
+"""
+input playlist_photos_stddev_samp_order_by {
+  position: order_by
+}
+
+"""
+Streaming cursor of the table "playlist_photos"
+"""
+input playlist_photos_stream_cursor_input {
+  """Stream column input with initial value"""
+  initial_value: playlist_photos_stream_cursor_value_input!
+  """cursor ordering"""
+  ordering: cursor_ordering
+}
+
+"""Initial value of the column from where the streaming should start"""
+input playlist_photos_stream_cursor_value_input {
+  createdAt: timestamptz
+  photo_id: uuid
+  playlist_id: uuid
+  position: Int
+  updatedAt: timestamptz
+}
+
+"""aggregate sum on columns"""
+type playlist_photos_sum_fields {
+  position: Int
+}
+
+"""
+order by sum() on columns of table "playlist_photos"
+"""
+input playlist_photos_sum_order_by {
+  position: order_by
+}
+
+"""
+update columns of table "playlist_photos"
+"""
+enum playlist_photos_update_column {
+  """column name"""
+  createdAt
+  """column name"""
+  photo_id
+  """column name"""
+  playlist_id
+  """column name"""
+  position
+  """column name"""
+  updatedAt
+}
+
+input playlist_photos_updates {
+  """increments the numeric columns with given value of the filtered values"""
+  _inc: playlist_photos_inc_input
+  """sets the columns of the filtered rows to the given values"""
+  _set: playlist_photos_set_input
+  """filter the rows which have to be updated"""
+  where: playlist_photos_bool_exp!
+}
+
+"""aggregate var_pop on columns"""
+type playlist_photos_var_pop_fields {
+  position: Float
+}
+
+"""
+order by var_pop() on columns of table "playlist_photos"
+"""
+input playlist_photos_var_pop_order_by {
+  position: order_by
+}
+
+"""aggregate var_samp on columns"""
+type playlist_photos_var_samp_fields {
+  position: Float
+}
+
+"""
+order by var_samp() on columns of table "playlist_photos"
+"""
+input playlist_photos_var_samp_order_by {
+  position: order_by
+}
+
+"""aggregate variance on columns"""
+type playlist_photos_variance_fields {
+  position: Float
+}
+
+"""
+order by variance() on columns of table "playlist_photos"
+"""
+input playlist_photos_variance_order_by {
+  position: order_by
 }
 
 """primary key columns input for table: playlist"""
@@ -7999,6 +8892,38 @@ type query_root {
   """fetch data from the table: "notifications" using primary key columns"""
   notifications_by_pk(id: uuid!): notifications
   """
+  fetch data from the table: "photos"
+  """
+  photos(
+    """distinct select on columns"""
+    distinct_on: [photos_select_column!]
+    """limit the number of rows returned"""
+    limit: Int
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+    """sort the rows by one or more columns"""
+    order_by: [photos_order_by!]
+    """filter the rows returned"""
+    where: photos_bool_exp
+  ): [photos!]!
+  """
+  fetch aggregated fields from the table: "photos"
+  """
+  photos_aggregate(
+    """distinct select on columns"""
+    distinct_on: [photos_select_column!]
+    """limit the number of rows returned"""
+    limit: Int
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+    """sort the rows by one or more columns"""
+    order_by: [photos_order_by!]
+    """filter the rows returned"""
+    where: photos_bool_exp
+  ): photos_aggregate!
+  """fetch data from the table: "photos" using primary key columns"""
+  photos_by_pk(id: uuid!): photos
+  """
   fetch data from the table: "playlist"
   """
   playlist(
@@ -8058,6 +8983,34 @@ type query_root {
   playlist_audios_by_pk(audio_id: uuid!, playlist_id: uuid!): playlist_audios
   """fetch data from the table: "playlist" using primary key columns"""
   playlist_by_pk(id: uuid!): playlist
+  """An array relationship"""
+  playlist_photos(
+    """distinct select on columns"""
+    distinct_on: [playlist_photos_select_column!]
+    """limit the number of rows returned"""
+    limit: Int
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+    """sort the rows by one or more columns"""
+    order_by: [playlist_photos_order_by!]
+    """filter the rows returned"""
+    where: playlist_photos_bool_exp
+  ): [playlist_photos!]!
+  """An aggregate relationship"""
+  playlist_photos_aggregate(
+    """distinct select on columns"""
+    distinct_on: [playlist_photos_select_column!]
+    """limit the number of rows returned"""
+    limit: Int
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+    """sort the rows by one or more columns"""
+    order_by: [playlist_photos_order_by!]
+    """filter the rows returned"""
+    where: playlist_photos_bool_exp
+  ): playlist_photos_aggregate!
+  """fetch data from the table: "playlist_photos" using primary key columns"""
+  playlist_photos_by_pk(photo_id: uuid!, playlist_id: uuid!): playlist_photos
   """An array relationship"""
   playlist_videos(
     """distinct select on columns"""
@@ -10022,6 +10975,49 @@ type subscription_root {
     where: notifications_bool_exp
   ): [notifications!]!
   """
+  fetch data from the table: "photos"
+  """
+  photos(
+    """distinct select on columns"""
+    distinct_on: [photos_select_column!]
+    """limit the number of rows returned"""
+    limit: Int
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+    """sort the rows by one or more columns"""
+    order_by: [photos_order_by!]
+    """filter the rows returned"""
+    where: photos_bool_exp
+  ): [photos!]!
+  """
+  fetch aggregated fields from the table: "photos"
+  """
+  photos_aggregate(
+    """distinct select on columns"""
+    distinct_on: [photos_select_column!]
+    """limit the number of rows returned"""
+    limit: Int
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+    """sort the rows by one or more columns"""
+    order_by: [photos_order_by!]
+    """filter the rows returned"""
+    where: photos_bool_exp
+  ): photos_aggregate!
+  """fetch data from the table: "photos" using primary key columns"""
+  photos_by_pk(id: uuid!): photos
+  """
+  fetch data from the table in a streaming manner: "photos"
+  """
+  photos_stream(
+    """maximum number of rows returned in a single batch"""
+    batch_size: Int!
+    """cursor to stream the results returned by the query"""
+    cursor: [photos_stream_cursor_input]!
+    """filter the rows returned"""
+    where: photos_bool_exp
+  ): [photos!]!
+  """
   fetch data from the table: "playlist"
   """
   playlist(
@@ -10092,6 +11088,45 @@ type subscription_root {
   ): [playlist_audios!]!
   """fetch data from the table: "playlist" using primary key columns"""
   playlist_by_pk(id: uuid!): playlist
+  """An array relationship"""
+  playlist_photos(
+    """distinct select on columns"""
+    distinct_on: [playlist_photos_select_column!]
+    """limit the number of rows returned"""
+    limit: Int
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+    """sort the rows by one or more columns"""
+    order_by: [playlist_photos_order_by!]
+    """filter the rows returned"""
+    where: playlist_photos_bool_exp
+  ): [playlist_photos!]!
+  """An aggregate relationship"""
+  playlist_photos_aggregate(
+    """distinct select on columns"""
+    distinct_on: [playlist_photos_select_column!]
+    """limit the number of rows returned"""
+    limit: Int
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+    """sort the rows by one or more columns"""
+    order_by: [playlist_photos_order_by!]
+    """filter the rows returned"""
+    where: playlist_photos_bool_exp
+  ): playlist_photos_aggregate!
+  """fetch data from the table: "playlist_photos" using primary key columns"""
+  playlist_photos_by_pk(photo_id: uuid!, playlist_id: uuid!): playlist_photos
+  """
+  fetch data from the table in a streaming manner: "playlist_photos"
+  """
+  playlist_photos_stream(
+    """maximum number of rows returned in a single batch"""
+    batch_size: Int!
+    """cursor to stream the results returned by the query"""
+    cursor: [playlist_photos_stream_cursor_input]!
+    """filter the rows returned"""
+    where: playlist_photos_bool_exp
+  ): [playlist_photos!]!
   """
   fetch data from the table in a streaming manner: "playlist"
   """

--- a/packages/core/src/graphql/gql.ts
+++ b/packages/core/src/graphql/gql.ts
@@ -48,6 +48,12 @@ type Documents = {
     "\n  query ListenManage($userId: uuid!) {\n    audios(\n      where: { user_id: { _eq: $userId } }\n      order_by: { createdAt: desc }\n    ) {\n      id\n      name\n      source\n      thumbnailUrl\n      artistName\n      audio_tags {\n        tag_id\n      }\n    }\n    tags(\n      where: { site: { _eq: \"listen\" } }\n      order_by: { display_order: asc }\n    ) {\n      id\n      name\n    }\n    playlist(\n      where: { user_id: { _eq: $userId }, site: { _eq: \"listen\" } }\n      order_by: { createdAt: desc }\n    ) {\n      id\n      title\n      slug\n      description\n      thumbnailUrl\n    }\n  }\n": typeof types.ListenManageDocument,
     "\n  query ListenPlaylistDetail($id: uuid!) {\n    playlist_by_pk(id: $id) {\n      ...ListenPlaylistFields\n    }\n  }\n": typeof types.ListenPlaylistDetailDocument,
     "\n  query ListenPlaylists {\n    playlist(\n      where: { site: { _eq: \"listen\" } }\n      order_by: { createdAt: desc }\n    ) {\n      id\n      title\n      slug\n    }\n  }\n": typeof types.ListenPlaylistsDocument,
+    "\n  query LookAlbums @cached {\n    playlist(\n      where: { site: { _eq: \"look\" } }\n      order_by: { createdAt: desc }\n    ) {\n      ...AlbumFields\n    }\n  }\n": typeof types.LookAlbumsDocument,
+    "\n  query LookAlbumDetail($id: uuid!) @cached {\n    playlist_by_pk(id: $id) {\n      ...AlbumFields\n    }\n  }\n": typeof types.LookAlbumDetailDocument,
+    "\n  fragment PhotoFields on photos {\n    id\n    source\n    mediumUrl\n    thumbnailUrl\n    blurHash\n    width\n    height\n    takenAt\n    slug\n    createdAt\n    user_id\n  }\n": typeof types.PhotoFieldsFragmentDoc,
+    "\n  fragment AlbumFields on playlist {\n    id\n    title\n    thumbnailUrl\n    slug\n    createdAt\n    description\n    playlist_photos(order_by: { position: asc }) {\n      position\n      photo {\n        ...PhotoFields\n      }\n    }\n  }\n": typeof types.AlbumFieldsFragmentDoc,
+    "\n  query LookPhotoDetail($id: uuid!) @cached {\n    photos_by_pk(id: $id) {\n      ...PhotoFields\n    }\n  }\n": typeof types.LookPhotoDetailDocument,
+    "\n  query LookPhotos @cached {\n    photos(order_by: { takenAt: desc }) {\n      ...PhotoFields\n    }\n  }\n": typeof types.LookPhotosDocument,
     "\n  mutation InsertPost($object: posts_insert_input!) {\n    insert_posts_one(object: $object) {\n      id\n      title\n      slug\n      brief\n      markdownContent\n      readTimeInMinutes\n      created_at\n      updated_at\n    }\n  }\n": typeof types.InsertPostDocument,
     "\n  mutation UpdatePost($id: uuid!, $object: posts_set_input!) {\n    update_posts_by_pk(pk_columns: { id: $id }, _set: $object) {\n      id\n      title\n      slug\n      brief\n      markdownContent\n      readTimeInMinutes\n      created_at\n      updated_at\n      status\n    }\n  }\n": typeof types.UpdatePostDocument,
     "\n  query Post($id: uuid!) {\n    posts_by_pk(id: $id) {\n      title\n      readTimeInMinutes\n      markdownContent\n      id\n      brief\n      slug\n      created_at\n      status\n      visibility\n      pinned\n    }\n  }\n": typeof types.PostDocument,
@@ -116,6 +122,12 @@ const documents: Documents = {
     "\n  query ListenManage($userId: uuid!) {\n    audios(\n      where: { user_id: { _eq: $userId } }\n      order_by: { createdAt: desc }\n    ) {\n      id\n      name\n      source\n      thumbnailUrl\n      artistName\n      audio_tags {\n        tag_id\n      }\n    }\n    tags(\n      where: { site: { _eq: \"listen\" } }\n      order_by: { display_order: asc }\n    ) {\n      id\n      name\n    }\n    playlist(\n      where: { user_id: { _eq: $userId }, site: { _eq: \"listen\" } }\n      order_by: { createdAt: desc }\n    ) {\n      id\n      title\n      slug\n      description\n      thumbnailUrl\n    }\n  }\n": types.ListenManageDocument,
     "\n  query ListenPlaylistDetail($id: uuid!) {\n    playlist_by_pk(id: $id) {\n      ...ListenPlaylistFields\n    }\n  }\n": types.ListenPlaylistDetailDocument,
     "\n  query ListenPlaylists {\n    playlist(\n      where: { site: { _eq: \"listen\" } }\n      order_by: { createdAt: desc }\n    ) {\n      id\n      title\n      slug\n    }\n  }\n": types.ListenPlaylistsDocument,
+    "\n  query LookAlbums @cached {\n    playlist(\n      where: { site: { _eq: \"look\" } }\n      order_by: { createdAt: desc }\n    ) {\n      ...AlbumFields\n    }\n  }\n": types.LookAlbumsDocument,
+    "\n  query LookAlbumDetail($id: uuid!) @cached {\n    playlist_by_pk(id: $id) {\n      ...AlbumFields\n    }\n  }\n": types.LookAlbumDetailDocument,
+    "\n  fragment PhotoFields on photos {\n    id\n    source\n    mediumUrl\n    thumbnailUrl\n    blurHash\n    width\n    height\n    takenAt\n    slug\n    createdAt\n    user_id\n  }\n": types.PhotoFieldsFragmentDoc,
+    "\n  fragment AlbumFields on playlist {\n    id\n    title\n    thumbnailUrl\n    slug\n    createdAt\n    description\n    playlist_photos(order_by: { position: asc }) {\n      position\n      photo {\n        ...PhotoFields\n      }\n    }\n  }\n": types.AlbumFieldsFragmentDoc,
+    "\n  query LookPhotoDetail($id: uuid!) @cached {\n    photos_by_pk(id: $id) {\n      ...PhotoFields\n    }\n  }\n": types.LookPhotoDetailDocument,
+    "\n  query LookPhotos @cached {\n    photos(order_by: { takenAt: desc }) {\n      ...PhotoFields\n    }\n  }\n": types.LookPhotosDocument,
     "\n  mutation InsertPost($object: posts_insert_input!) {\n    insert_posts_one(object: $object) {\n      id\n      title\n      slug\n      brief\n      markdownContent\n      readTimeInMinutes\n      created_at\n      updated_at\n    }\n  }\n": types.InsertPostDocument,
     "\n  mutation UpdatePost($id: uuid!, $object: posts_set_input!) {\n    update_posts_by_pk(pk_columns: { id: $id }, _set: $object) {\n      id\n      title\n      slug\n      brief\n      markdownContent\n      readTimeInMinutes\n      created_at\n      updated_at\n      status\n    }\n  }\n": types.UpdatePostDocument,
     "\n  query Post($id: uuid!) {\n    posts_by_pk(id: $id) {\n      title\n      readTimeInMinutes\n      markdownContent\n      id\n      brief\n      slug\n      created_at\n      status\n      visibility\n      pinned\n    }\n  }\n": types.PostDocument,
@@ -283,6 +295,30 @@ export function graphql(source: "\n  query ListenPlaylistDetail($id: uuid!) {\n 
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(source: "\n  query ListenPlaylists {\n    playlist(\n      where: { site: { _eq: \"listen\" } }\n      order_by: { createdAt: desc }\n    ) {\n      id\n      title\n      slug\n    }\n  }\n"): typeof import('./graphql').ListenPlaylistsDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n  query LookAlbums @cached {\n    playlist(\n      where: { site: { _eq: \"look\" } }\n      order_by: { createdAt: desc }\n    ) {\n      ...AlbumFields\n    }\n  }\n"): typeof import('./graphql').LookAlbumsDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n  query LookAlbumDetail($id: uuid!) @cached {\n    playlist_by_pk(id: $id) {\n      ...AlbumFields\n    }\n  }\n"): typeof import('./graphql').LookAlbumDetailDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n  fragment PhotoFields on photos {\n    id\n    source\n    mediumUrl\n    thumbnailUrl\n    blurHash\n    width\n    height\n    takenAt\n    slug\n    createdAt\n    user_id\n  }\n"): typeof import('./graphql').PhotoFieldsFragmentDoc;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n  fragment AlbumFields on playlist {\n    id\n    title\n    thumbnailUrl\n    slug\n    createdAt\n    description\n    playlist_photos(order_by: { position: asc }) {\n      position\n      photo {\n        ...PhotoFields\n      }\n    }\n  }\n"): typeof import('./graphql').AlbumFieldsFragmentDoc;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n  query LookPhotoDetail($id: uuid!) @cached {\n    photos_by_pk(id: $id) {\n      ...PhotoFields\n    }\n  }\n"): typeof import('./graphql').LookPhotoDetailDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n  query LookPhotos @cached {\n    photos(order_by: { takenAt: desc }) {\n      ...PhotoFields\n    }\n  }\n"): typeof import('./graphql').LookPhotosDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/packages/core/src/graphql/gql.ts
+++ b/packages/core/src/graphql/gql.ts
@@ -50,7 +50,7 @@ type Documents = {
     "\n  query ListenPlaylists {\n    playlist(\n      where: { site: { _eq: \"listen\" } }\n      order_by: { createdAt: desc }\n    ) {\n      id\n      title\n      slug\n    }\n  }\n": typeof types.ListenPlaylistsDocument,
     "\n  query LookAlbums @cached {\n    playlist(\n      where: { site: { _eq: \"look\" } }\n      order_by: { createdAt: desc }\n    ) {\n      ...AlbumFields\n    }\n  }\n": typeof types.LookAlbumsDocument,
     "\n  query LookAlbumDetail($id: uuid!) @cached {\n    playlist_by_pk(id: $id) {\n      ...AlbumFields\n    }\n  }\n": typeof types.LookAlbumDetailDocument,
-    "\n  fragment PhotoFields on photos {\n    id\n    source\n    mediumUrl\n    thumbnailUrl\n    blurHash\n    width\n    height\n    takenAt\n    slug\n    createdAt\n    user_id\n  }\n": typeof types.PhotoFieldsFragmentDoc,
+    "\n  fragment PhotoFields on photos {\n    id\n    source\n    mediumUrl\n    thumbnailUrl\n    blurHash\n    width\n    height\n    takenAt\n    slug\n  }\n": typeof types.PhotoFieldsFragmentDoc,
     "\n  fragment AlbumFields on playlist {\n    id\n    title\n    thumbnailUrl\n    slug\n    createdAt\n    description\n    playlist_photos(order_by: { position: asc }) {\n      position\n      photo {\n        ...PhotoFields\n      }\n    }\n  }\n": typeof types.AlbumFieldsFragmentDoc,
     "\n  query LookPhotoDetail($id: uuid!) @cached {\n    photos_by_pk(id: $id) {\n      ...PhotoFields\n    }\n  }\n": typeof types.LookPhotoDetailDocument,
     "\n  query LookPhotos @cached {\n    photos(order_by: { takenAt: desc }) {\n      ...PhotoFields\n    }\n  }\n": typeof types.LookPhotosDocument,
@@ -124,7 +124,7 @@ const documents: Documents = {
     "\n  query ListenPlaylists {\n    playlist(\n      where: { site: { _eq: \"listen\" } }\n      order_by: { createdAt: desc }\n    ) {\n      id\n      title\n      slug\n    }\n  }\n": types.ListenPlaylistsDocument,
     "\n  query LookAlbums @cached {\n    playlist(\n      where: { site: { _eq: \"look\" } }\n      order_by: { createdAt: desc }\n    ) {\n      ...AlbumFields\n    }\n  }\n": types.LookAlbumsDocument,
     "\n  query LookAlbumDetail($id: uuid!) @cached {\n    playlist_by_pk(id: $id) {\n      ...AlbumFields\n    }\n  }\n": types.LookAlbumDetailDocument,
-    "\n  fragment PhotoFields on photos {\n    id\n    source\n    mediumUrl\n    thumbnailUrl\n    blurHash\n    width\n    height\n    takenAt\n    slug\n    createdAt\n    user_id\n  }\n": types.PhotoFieldsFragmentDoc,
+    "\n  fragment PhotoFields on photos {\n    id\n    source\n    mediumUrl\n    thumbnailUrl\n    blurHash\n    width\n    height\n    takenAt\n    slug\n  }\n": types.PhotoFieldsFragmentDoc,
     "\n  fragment AlbumFields on playlist {\n    id\n    title\n    thumbnailUrl\n    slug\n    createdAt\n    description\n    playlist_photos(order_by: { position: asc }) {\n      position\n      photo {\n        ...PhotoFields\n      }\n    }\n  }\n": types.AlbumFieldsFragmentDoc,
     "\n  query LookPhotoDetail($id: uuid!) @cached {\n    photos_by_pk(id: $id) {\n      ...PhotoFields\n    }\n  }\n": types.LookPhotoDetailDocument,
     "\n  query LookPhotos @cached {\n    photos(order_by: { takenAt: desc }) {\n      ...PhotoFields\n    }\n  }\n": types.LookPhotosDocument,
@@ -306,7 +306,7 @@ export function graphql(source: "\n  query LookAlbumDetail($id: uuid!) @cached {
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
-export function graphql(source: "\n  fragment PhotoFields on photos {\n    id\n    source\n    mediumUrl\n    thumbnailUrl\n    blurHash\n    width\n    height\n    takenAt\n    slug\n    createdAt\n    user_id\n  }\n"): typeof import('./graphql').PhotoFieldsFragmentDoc;
+export function graphql(source: "\n  fragment PhotoFields on photos {\n    id\n    source\n    mediumUrl\n    thumbnailUrl\n    blurHash\n    width\n    height\n    takenAt\n    slug\n  }\n"): typeof import('./graphql').PhotoFieldsFragmentDoc;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/packages/core/src/graphql/graphql.ts
+++ b/packages/core/src/graphql/graphql.ts
@@ -15343,7 +15343,7 @@ export type LookAlbumDetailQuery = { __typename?: 'query_root', playlist_by_pk?:
     & { ' $fragmentRefs'?: { 'AlbumFieldsFragment': AlbumFieldsFragment } }
   ) | null };
 
-export type PhotoFieldsFragment = { __typename?: 'photos', id: any, source: string, mediumUrl?: string | null, thumbnailUrl?: string | null, blurHash?: string | null, width?: number | null, height?: number | null, takenAt?: any | null, slug?: string | null, createdAt: any, user_id: any } & { ' $fragmentName'?: 'PhotoFieldsFragment' };
+export type PhotoFieldsFragment = { __typename?: 'photos', id: any, source: string, mediumUrl?: string | null, thumbnailUrl?: string | null, blurHash?: string | null, width?: number | null, height?: number | null, takenAt?: any | null, slug?: string | null } & { ' $fragmentName'?: 'PhotoFieldsFragment' };
 
 export type AlbumFieldsFragment = { __typename?: 'playlist', id: any, title: string, thumbnailUrl?: string | null, slug: string, createdAt: any, description?: string | null, playlist_photos: Array<{ __typename?: 'playlist_photos', position: number, photo: (
       { __typename?: 'photos' }
@@ -15686,8 +15686,6 @@ export const PhotoFieldsFragmentDoc = new TypedDocumentString(`
   height
   takenAt
   slug
-  createdAt
-  user_id
 }
     `, {"fragmentName":"PhotoFields"}) as unknown as TypedDocumentString<PhotoFieldsFragment, unknown>;
 export const AlbumFieldsFragmentDoc = new TypedDocumentString(`
@@ -15715,8 +15713,6 @@ export const AlbumFieldsFragmentDoc = new TypedDocumentString(`
   height
   takenAt
   slug
-  createdAt
-  user_id
 }`, {"fragmentName":"AlbumFields"}) as unknown as TypedDocumentString<AlbumFieldsFragment, unknown>;
 export const UserFieldsFragmentDoc = new TypedDocumentString(`
     fragment UserFields on users {
@@ -16351,8 +16347,6 @@ export const LookAlbumsDocument = new TypedDocumentString(`
   height
   takenAt
   slug
-  createdAt
-  user_id
 }
 fragment AlbumFields on playlist {
   id
@@ -16384,8 +16378,6 @@ export const LookAlbumDetailDocument = new TypedDocumentString(`
   height
   takenAt
   slug
-  createdAt
-  user_id
 }
 fragment AlbumFields on playlist {
   id
@@ -16417,8 +16409,6 @@ export const LookPhotoDetailDocument = new TypedDocumentString(`
   height
   takenAt
   slug
-  createdAt
-  user_id
 }`) as unknown as TypedDocumentString<LookPhotoDetailQuery, LookPhotoDetailQueryVariables>;
 export const LookPhotosDocument = new TypedDocumentString(`
     query LookPhotos @cached {
@@ -16436,8 +16426,6 @@ export const LookPhotosDocument = new TypedDocumentString(`
   height
   takenAt
   slug
-  createdAt
-  user_id
 }`) as unknown as TypedDocumentString<LookPhotosQuery, LookPhotosQueryVariables>;
 export const InsertPostDocument = new TypedDocumentString(`
     mutation InsertPost($object: posts_insert_input!) {

--- a/packages/core/src/graphql/graphql.ts
+++ b/packages/core/src/graphql/graphql.ts
@@ -3550,6 +3550,10 @@ export type Mutation_Root = {
   delete_notifications?: Maybe<Notifications_Mutation_Response>;
   /** delete single row from the table: "notifications" */
   delete_notifications_by_pk?: Maybe<Notifications>;
+  /** delete data from the table: "photos" */
+  delete_photos?: Maybe<Photos_Mutation_Response>;
+  /** delete single row from the table: "photos" */
+  delete_photos_by_pk?: Maybe<Photos>;
   /** delete data from the table: "playlist" */
   delete_playlist?: Maybe<Playlist_Mutation_Response>;
   /** delete data from the table: "playlist_audios" */
@@ -3558,6 +3562,10 @@ export type Mutation_Root = {
   delete_playlist_audios_by_pk?: Maybe<Playlist_Audios>;
   /** delete single row from the table: "playlist" */
   delete_playlist_by_pk?: Maybe<Playlist>;
+  /** delete data from the table: "playlist_photos" */
+  delete_playlist_photos?: Maybe<Playlist_Photos_Mutation_Response>;
+  /** delete single row from the table: "playlist_photos" */
+  delete_playlist_photos_by_pk?: Maybe<Playlist_Photos>;
   /** delete data from the table: "playlist_videos" */
   delete_playlist_videos?: Maybe<Playlist_Videos_Mutation_Response>;
   /** delete single row from the table: "playlist_videos" */
@@ -3670,6 +3678,10 @@ export type Mutation_Root = {
   insert_notifications?: Maybe<Notifications_Mutation_Response>;
   /** insert a single row into the table: "notifications" */
   insert_notifications_one?: Maybe<Notifications>;
+  /** insert data into the table: "photos" */
+  insert_photos?: Maybe<Photos_Mutation_Response>;
+  /** insert a single row into the table: "photos" */
+  insert_photos_one?: Maybe<Photos>;
   /** insert data into the table: "playlist" */
   insert_playlist?: Maybe<Playlist_Mutation_Response>;
   /** insert data into the table: "playlist_audios" */
@@ -3678,6 +3690,10 @@ export type Mutation_Root = {
   insert_playlist_audios_one?: Maybe<Playlist_Audios>;
   /** insert a single row into the table: "playlist" */
   insert_playlist_one?: Maybe<Playlist>;
+  /** insert data into the table: "playlist_photos" */
+  insert_playlist_photos?: Maybe<Playlist_Photos_Mutation_Response>;
+  /** insert a single row into the table: "playlist_photos" */
+  insert_playlist_photos_one?: Maybe<Playlist_Photos>;
   /** insert data into the table: "playlist_videos" */
   insert_playlist_videos?: Maybe<Playlist_Videos_Mutation_Response>;
   /** insert a single row into the table: "playlist_videos" */
@@ -3818,6 +3834,12 @@ export type Mutation_Root = {
   update_notifications_by_pk?: Maybe<Notifications>;
   /** update multiples rows of table: "notifications" */
   update_notifications_many?: Maybe<Array<Maybe<Notifications_Mutation_Response>>>;
+  /** update data of the table: "photos" */
+  update_photos?: Maybe<Photos_Mutation_Response>;
+  /** update single row of the table: "photos" */
+  update_photos_by_pk?: Maybe<Photos>;
+  /** update multiples rows of table: "photos" */
+  update_photos_many?: Maybe<Array<Maybe<Photos_Mutation_Response>>>;
   /** update data of the table: "playlist" */
   update_playlist?: Maybe<Playlist_Mutation_Response>;
   /** update data of the table: "playlist_audios" */
@@ -3830,6 +3852,12 @@ export type Mutation_Root = {
   update_playlist_by_pk?: Maybe<Playlist>;
   /** update multiples rows of table: "playlist" */
   update_playlist_many?: Maybe<Array<Maybe<Playlist_Mutation_Response>>>;
+  /** update data of the table: "playlist_photos" */
+  update_playlist_photos?: Maybe<Playlist_Photos_Mutation_Response>;
+  /** update single row of the table: "playlist_photos" */
+  update_playlist_photos_by_pk?: Maybe<Playlist_Photos>;
+  /** update multiples rows of table: "playlist_photos" */
+  update_playlist_photos_many?: Maybe<Array<Maybe<Playlist_Photos_Mutation_Response>>>;
   /** update data of the table: "playlist_videos" */
   update_playlist_videos?: Maybe<Playlist_Videos_Mutation_Response>;
   /** update single row of the table: "playlist_videos" */
@@ -4081,6 +4109,18 @@ export type Mutation_RootDelete_Notifications_By_PkArgs = {
 
 
 /** mutation root */
+export type Mutation_RootDelete_PhotosArgs = {
+  where: Photos_Bool_Exp;
+};
+
+
+/** mutation root */
+export type Mutation_RootDelete_Photos_By_PkArgs = {
+  id: Scalars['uuid']['input'];
+};
+
+
+/** mutation root */
 export type Mutation_RootDelete_PlaylistArgs = {
   where: Playlist_Bool_Exp;
 };
@@ -4102,6 +4142,19 @@ export type Mutation_RootDelete_Playlist_Audios_By_PkArgs = {
 /** mutation root */
 export type Mutation_RootDelete_Playlist_By_PkArgs = {
   id: Scalars['uuid']['input'];
+};
+
+
+/** mutation root */
+export type Mutation_RootDelete_Playlist_PhotosArgs = {
+  where: Playlist_Photos_Bool_Exp;
+};
+
+
+/** mutation root */
+export type Mutation_RootDelete_Playlist_Photos_By_PkArgs = {
+  photo_id: Scalars['uuid']['input'];
+  playlist_id: Scalars['uuid']['input'];
 };
 
 
@@ -4466,6 +4519,20 @@ export type Mutation_RootInsert_Notifications_OneArgs = {
 
 
 /** mutation root */
+export type Mutation_RootInsert_PhotosArgs = {
+  objects: Array<Photos_Insert_Input>;
+  on_conflict?: InputMaybe<Photos_On_Conflict>;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_Photos_OneArgs = {
+  object: Photos_Insert_Input;
+  on_conflict?: InputMaybe<Photos_On_Conflict>;
+};
+
+
+/** mutation root */
 export type Mutation_RootInsert_PlaylistArgs = {
   objects: Array<Playlist_Insert_Input>;
   on_conflict?: InputMaybe<Playlist_On_Conflict>;
@@ -4490,6 +4557,20 @@ export type Mutation_RootInsert_Playlist_Audios_OneArgs = {
 export type Mutation_RootInsert_Playlist_OneArgs = {
   object: Playlist_Insert_Input;
   on_conflict?: InputMaybe<Playlist_On_Conflict>;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_Playlist_PhotosArgs = {
+  objects: Array<Playlist_Photos_Insert_Input>;
+  on_conflict?: InputMaybe<Playlist_Photos_On_Conflict>;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_Playlist_Photos_OneArgs = {
+  object: Playlist_Photos_Insert_Input;
+  on_conflict?: InputMaybe<Playlist_Photos_On_Conflict>;
 };
 
 
@@ -4998,6 +5079,28 @@ export type Mutation_RootUpdate_Notifications_ManyArgs = {
 
 
 /** mutation root */
+export type Mutation_RootUpdate_PhotosArgs = {
+  _inc?: InputMaybe<Photos_Inc_Input>;
+  _set?: InputMaybe<Photos_Set_Input>;
+  where: Photos_Bool_Exp;
+};
+
+
+/** mutation root */
+export type Mutation_RootUpdate_Photos_By_PkArgs = {
+  _inc?: InputMaybe<Photos_Inc_Input>;
+  _set?: InputMaybe<Photos_Set_Input>;
+  pk_columns: Photos_Pk_Columns_Input;
+};
+
+
+/** mutation root */
+export type Mutation_RootUpdate_Photos_ManyArgs = {
+  updates: Array<Photos_Updates>;
+};
+
+
+/** mutation root */
 export type Mutation_RootUpdate_PlaylistArgs = {
   _append?: InputMaybe<Playlist_Append_Input>;
   _delete_at_path?: InputMaybe<Playlist_Delete_At_Path_Input>;
@@ -5046,6 +5149,28 @@ export type Mutation_RootUpdate_Playlist_By_PkArgs = {
 /** mutation root */
 export type Mutation_RootUpdate_Playlist_ManyArgs = {
   updates: Array<Playlist_Updates>;
+};
+
+
+/** mutation root */
+export type Mutation_RootUpdate_Playlist_PhotosArgs = {
+  _inc?: InputMaybe<Playlist_Photos_Inc_Input>;
+  _set?: InputMaybe<Playlist_Photos_Set_Input>;
+  where: Playlist_Photos_Bool_Exp;
+};
+
+
+/** mutation root */
+export type Mutation_RootUpdate_Playlist_Photos_By_PkArgs = {
+  _inc?: InputMaybe<Playlist_Photos_Inc_Input>;
+  _set?: InputMaybe<Playlist_Photos_Set_Input>;
+  pk_columns: Playlist_Photos_Pk_Columns_Input;
+};
+
+
+/** mutation root */
+export type Mutation_RootUpdate_Playlist_Photos_ManyArgs = {
+  updates: Array<Playlist_Photos_Updates>;
 };
 
 
@@ -5771,6 +5896,382 @@ export enum Order_By {
   DescNullsLast = 'desc_nulls_last'
 }
 
+/** Image metadata for the Look app */
+export type Photos = {
+  __typename?: 'photos';
+  blurHash?: Maybe<Scalars['String']['output']>;
+  createdAt: Scalars['timestamptz']['output'];
+  height?: Maybe<Scalars['Int']['output']>;
+  id: Scalars['uuid']['output'];
+  mediumUrl?: Maybe<Scalars['String']['output']>;
+  /** An array relationship */
+  playlist_photos: Array<Playlist_Photos>;
+  /** An aggregate relationship */
+  playlist_photos_aggregate: Playlist_Photos_Aggregate;
+  public: Scalars['Boolean']['output'];
+  slug?: Maybe<Scalars['String']['output']>;
+  source: Scalars['String']['output'];
+  takenAt?: Maybe<Scalars['timestamptz']['output']>;
+  thumbnailUrl?: Maybe<Scalars['String']['output']>;
+  updatedAt: Scalars['timestamptz']['output'];
+  /** An object relationship */
+  user: Users;
+  user_id: Scalars['uuid']['output'];
+  width?: Maybe<Scalars['Int']['output']>;
+};
+
+
+/** Image metadata for the Look app */
+export type PhotosPlaylist_PhotosArgs = {
+  distinct_on?: InputMaybe<Array<Playlist_Photos_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Playlist_Photos_Order_By>>;
+  where?: InputMaybe<Playlist_Photos_Bool_Exp>;
+};
+
+
+/** Image metadata for the Look app */
+export type PhotosPlaylist_Photos_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Playlist_Photos_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Playlist_Photos_Order_By>>;
+  where?: InputMaybe<Playlist_Photos_Bool_Exp>;
+};
+
+/** aggregated selection of "photos" */
+export type Photos_Aggregate = {
+  __typename?: 'photos_aggregate';
+  aggregate?: Maybe<Photos_Aggregate_Fields>;
+  nodes: Array<Photos>;
+};
+
+/** aggregate fields of "photos" */
+export type Photos_Aggregate_Fields = {
+  __typename?: 'photos_aggregate_fields';
+  avg?: Maybe<Photos_Avg_Fields>;
+  count: Scalars['Int']['output'];
+  max?: Maybe<Photos_Max_Fields>;
+  min?: Maybe<Photos_Min_Fields>;
+  stddev?: Maybe<Photos_Stddev_Fields>;
+  stddev_pop?: Maybe<Photos_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Photos_Stddev_Samp_Fields>;
+  sum?: Maybe<Photos_Sum_Fields>;
+  var_pop?: Maybe<Photos_Var_Pop_Fields>;
+  var_samp?: Maybe<Photos_Var_Samp_Fields>;
+  variance?: Maybe<Photos_Variance_Fields>;
+};
+
+
+/** aggregate fields of "photos" */
+export type Photos_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Photos_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** aggregate avg on columns */
+export type Photos_Avg_Fields = {
+  __typename?: 'photos_avg_fields';
+  height?: Maybe<Scalars['Float']['output']>;
+  width?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Boolean expression to filter rows from the table "photos". All fields are combined with a logical 'AND'. */
+export type Photos_Bool_Exp = {
+  _and?: InputMaybe<Array<Photos_Bool_Exp>>;
+  _not?: InputMaybe<Photos_Bool_Exp>;
+  _or?: InputMaybe<Array<Photos_Bool_Exp>>;
+  blurHash?: InputMaybe<String_Comparison_Exp>;
+  createdAt?: InputMaybe<Timestamptz_Comparison_Exp>;
+  height?: InputMaybe<Int_Comparison_Exp>;
+  id?: InputMaybe<Uuid_Comparison_Exp>;
+  mediumUrl?: InputMaybe<String_Comparison_Exp>;
+  playlist_photos?: InputMaybe<Playlist_Photos_Bool_Exp>;
+  playlist_photos_aggregate?: InputMaybe<Playlist_Photos_Aggregate_Bool_Exp>;
+  public?: InputMaybe<Boolean_Comparison_Exp>;
+  slug?: InputMaybe<String_Comparison_Exp>;
+  source?: InputMaybe<String_Comparison_Exp>;
+  takenAt?: InputMaybe<Timestamptz_Comparison_Exp>;
+  thumbnailUrl?: InputMaybe<String_Comparison_Exp>;
+  updatedAt?: InputMaybe<Timestamptz_Comparison_Exp>;
+  user?: InputMaybe<Users_Bool_Exp>;
+  user_id?: InputMaybe<Uuid_Comparison_Exp>;
+  width?: InputMaybe<Int_Comparison_Exp>;
+};
+
+/** unique or primary key constraints on table "photos" */
+export enum Photos_Constraint {
+  /** unique or primary key constraint on columns "id" */
+  PhotosPkey = 'photos_pkey'
+}
+
+/** input type for incrementing numeric columns in table "photos" */
+export type Photos_Inc_Input = {
+  height?: InputMaybe<Scalars['Int']['input']>;
+  width?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** input type for inserting data into table "photos" */
+export type Photos_Insert_Input = {
+  blurHash?: InputMaybe<Scalars['String']['input']>;
+  createdAt?: InputMaybe<Scalars['timestamptz']['input']>;
+  height?: InputMaybe<Scalars['Int']['input']>;
+  id?: InputMaybe<Scalars['uuid']['input']>;
+  mediumUrl?: InputMaybe<Scalars['String']['input']>;
+  playlist_photos?: InputMaybe<Playlist_Photos_Arr_Rel_Insert_Input>;
+  public?: InputMaybe<Scalars['Boolean']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  source?: InputMaybe<Scalars['String']['input']>;
+  takenAt?: InputMaybe<Scalars['timestamptz']['input']>;
+  thumbnailUrl?: InputMaybe<Scalars['String']['input']>;
+  updatedAt?: InputMaybe<Scalars['timestamptz']['input']>;
+  user?: InputMaybe<Users_Obj_Rel_Insert_Input>;
+  user_id?: InputMaybe<Scalars['uuid']['input']>;
+  width?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** aggregate max on columns */
+export type Photos_Max_Fields = {
+  __typename?: 'photos_max_fields';
+  blurHash?: Maybe<Scalars['String']['output']>;
+  createdAt?: Maybe<Scalars['timestamptz']['output']>;
+  height?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['uuid']['output']>;
+  mediumUrl?: Maybe<Scalars['String']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  source?: Maybe<Scalars['String']['output']>;
+  takenAt?: Maybe<Scalars['timestamptz']['output']>;
+  thumbnailUrl?: Maybe<Scalars['String']['output']>;
+  updatedAt?: Maybe<Scalars['timestamptz']['output']>;
+  user_id?: Maybe<Scalars['uuid']['output']>;
+  width?: Maybe<Scalars['Int']['output']>;
+};
+
+/** aggregate min on columns */
+export type Photos_Min_Fields = {
+  __typename?: 'photos_min_fields';
+  blurHash?: Maybe<Scalars['String']['output']>;
+  createdAt?: Maybe<Scalars['timestamptz']['output']>;
+  height?: Maybe<Scalars['Int']['output']>;
+  id?: Maybe<Scalars['uuid']['output']>;
+  mediumUrl?: Maybe<Scalars['String']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  source?: Maybe<Scalars['String']['output']>;
+  takenAt?: Maybe<Scalars['timestamptz']['output']>;
+  thumbnailUrl?: Maybe<Scalars['String']['output']>;
+  updatedAt?: Maybe<Scalars['timestamptz']['output']>;
+  user_id?: Maybe<Scalars['uuid']['output']>;
+  width?: Maybe<Scalars['Int']['output']>;
+};
+
+/** response of any mutation on the table "photos" */
+export type Photos_Mutation_Response = {
+  __typename?: 'photos_mutation_response';
+  /** number of rows affected by the mutation */
+  affected_rows: Scalars['Int']['output'];
+  /** data from the rows affected by the mutation */
+  returning: Array<Photos>;
+};
+
+/** input type for inserting object relation for remote table "photos" */
+export type Photos_Obj_Rel_Insert_Input = {
+  data: Photos_Insert_Input;
+  /** upsert condition */
+  on_conflict?: InputMaybe<Photos_On_Conflict>;
+};
+
+/** on_conflict condition type for table "photos" */
+export type Photos_On_Conflict = {
+  constraint: Photos_Constraint;
+  update_columns?: Array<Photos_Update_Column>;
+  where?: InputMaybe<Photos_Bool_Exp>;
+};
+
+/** Ordering options when selecting data from "photos". */
+export type Photos_Order_By = {
+  blurHash?: InputMaybe<Order_By>;
+  createdAt?: InputMaybe<Order_By>;
+  height?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  mediumUrl?: InputMaybe<Order_By>;
+  playlist_photos_aggregate?: InputMaybe<Playlist_Photos_Aggregate_Order_By>;
+  public?: InputMaybe<Order_By>;
+  slug?: InputMaybe<Order_By>;
+  source?: InputMaybe<Order_By>;
+  takenAt?: InputMaybe<Order_By>;
+  thumbnailUrl?: InputMaybe<Order_By>;
+  updatedAt?: InputMaybe<Order_By>;
+  user?: InputMaybe<Users_Order_By>;
+  user_id?: InputMaybe<Order_By>;
+  width?: InputMaybe<Order_By>;
+};
+
+/** primary key columns input for table: photos */
+export type Photos_Pk_Columns_Input = {
+  id: Scalars['uuid']['input'];
+};
+
+/** select columns of table "photos" */
+export enum Photos_Select_Column {
+  /** column name */
+  BlurHash = 'blurHash',
+  /** column name */
+  CreatedAt = 'createdAt',
+  /** column name */
+  Height = 'height',
+  /** column name */
+  Id = 'id',
+  /** column name */
+  MediumUrl = 'mediumUrl',
+  /** column name */
+  Public = 'public',
+  /** column name */
+  Slug = 'slug',
+  /** column name */
+  Source = 'source',
+  /** column name */
+  TakenAt = 'takenAt',
+  /** column name */
+  ThumbnailUrl = 'thumbnailUrl',
+  /** column name */
+  UpdatedAt = 'updatedAt',
+  /** column name */
+  UserId = 'user_id',
+  /** column name */
+  Width = 'width'
+}
+
+/** input type for updating data in table "photos" */
+export type Photos_Set_Input = {
+  blurHash?: InputMaybe<Scalars['String']['input']>;
+  createdAt?: InputMaybe<Scalars['timestamptz']['input']>;
+  height?: InputMaybe<Scalars['Int']['input']>;
+  id?: InputMaybe<Scalars['uuid']['input']>;
+  mediumUrl?: InputMaybe<Scalars['String']['input']>;
+  public?: InputMaybe<Scalars['Boolean']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  source?: InputMaybe<Scalars['String']['input']>;
+  takenAt?: InputMaybe<Scalars['timestamptz']['input']>;
+  thumbnailUrl?: InputMaybe<Scalars['String']['input']>;
+  updatedAt?: InputMaybe<Scalars['timestamptz']['input']>;
+  user_id?: InputMaybe<Scalars['uuid']['input']>;
+  width?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** aggregate stddev on columns */
+export type Photos_Stddev_Fields = {
+  __typename?: 'photos_stddev_fields';
+  height?: Maybe<Scalars['Float']['output']>;
+  width?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Photos_Stddev_Pop_Fields = {
+  __typename?: 'photos_stddev_pop_fields';
+  height?: Maybe<Scalars['Float']['output']>;
+  width?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Photos_Stddev_Samp_Fields = {
+  __typename?: 'photos_stddev_samp_fields';
+  height?: Maybe<Scalars['Float']['output']>;
+  width?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Streaming cursor of the table "photos" */
+export type Photos_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Photos_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Photos_Stream_Cursor_Value_Input = {
+  blurHash?: InputMaybe<Scalars['String']['input']>;
+  createdAt?: InputMaybe<Scalars['timestamptz']['input']>;
+  height?: InputMaybe<Scalars['Int']['input']>;
+  id?: InputMaybe<Scalars['uuid']['input']>;
+  mediumUrl?: InputMaybe<Scalars['String']['input']>;
+  public?: InputMaybe<Scalars['Boolean']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  source?: InputMaybe<Scalars['String']['input']>;
+  takenAt?: InputMaybe<Scalars['timestamptz']['input']>;
+  thumbnailUrl?: InputMaybe<Scalars['String']['input']>;
+  updatedAt?: InputMaybe<Scalars['timestamptz']['input']>;
+  user_id?: InputMaybe<Scalars['uuid']['input']>;
+  width?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** aggregate sum on columns */
+export type Photos_Sum_Fields = {
+  __typename?: 'photos_sum_fields';
+  height?: Maybe<Scalars['Int']['output']>;
+  width?: Maybe<Scalars['Int']['output']>;
+};
+
+/** update columns of table "photos" */
+export enum Photos_Update_Column {
+  /** column name */
+  BlurHash = 'blurHash',
+  /** column name */
+  CreatedAt = 'createdAt',
+  /** column name */
+  Height = 'height',
+  /** column name */
+  Id = 'id',
+  /** column name */
+  MediumUrl = 'mediumUrl',
+  /** column name */
+  Public = 'public',
+  /** column name */
+  Slug = 'slug',
+  /** column name */
+  Source = 'source',
+  /** column name */
+  TakenAt = 'takenAt',
+  /** column name */
+  ThumbnailUrl = 'thumbnailUrl',
+  /** column name */
+  UpdatedAt = 'updatedAt',
+  /** column name */
+  UserId = 'user_id',
+  /** column name */
+  Width = 'width'
+}
+
+export type Photos_Updates = {
+  /** increments the numeric columns with given value of the filtered values */
+  _inc?: InputMaybe<Photos_Inc_Input>;
+  /** sets the columns of the filtered rows to the given values */
+  _set?: InputMaybe<Photos_Set_Input>;
+  /** filter the rows which have to be updated */
+  where: Photos_Bool_Exp;
+};
+
+/** aggregate var_pop on columns */
+export type Photos_Var_Pop_Fields = {
+  __typename?: 'photos_var_pop_fields';
+  height?: Maybe<Scalars['Float']['output']>;
+  width?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate var_samp on columns */
+export type Photos_Var_Samp_Fields = {
+  __typename?: 'photos_var_samp_fields';
+  height?: Maybe<Scalars['Float']['output']>;
+  width?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate variance on columns */
+export type Photos_Variance_Fields = {
+  __typename?: 'photos_variance_fields';
+  height?: Maybe<Scalars['Float']['output']>;
+  width?: Maybe<Scalars['Float']['output']>;
+};
+
 /** Playlist contain set of videos or audios */
 export type Playlist = {
   __typename?: 'playlist';
@@ -5781,6 +6282,10 @@ export type Playlist = {
   playlist_audios: Array<Playlist_Audios>;
   /** An aggregate relationship */
   playlist_audios_aggregate: Playlist_Audios_Aggregate;
+  /** An array relationship */
+  playlist_photos: Array<Playlist_Photos>;
+  /** An aggregate relationship */
+  playlist_photos_aggregate: Playlist_Photos_Aggregate;
   /** An array relationship */
   playlist_videos: Array<Playlist_Videos>;
   /** An aggregate relationship */
@@ -5824,6 +6329,26 @@ export type PlaylistPlaylist_Audios_AggregateArgs = {
   offset?: InputMaybe<Scalars['Int']['input']>;
   order_by?: InputMaybe<Array<Playlist_Audios_Order_By>>;
   where?: InputMaybe<Playlist_Audios_Bool_Exp>;
+};
+
+
+/** Playlist contain set of videos or audios */
+export type PlaylistPlaylist_PhotosArgs = {
+  distinct_on?: InputMaybe<Array<Playlist_Photos_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Playlist_Photos_Order_By>>;
+  where?: InputMaybe<Playlist_Photos_Bool_Exp>;
+};
+
+
+/** Playlist contain set of videos or audios */
+export type PlaylistPlaylist_Photos_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Playlist_Photos_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Playlist_Photos_Order_By>>;
+  where?: InputMaybe<Playlist_Photos_Bool_Exp>;
 };
 
 
@@ -6294,6 +6819,8 @@ export type Playlist_Bool_Exp = {
   id?: InputMaybe<Uuid_Comparison_Exp>;
   playlist_audios?: InputMaybe<Playlist_Audios_Bool_Exp>;
   playlist_audios_aggregate?: InputMaybe<Playlist_Audios_Aggregate_Bool_Exp>;
+  playlist_photos?: InputMaybe<Playlist_Photos_Bool_Exp>;
+  playlist_photos_aggregate?: InputMaybe<Playlist_Photos_Aggregate_Bool_Exp>;
   playlist_videos?: InputMaybe<Playlist_Videos_Bool_Exp>;
   playlist_videos_aggregate?: InputMaybe<Playlist_Videos_Aggregate_Bool_Exp>;
   public?: InputMaybe<Boolean_Comparison_Exp>;
@@ -6351,6 +6878,7 @@ export type Playlist_Insert_Input = {
   description?: InputMaybe<Scalars['String']['input']>;
   id?: InputMaybe<Scalars['uuid']['input']>;
   playlist_audios?: InputMaybe<Playlist_Audios_Arr_Rel_Insert_Input>;
+  playlist_photos?: InputMaybe<Playlist_Photos_Arr_Rel_Insert_Input>;
   playlist_videos?: InputMaybe<Playlist_Videos_Arr_Rel_Insert_Input>;
   public?: InputMaybe<Scalars['Boolean']['input']>;
   /** Short id like Youtube video id */
@@ -6460,6 +6988,7 @@ export type Playlist_Order_By = {
   description?: InputMaybe<Order_By>;
   id?: InputMaybe<Order_By>;
   playlist_audios_aggregate?: InputMaybe<Playlist_Audios_Aggregate_Order_By>;
+  playlist_photos_aggregate?: InputMaybe<Playlist_Photos_Aggregate_Order_By>;
   playlist_videos_aggregate?: InputMaybe<Playlist_Videos_Aggregate_Order_By>;
   public?: InputMaybe<Order_By>;
   sId?: InputMaybe<Order_By>;
@@ -6473,6 +7002,341 @@ export type Playlist_Order_By = {
   updatedAt?: InputMaybe<Order_By>;
   user?: InputMaybe<Users_Order_By>;
   user_id?: InputMaybe<Order_By>;
+};
+
+/** Junction table between photos and playlist */
+export type Playlist_Photos = {
+  __typename?: 'playlist_photos';
+  createdAt: Scalars['timestamptz']['output'];
+  /** An object relationship */
+  photo: Photos;
+  photo_id: Scalars['uuid']['output'];
+  /** An object relationship */
+  playlist: Playlist;
+  playlist_id: Scalars['uuid']['output'];
+  position: Scalars['Int']['output'];
+  updatedAt: Scalars['timestamptz']['output'];
+};
+
+/** aggregated selection of "playlist_photos" */
+export type Playlist_Photos_Aggregate = {
+  __typename?: 'playlist_photos_aggregate';
+  aggregate?: Maybe<Playlist_Photos_Aggregate_Fields>;
+  nodes: Array<Playlist_Photos>;
+};
+
+export type Playlist_Photos_Aggregate_Bool_Exp = {
+  count?: InputMaybe<Playlist_Photos_Aggregate_Bool_Exp_Count>;
+};
+
+export type Playlist_Photos_Aggregate_Bool_Exp_Count = {
+  arguments?: InputMaybe<Array<Playlist_Photos_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+  filter?: InputMaybe<Playlist_Photos_Bool_Exp>;
+  predicate: Int_Comparison_Exp;
+};
+
+/** aggregate fields of "playlist_photos" */
+export type Playlist_Photos_Aggregate_Fields = {
+  __typename?: 'playlist_photos_aggregate_fields';
+  avg?: Maybe<Playlist_Photos_Avg_Fields>;
+  count: Scalars['Int']['output'];
+  max?: Maybe<Playlist_Photos_Max_Fields>;
+  min?: Maybe<Playlist_Photos_Min_Fields>;
+  stddev?: Maybe<Playlist_Photos_Stddev_Fields>;
+  stddev_pop?: Maybe<Playlist_Photos_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Playlist_Photos_Stddev_Samp_Fields>;
+  sum?: Maybe<Playlist_Photos_Sum_Fields>;
+  var_pop?: Maybe<Playlist_Photos_Var_Pop_Fields>;
+  var_samp?: Maybe<Playlist_Photos_Var_Samp_Fields>;
+  variance?: Maybe<Playlist_Photos_Variance_Fields>;
+};
+
+
+/** aggregate fields of "playlist_photos" */
+export type Playlist_Photos_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Playlist_Photos_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** order by aggregate values of table "playlist_photos" */
+export type Playlist_Photos_Aggregate_Order_By = {
+  avg?: InputMaybe<Playlist_Photos_Avg_Order_By>;
+  count?: InputMaybe<Order_By>;
+  max?: InputMaybe<Playlist_Photos_Max_Order_By>;
+  min?: InputMaybe<Playlist_Photos_Min_Order_By>;
+  stddev?: InputMaybe<Playlist_Photos_Stddev_Order_By>;
+  stddev_pop?: InputMaybe<Playlist_Photos_Stddev_Pop_Order_By>;
+  stddev_samp?: InputMaybe<Playlist_Photos_Stddev_Samp_Order_By>;
+  sum?: InputMaybe<Playlist_Photos_Sum_Order_By>;
+  var_pop?: InputMaybe<Playlist_Photos_Var_Pop_Order_By>;
+  var_samp?: InputMaybe<Playlist_Photos_Var_Samp_Order_By>;
+  variance?: InputMaybe<Playlist_Photos_Variance_Order_By>;
+};
+
+/** input type for inserting array relation for remote table "playlist_photos" */
+export type Playlist_Photos_Arr_Rel_Insert_Input = {
+  data: Array<Playlist_Photos_Insert_Input>;
+  /** upsert condition */
+  on_conflict?: InputMaybe<Playlist_Photos_On_Conflict>;
+};
+
+/** aggregate avg on columns */
+export type Playlist_Photos_Avg_Fields = {
+  __typename?: 'playlist_photos_avg_fields';
+  position?: Maybe<Scalars['Float']['output']>;
+};
+
+/** order by avg() on columns of table "playlist_photos" */
+export type Playlist_Photos_Avg_Order_By = {
+  position?: InputMaybe<Order_By>;
+};
+
+/** Boolean expression to filter rows from the table "playlist_photos". All fields are combined with a logical 'AND'. */
+export type Playlist_Photos_Bool_Exp = {
+  _and?: InputMaybe<Array<Playlist_Photos_Bool_Exp>>;
+  _not?: InputMaybe<Playlist_Photos_Bool_Exp>;
+  _or?: InputMaybe<Array<Playlist_Photos_Bool_Exp>>;
+  createdAt?: InputMaybe<Timestamptz_Comparison_Exp>;
+  photo?: InputMaybe<Photos_Bool_Exp>;
+  photo_id?: InputMaybe<Uuid_Comparison_Exp>;
+  playlist?: InputMaybe<Playlist_Bool_Exp>;
+  playlist_id?: InputMaybe<Uuid_Comparison_Exp>;
+  position?: InputMaybe<Int_Comparison_Exp>;
+  updatedAt?: InputMaybe<Timestamptz_Comparison_Exp>;
+};
+
+/** unique or primary key constraints on table "playlist_photos" */
+export enum Playlist_Photos_Constraint {
+  /** unique or primary key constraint on columns "photo_id", "playlist_id" */
+  PlaylistPhotosPkey = 'playlist_photos_pkey'
+}
+
+/** input type for incrementing numeric columns in table "playlist_photos" */
+export type Playlist_Photos_Inc_Input = {
+  position?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** input type for inserting data into table "playlist_photos" */
+export type Playlist_Photos_Insert_Input = {
+  createdAt?: InputMaybe<Scalars['timestamptz']['input']>;
+  photo?: InputMaybe<Photos_Obj_Rel_Insert_Input>;
+  photo_id?: InputMaybe<Scalars['uuid']['input']>;
+  playlist?: InputMaybe<Playlist_Obj_Rel_Insert_Input>;
+  playlist_id?: InputMaybe<Scalars['uuid']['input']>;
+  position?: InputMaybe<Scalars['Int']['input']>;
+  updatedAt?: InputMaybe<Scalars['timestamptz']['input']>;
+};
+
+/** aggregate max on columns */
+export type Playlist_Photos_Max_Fields = {
+  __typename?: 'playlist_photos_max_fields';
+  createdAt?: Maybe<Scalars['timestamptz']['output']>;
+  photo_id?: Maybe<Scalars['uuid']['output']>;
+  playlist_id?: Maybe<Scalars['uuid']['output']>;
+  position?: Maybe<Scalars['Int']['output']>;
+  updatedAt?: Maybe<Scalars['timestamptz']['output']>;
+};
+
+/** order by max() on columns of table "playlist_photos" */
+export type Playlist_Photos_Max_Order_By = {
+  createdAt?: InputMaybe<Order_By>;
+  photo_id?: InputMaybe<Order_By>;
+  playlist_id?: InputMaybe<Order_By>;
+  position?: InputMaybe<Order_By>;
+  updatedAt?: InputMaybe<Order_By>;
+};
+
+/** aggregate min on columns */
+export type Playlist_Photos_Min_Fields = {
+  __typename?: 'playlist_photos_min_fields';
+  createdAt?: Maybe<Scalars['timestamptz']['output']>;
+  photo_id?: Maybe<Scalars['uuid']['output']>;
+  playlist_id?: Maybe<Scalars['uuid']['output']>;
+  position?: Maybe<Scalars['Int']['output']>;
+  updatedAt?: Maybe<Scalars['timestamptz']['output']>;
+};
+
+/** order by min() on columns of table "playlist_photos" */
+export type Playlist_Photos_Min_Order_By = {
+  createdAt?: InputMaybe<Order_By>;
+  photo_id?: InputMaybe<Order_By>;
+  playlist_id?: InputMaybe<Order_By>;
+  position?: InputMaybe<Order_By>;
+  updatedAt?: InputMaybe<Order_By>;
+};
+
+/** response of any mutation on the table "playlist_photos" */
+export type Playlist_Photos_Mutation_Response = {
+  __typename?: 'playlist_photos_mutation_response';
+  /** number of rows affected by the mutation */
+  affected_rows: Scalars['Int']['output'];
+  /** data from the rows affected by the mutation */
+  returning: Array<Playlist_Photos>;
+};
+
+/** on_conflict condition type for table "playlist_photos" */
+export type Playlist_Photos_On_Conflict = {
+  constraint: Playlist_Photos_Constraint;
+  update_columns?: Array<Playlist_Photos_Update_Column>;
+  where?: InputMaybe<Playlist_Photos_Bool_Exp>;
+};
+
+/** Ordering options when selecting data from "playlist_photos". */
+export type Playlist_Photos_Order_By = {
+  createdAt?: InputMaybe<Order_By>;
+  photo?: InputMaybe<Photos_Order_By>;
+  photo_id?: InputMaybe<Order_By>;
+  playlist?: InputMaybe<Playlist_Order_By>;
+  playlist_id?: InputMaybe<Order_By>;
+  position?: InputMaybe<Order_By>;
+  updatedAt?: InputMaybe<Order_By>;
+};
+
+/** primary key columns input for table: playlist_photos */
+export type Playlist_Photos_Pk_Columns_Input = {
+  photo_id: Scalars['uuid']['input'];
+  playlist_id: Scalars['uuid']['input'];
+};
+
+/** select columns of table "playlist_photos" */
+export enum Playlist_Photos_Select_Column {
+  /** column name */
+  CreatedAt = 'createdAt',
+  /** column name */
+  PhotoId = 'photo_id',
+  /** column name */
+  PlaylistId = 'playlist_id',
+  /** column name */
+  Position = 'position',
+  /** column name */
+  UpdatedAt = 'updatedAt'
+}
+
+/** input type for updating data in table "playlist_photos" */
+export type Playlist_Photos_Set_Input = {
+  createdAt?: InputMaybe<Scalars['timestamptz']['input']>;
+  photo_id?: InputMaybe<Scalars['uuid']['input']>;
+  playlist_id?: InputMaybe<Scalars['uuid']['input']>;
+  position?: InputMaybe<Scalars['Int']['input']>;
+  updatedAt?: InputMaybe<Scalars['timestamptz']['input']>;
+};
+
+/** aggregate stddev on columns */
+export type Playlist_Photos_Stddev_Fields = {
+  __typename?: 'playlist_photos_stddev_fields';
+  position?: Maybe<Scalars['Float']['output']>;
+};
+
+/** order by stddev() on columns of table "playlist_photos" */
+export type Playlist_Photos_Stddev_Order_By = {
+  position?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Playlist_Photos_Stddev_Pop_Fields = {
+  __typename?: 'playlist_photos_stddev_pop_fields';
+  position?: Maybe<Scalars['Float']['output']>;
+};
+
+/** order by stddev_pop() on columns of table "playlist_photos" */
+export type Playlist_Photos_Stddev_Pop_Order_By = {
+  position?: InputMaybe<Order_By>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Playlist_Photos_Stddev_Samp_Fields = {
+  __typename?: 'playlist_photos_stddev_samp_fields';
+  position?: Maybe<Scalars['Float']['output']>;
+};
+
+/** order by stddev_samp() on columns of table "playlist_photos" */
+export type Playlist_Photos_Stddev_Samp_Order_By = {
+  position?: InputMaybe<Order_By>;
+};
+
+/** Streaming cursor of the table "playlist_photos" */
+export type Playlist_Photos_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Playlist_Photos_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Playlist_Photos_Stream_Cursor_Value_Input = {
+  createdAt?: InputMaybe<Scalars['timestamptz']['input']>;
+  photo_id?: InputMaybe<Scalars['uuid']['input']>;
+  playlist_id?: InputMaybe<Scalars['uuid']['input']>;
+  position?: InputMaybe<Scalars['Int']['input']>;
+  updatedAt?: InputMaybe<Scalars['timestamptz']['input']>;
+};
+
+/** aggregate sum on columns */
+export type Playlist_Photos_Sum_Fields = {
+  __typename?: 'playlist_photos_sum_fields';
+  position?: Maybe<Scalars['Int']['output']>;
+};
+
+/** order by sum() on columns of table "playlist_photos" */
+export type Playlist_Photos_Sum_Order_By = {
+  position?: InputMaybe<Order_By>;
+};
+
+/** update columns of table "playlist_photos" */
+export enum Playlist_Photos_Update_Column {
+  /** column name */
+  CreatedAt = 'createdAt',
+  /** column name */
+  PhotoId = 'photo_id',
+  /** column name */
+  PlaylistId = 'playlist_id',
+  /** column name */
+  Position = 'position',
+  /** column name */
+  UpdatedAt = 'updatedAt'
+}
+
+export type Playlist_Photos_Updates = {
+  /** increments the numeric columns with given value of the filtered values */
+  _inc?: InputMaybe<Playlist_Photos_Inc_Input>;
+  /** sets the columns of the filtered rows to the given values */
+  _set?: InputMaybe<Playlist_Photos_Set_Input>;
+  /** filter the rows which have to be updated */
+  where: Playlist_Photos_Bool_Exp;
+};
+
+/** aggregate var_pop on columns */
+export type Playlist_Photos_Var_Pop_Fields = {
+  __typename?: 'playlist_photos_var_pop_fields';
+  position?: Maybe<Scalars['Float']['output']>;
+};
+
+/** order by var_pop() on columns of table "playlist_photos" */
+export type Playlist_Photos_Var_Pop_Order_By = {
+  position?: InputMaybe<Order_By>;
+};
+
+/** aggregate var_samp on columns */
+export type Playlist_Photos_Var_Samp_Fields = {
+  __typename?: 'playlist_photos_var_samp_fields';
+  position?: Maybe<Scalars['Float']['output']>;
+};
+
+/** order by var_samp() on columns of table "playlist_photos" */
+export type Playlist_Photos_Var_Samp_Order_By = {
+  position?: InputMaybe<Order_By>;
+};
+
+/** aggregate variance on columns */
+export type Playlist_Photos_Variance_Fields = {
+  __typename?: 'playlist_photos_variance_fields';
+  position?: Maybe<Scalars['Float']['output']>;
+};
+
+/** order by variance() on columns of table "playlist_photos" */
+export type Playlist_Photos_Variance_Order_By = {
+  position?: InputMaybe<Order_By>;
 };
 
 /** primary key columns input for table: playlist */
@@ -7365,6 +8229,12 @@ export type Query_Root = {
   notifications_aggregate: Notifications_Aggregate;
   /** fetch data from the table: "notifications" using primary key columns */
   notifications_by_pk?: Maybe<Notifications>;
+  /** fetch data from the table: "photos" */
+  photos: Array<Photos>;
+  /** fetch aggregated fields from the table: "photos" */
+  photos_aggregate: Photos_Aggregate;
+  /** fetch data from the table: "photos" using primary key columns */
+  photos_by_pk?: Maybe<Photos>;
   /** fetch data from the table: "playlist" */
   playlist: Array<Playlist>;
   /** fetch aggregated fields from the table: "playlist" */
@@ -7377,6 +8247,12 @@ export type Query_Root = {
   playlist_audios_by_pk?: Maybe<Playlist_Audios>;
   /** fetch data from the table: "playlist" using primary key columns */
   playlist_by_pk?: Maybe<Playlist>;
+  /** An array relationship */
+  playlist_photos: Array<Playlist_Photos>;
+  /** An aggregate relationship */
+  playlist_photos_aggregate: Playlist_Photos_Aggregate;
+  /** fetch data from the table: "playlist_photos" using primary key columns */
+  playlist_photos_by_pk?: Maybe<Playlist_Photos>;
   /** An array relationship */
   playlist_videos: Array<Playlist_Videos>;
   /** An aggregate relationship */
@@ -7730,6 +8606,29 @@ export type Query_RootNotifications_By_PkArgs = {
 };
 
 
+export type Query_RootPhotosArgs = {
+  distinct_on?: InputMaybe<Array<Photos_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Photos_Order_By>>;
+  where?: InputMaybe<Photos_Bool_Exp>;
+};
+
+
+export type Query_RootPhotos_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Photos_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Photos_Order_By>>;
+  where?: InputMaybe<Photos_Bool_Exp>;
+};
+
+
+export type Query_RootPhotos_By_PkArgs = {
+  id: Scalars['uuid']['input'];
+};
+
+
 export type Query_RootPlaylistArgs = {
   distinct_on?: InputMaybe<Array<Playlist_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -7774,6 +8673,30 @@ export type Query_RootPlaylist_Audios_By_PkArgs = {
 
 export type Query_RootPlaylist_By_PkArgs = {
   id: Scalars['uuid']['input'];
+};
+
+
+export type Query_RootPlaylist_PhotosArgs = {
+  distinct_on?: InputMaybe<Array<Playlist_Photos_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Playlist_Photos_Order_By>>;
+  where?: InputMaybe<Playlist_Photos_Bool_Exp>;
+};
+
+
+export type Query_RootPlaylist_Photos_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Playlist_Photos_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Playlist_Photos_Order_By>>;
+  where?: InputMaybe<Playlist_Photos_Bool_Exp>;
+};
+
+
+export type Query_RootPlaylist_Photos_By_PkArgs = {
+  photo_id: Scalars['uuid']['input'];
+  playlist_id: Scalars['uuid']['input'];
 };
 
 
@@ -9182,6 +10105,14 @@ export type Subscription_Root = {
   notifications_by_pk?: Maybe<Notifications>;
   /** fetch data from the table in a streaming manner: "notifications" */
   notifications_stream: Array<Notifications>;
+  /** fetch data from the table: "photos" */
+  photos: Array<Photos>;
+  /** fetch aggregated fields from the table: "photos" */
+  photos_aggregate: Photos_Aggregate;
+  /** fetch data from the table: "photos" using primary key columns */
+  photos_by_pk?: Maybe<Photos>;
+  /** fetch data from the table in a streaming manner: "photos" */
+  photos_stream: Array<Photos>;
   /** fetch data from the table: "playlist" */
   playlist: Array<Playlist>;
   /** fetch aggregated fields from the table: "playlist" */
@@ -9196,6 +10127,14 @@ export type Subscription_Root = {
   playlist_audios_stream: Array<Playlist_Audios>;
   /** fetch data from the table: "playlist" using primary key columns */
   playlist_by_pk?: Maybe<Playlist>;
+  /** An array relationship */
+  playlist_photos: Array<Playlist_Photos>;
+  /** An aggregate relationship */
+  playlist_photos_aggregate: Playlist_Photos_Aggregate;
+  /** fetch data from the table: "playlist_photos" using primary key columns */
+  playlist_photos_by_pk?: Maybe<Playlist_Photos>;
+  /** fetch data from the table in a streaming manner: "playlist_photos" */
+  playlist_photos_stream: Array<Playlist_Photos>;
   /** fetch data from the table in a streaming manner: "playlist" */
   playlist_stream: Array<Playlist>;
   /** An array relationship */
@@ -9660,6 +10599,36 @@ export type Subscription_RootNotifications_StreamArgs = {
 };
 
 
+export type Subscription_RootPhotosArgs = {
+  distinct_on?: InputMaybe<Array<Photos_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Photos_Order_By>>;
+  where?: InputMaybe<Photos_Bool_Exp>;
+};
+
+
+export type Subscription_RootPhotos_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Photos_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Photos_Order_By>>;
+  where?: InputMaybe<Photos_Bool_Exp>;
+};
+
+
+export type Subscription_RootPhotos_By_PkArgs = {
+  id: Scalars['uuid']['input'];
+};
+
+
+export type Subscription_RootPhotos_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Photos_Stream_Cursor_Input>>;
+  where?: InputMaybe<Photos_Bool_Exp>;
+};
+
+
 export type Subscription_RootPlaylistArgs = {
   distinct_on?: InputMaybe<Array<Playlist_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -9711,6 +10680,37 @@ export type Subscription_RootPlaylist_Audios_StreamArgs = {
 
 export type Subscription_RootPlaylist_By_PkArgs = {
   id: Scalars['uuid']['input'];
+};
+
+
+export type Subscription_RootPlaylist_PhotosArgs = {
+  distinct_on?: InputMaybe<Array<Playlist_Photos_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Playlist_Photos_Order_By>>;
+  where?: InputMaybe<Playlist_Photos_Bool_Exp>;
+};
+
+
+export type Subscription_RootPlaylist_Photos_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Playlist_Photos_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Playlist_Photos_Order_By>>;
+  where?: InputMaybe<Playlist_Photos_Bool_Exp>;
+};
+
+
+export type Subscription_RootPlaylist_Photos_By_PkArgs = {
+  photo_id: Scalars['uuid']['input'];
+  playlist_id: Scalars['uuid']['input'];
+};
+
+
+export type Subscription_RootPlaylist_Photos_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Playlist_Photos_Stream_Cursor_Input>>;
+  where?: InputMaybe<Playlist_Photos_Bool_Exp>;
 };
 
 
@@ -14325,6 +15325,49 @@ export type ListenPlaylistsQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type ListenPlaylistsQuery = { __typename?: 'query_root', playlist: Array<{ __typename?: 'playlist', id: any, title: string, slug: string }> };
 
+export type LookAlbumsQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type LookAlbumsQuery = { __typename?: 'query_root', playlist: Array<(
+    { __typename?: 'playlist' }
+    & { ' $fragmentRefs'?: { 'AlbumFieldsFragment': AlbumFieldsFragment } }
+  )> };
+
+export type LookAlbumDetailQueryVariables = Exact<{
+  id: Scalars['uuid']['input'];
+}>;
+
+
+export type LookAlbumDetailQuery = { __typename?: 'query_root', playlist_by_pk?: (
+    { __typename?: 'playlist' }
+    & { ' $fragmentRefs'?: { 'AlbumFieldsFragment': AlbumFieldsFragment } }
+  ) | null };
+
+export type PhotoFieldsFragment = { __typename?: 'photos', id: any, source: string, mediumUrl?: string | null, thumbnailUrl?: string | null, blurHash?: string | null, width?: number | null, height?: number | null, takenAt?: any | null, slug?: string | null, createdAt: any, user_id: any } & { ' $fragmentName'?: 'PhotoFieldsFragment' };
+
+export type AlbumFieldsFragment = { __typename?: 'playlist', id: any, title: string, thumbnailUrl?: string | null, slug: string, createdAt: any, description?: string | null, playlist_photos: Array<{ __typename?: 'playlist_photos', position: number, photo: (
+      { __typename?: 'photos' }
+      & { ' $fragmentRefs'?: { 'PhotoFieldsFragment': PhotoFieldsFragment } }
+    ) }> } & { ' $fragmentName'?: 'AlbumFieldsFragment' };
+
+export type LookPhotoDetailQueryVariables = Exact<{
+  id: Scalars['uuid']['input'];
+}>;
+
+
+export type LookPhotoDetailQuery = { __typename?: 'query_root', photos_by_pk?: (
+    { __typename?: 'photos' }
+    & { ' $fragmentRefs'?: { 'PhotoFieldsFragment': PhotoFieldsFragment } }
+  ) | null };
+
+export type LookPhotosQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type LookPhotosQuery = { __typename?: 'query_root', photos: Array<(
+    { __typename?: 'photos' }
+    & { ' $fragmentRefs'?: { 'PhotoFieldsFragment': PhotoFieldsFragment } }
+  )> };
+
 export type InsertPostMutationVariables = Exact<{
   object: Posts_Insert_Input;
 }>;
@@ -14632,6 +15675,49 @@ fragment PlaylistAudioFields on playlist_audios {
     ...AudioFields
   }
 }`, {"fragmentName":"ListenPlaylistFields"}) as unknown as TypedDocumentString<ListenPlaylistFieldsFragment, unknown>;
+export const PhotoFieldsFragmentDoc = new TypedDocumentString(`
+    fragment PhotoFields on photos {
+  id
+  source
+  mediumUrl
+  thumbnailUrl
+  blurHash
+  width
+  height
+  takenAt
+  slug
+  createdAt
+  user_id
+}
+    `, {"fragmentName":"PhotoFields"}) as unknown as TypedDocumentString<PhotoFieldsFragment, unknown>;
+export const AlbumFieldsFragmentDoc = new TypedDocumentString(`
+    fragment AlbumFields on playlist {
+  id
+  title
+  thumbnailUrl
+  slug
+  createdAt
+  description
+  playlist_photos(order_by: {position: asc}) {
+    position
+    photo {
+      ...PhotoFields
+    }
+  }
+}
+    fragment PhotoFields on photos {
+  id
+  source
+  mediumUrl
+  thumbnailUrl
+  blurHash
+  width
+  height
+  takenAt
+  slug
+  createdAt
+  user_id
+}`, {"fragmentName":"AlbumFields"}) as unknown as TypedDocumentString<AlbumFieldsFragment, unknown>;
 export const UserFieldsFragmentDoc = new TypedDocumentString(`
     fragment UserFields on users {
   username
@@ -15249,6 +16335,110 @@ export const ListenPlaylistsDocument = new TypedDocumentString(`
   }
 }
     `) as unknown as TypedDocumentString<ListenPlaylistsQuery, ListenPlaylistsQueryVariables>;
+export const LookAlbumsDocument = new TypedDocumentString(`
+    query LookAlbums @cached {
+  playlist(where: {site: {_eq: "look"}}, order_by: {createdAt: desc}) {
+    ...AlbumFields
+  }
+}
+    fragment PhotoFields on photos {
+  id
+  source
+  mediumUrl
+  thumbnailUrl
+  blurHash
+  width
+  height
+  takenAt
+  slug
+  createdAt
+  user_id
+}
+fragment AlbumFields on playlist {
+  id
+  title
+  thumbnailUrl
+  slug
+  createdAt
+  description
+  playlist_photos(order_by: {position: asc}) {
+    position
+    photo {
+      ...PhotoFields
+    }
+  }
+}`) as unknown as TypedDocumentString<LookAlbumsQuery, LookAlbumsQueryVariables>;
+export const LookAlbumDetailDocument = new TypedDocumentString(`
+    query LookAlbumDetail($id: uuid!) @cached {
+  playlist_by_pk(id: $id) {
+    ...AlbumFields
+  }
+}
+    fragment PhotoFields on photos {
+  id
+  source
+  mediumUrl
+  thumbnailUrl
+  blurHash
+  width
+  height
+  takenAt
+  slug
+  createdAt
+  user_id
+}
+fragment AlbumFields on playlist {
+  id
+  title
+  thumbnailUrl
+  slug
+  createdAt
+  description
+  playlist_photos(order_by: {position: asc}) {
+    position
+    photo {
+      ...PhotoFields
+    }
+  }
+}`) as unknown as TypedDocumentString<LookAlbumDetailQuery, LookAlbumDetailQueryVariables>;
+export const LookPhotoDetailDocument = new TypedDocumentString(`
+    query LookPhotoDetail($id: uuid!) @cached {
+  photos_by_pk(id: $id) {
+    ...PhotoFields
+  }
+}
+    fragment PhotoFields on photos {
+  id
+  source
+  mediumUrl
+  thumbnailUrl
+  blurHash
+  width
+  height
+  takenAt
+  slug
+  createdAt
+  user_id
+}`) as unknown as TypedDocumentString<LookPhotoDetailQuery, LookPhotoDetailQueryVariables>;
+export const LookPhotosDocument = new TypedDocumentString(`
+    query LookPhotos @cached {
+  photos(order_by: {takenAt: desc}) {
+    ...PhotoFields
+  }
+}
+    fragment PhotoFields on photos {
+  id
+  source
+  mediumUrl
+  thumbnailUrl
+  blurHash
+  width
+  height
+  takenAt
+  slug
+  createdAt
+  user_id
+}`) as unknown as TypedDocumentString<LookPhotosQuery, LookPhotosQueryVariables>;
 export const InsertPostDocument = new TypedDocumentString(`
     mutation InsertPost($object: posts_insert_input!) {
   insert_posts_one(object: $object) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,7 @@ import {
   mutationHooks as listenMutationHooks,
   queryHooks as listenQueryHooks,
 } from './listen';
+import { queryHooks as lookQueryHooks } from './look';
 import hooks, {
   commonHelpers,
   ErrorBoundary,
@@ -22,6 +23,7 @@ export { commonHelpers, requestHelpers };
 export {
   listenMutationHooks,
   listenQueryHooks,
+  lookQueryHooks,
   watchMutationHooks,
   watchQueryHooks,
 };

--- a/packages/core/src/look/index.ts
+++ b/packages/core/src/look/index.ts
@@ -1,0 +1,1 @@
+export * as queryHooks from './query-hooks';

--- a/packages/core/src/look/query-hooks/albums/index.ts
+++ b/packages/core/src/look/query-hooks/albums/index.ts
@@ -1,0 +1,69 @@
+import { graphql } from '../../../graphql';
+import type {
+  LookAlbumDetailQuery,
+  LookAlbumsQuery,
+} from '../../../graphql/graphql';
+import { useRequest } from '../../../universal/hooks/use-request';
+import { transformAlbumFragment } from '../transformers';
+import type { BaseQueryProps, DetailQueryProps } from '../types';
+
+const albumsQuery = graphql(/* GraphQL */ `
+  query LookAlbums @cached {
+    playlist(
+      where: { site: { _eq: "look" } }
+      order_by: { createdAt: desc }
+    ) {
+      ...AlbumFields
+    }
+  }
+`);
+
+const albumDetailQuery = graphql(/* GraphQL */ `
+  query LookAlbumDetail($id: uuid!) @cached {
+    playlist_by_pk(id: $id) {
+      ...AlbumFields
+    }
+  }
+`);
+
+const useLoadAlbums = (props: BaseQueryProps) => {
+  const { getAccessToken } = props;
+
+  const { data, isLoading, error } = useRequest<LookAlbumsQuery>({
+    queryKey: ['look-albums'],
+    getAccessToken,
+    document: albumsQuery,
+  });
+
+  return {
+    albums: data ? data.playlist.map(transformAlbumFragment) : [],
+    isLoading,
+    error,
+  };
+};
+
+const useLoadAlbumDetail = (props: DetailQueryProps) => {
+  const { id, getAccessToken } = props;
+
+  const { data, isLoading, error } = useRequest<
+    LookAlbumDetailQuery,
+    { id: string }
+  >({
+    queryKey: ['look-album-detail', id],
+    getAccessToken,
+    document: albumDetailQuery,
+    variables: {
+      id,
+    },
+  });
+
+  return {
+    album: data?.playlist_by_pk
+      ? transformAlbumFragment(data.playlist_by_pk)
+      : null,
+    isLoading,
+    error,
+  };
+};
+
+export { useLoadAlbumDetail, useLoadAlbums };

--- a/packages/core/src/look/query-hooks/fragments.ts
+++ b/packages/core/src/look/query-hooks/fragments.ts
@@ -11,8 +11,6 @@ const PhotoFragment = graphql(/* GraphQL */ `
     height
     takenAt
     slug
-    createdAt
-    user_id
   }
 `);
 

--- a/packages/core/src/look/query-hooks/fragments.ts
+++ b/packages/core/src/look/query-hooks/fragments.ts
@@ -1,0 +1,36 @@
+import { graphql } from '../../graphql';
+
+const PhotoFragment = graphql(/* GraphQL */ `
+  fragment PhotoFields on photos {
+    id
+    source
+    mediumUrl
+    thumbnailUrl
+    blurHash
+    width
+    height
+    takenAt
+    slug
+    createdAt
+    user_id
+  }
+`);
+
+const AlbumFragment = graphql(/* GraphQL */ `
+  fragment AlbumFields on playlist {
+    id
+    title
+    thumbnailUrl
+    slug
+    createdAt
+    description
+    playlist_photos(order_by: { position: asc }) {
+      position
+      photo {
+        ...PhotoFields
+      }
+    }
+  }
+`);
+
+export { AlbumFragment, PhotoFragment };

--- a/packages/core/src/look/query-hooks/index.ts
+++ b/packages/core/src/look/query-hooks/index.ts
@@ -1,0 +1,4 @@
+export { useLoadAlbumDetail, useLoadAlbums } from './albums';
+export { useLoadPhotoDetail } from './photo-detail';
+export { useLoadPhotos } from './photos';
+export * from './types';

--- a/packages/core/src/look/query-hooks/photo-detail/index.ts
+++ b/packages/core/src/look/query-hooks/photo-detail/index.ts
@@ -1,0 +1,39 @@
+import { graphql } from '../../../graphql';
+import type { LookPhotoDetailQuery } from '../../../graphql/graphql';
+import { useRequest } from '../../../universal/hooks/use-request';
+import { transformPhotoFragment } from '../transformers';
+import type { DetailQueryProps } from '../types';
+
+const photoDetailQuery = graphql(/* GraphQL */ `
+  query LookPhotoDetail($id: uuid!) @cached {
+    photos_by_pk(id: $id) {
+      ...PhotoFields
+    }
+  }
+`);
+
+const useLoadPhotoDetail = (props: DetailQueryProps) => {
+  const { id, getAccessToken } = props;
+
+  const { data, isLoading, error } = useRequest<
+    LookPhotoDetailQuery,
+    { id: string }
+  >({
+    queryKey: ['look-photo-detail', id],
+    getAccessToken,
+    document: photoDetailQuery,
+    variables: {
+      id,
+    },
+  });
+
+  return {
+    photo: data?.photos_by_pk
+      ? transformPhotoFragment(data.photos_by_pk)
+      : null,
+    isLoading,
+    error,
+  };
+};
+
+export { useLoadPhotoDetail };

--- a/packages/core/src/look/query-hooks/photos/index.ts
+++ b/packages/core/src/look/query-hooks/photos/index.ts
@@ -1,0 +1,33 @@
+import { graphql } from '../../../graphql';
+import type { LookPhotosQuery } from '../../../graphql/graphql';
+import { useRequest } from '../../../universal/hooks/use-request';
+import { transformPhotoFragment } from '../transformers';
+import type { BaseQueryProps } from '../types';
+
+const photosQuery = graphql(/* GraphQL */ `
+  query LookPhotos @cached {
+    photos(order_by: { takenAt: desc }) {
+      ...PhotoFields
+    }
+  }
+`);
+
+// The flat, newest-first index the timeline reads. The UI groups it by month
+// client-side from each photo's takenAt, so the hook stays a plain list.
+const useLoadPhotos = (props: BaseQueryProps) => {
+  const { getAccessToken } = props;
+
+  const { data, isLoading, error } = useRequest<LookPhotosQuery>({
+    queryKey: ['look-photos'],
+    getAccessToken,
+    document: photosQuery,
+  });
+
+  return {
+    photos: data ? data.photos.map(transformPhotoFragment) : [],
+    isLoading,
+    error,
+  };
+};
+
+export { useLoadPhotos };

--- a/packages/core/src/look/query-hooks/transformers.test.ts
+++ b/packages/core/src/look/query-hooks/transformers.test.ts
@@ -16,8 +16,6 @@ describe('Look fragment transformations', () => {
       height: 1080,
       takenAt: '2023-01-01T00:00:00Z',
       slug: 'test-photo',
-      createdAt: '2023-01-02T00:00:00Z',
-      user_id: 'user-123',
     };
 
     it('should transform photo fragment correctly', () => {
@@ -69,8 +67,6 @@ describe('Look fragment transformations', () => {
             height: 1080,
             takenAt: '2023-01-01T00:00:00Z',
             slug: 'test-photo',
-            createdAt: '2023-01-02T00:00:00Z',
-            user_id: 'user-123',
           },
         },
       ],
@@ -102,6 +98,19 @@ describe('Look fragment transformations', () => {
           },
         ],
       });
+    });
+
+    it('should return an empty photos array for an album with no photos', () => {
+      const emptyAlbumData = {
+        ...mockAlbumData,
+        playlist_photos: [],
+      };
+
+      const result = transformAlbumFragment(
+        emptyAlbumData as unknown as FragmentType<typeof AlbumFragment>,
+      );
+
+      expect(result.photos).toEqual([]);
     });
   });
 });

--- a/packages/core/src/look/query-hooks/transformers.test.ts
+++ b/packages/core/src/look/query-hooks/transformers.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import type { FragmentType } from '../../graphql';
+import { AppError } from '../../universal/error-boundary/app-error';
+import type { AlbumFragment, PhotoFragment } from './fragments';
+import { transformAlbumFragment, transformPhotoFragment } from './transformers';
+
+describe('Look fragment transformations', () => {
+  describe('transformPhotoFragment', () => {
+    const mockPhotoData = {
+      id: 'photo-123',
+      source: 'https://example.com/photo.jpg',
+      mediumUrl: 'https://example.com/photo-medium.jpg',
+      thumbnailUrl: 'https://example.com/photo-thumb.jpg',
+      blurHash: 'LEHV6nWB2yk8pyo',
+      width: 1920,
+      height: 1080,
+      takenAt: '2023-01-01T00:00:00Z',
+      slug: 'test-photo',
+      createdAt: '2023-01-02T00:00:00Z',
+      user_id: 'user-123',
+    };
+
+    it('should transform photo fragment correctly', () => {
+      const result = transformPhotoFragment(
+        mockPhotoData as FragmentType<typeof PhotoFragment>,
+      );
+
+      expect(result).toEqual({
+        id: 'photo-123',
+        source: 'https://example.com/photo.jpg',
+        mediumUrl: 'https://example.com/photo-medium.jpg',
+        thumbnailUrl: 'https://example.com/photo-thumb.jpg',
+        blurHash: 'LEHV6nWB2yk8pyo',
+        width: 1920,
+        height: 1080,
+        takenAt: '2023-01-01T00:00:00Z',
+        slug: 'test-photo',
+      });
+    });
+
+    it('should throw AppError when thumbnailUrl is missing', () => {
+      const invalidPhotoData = {
+        ...mockPhotoData,
+        thumbnailUrl: null,
+      } as unknown as FragmentType<typeof PhotoFragment>;
+
+      expect(() => transformPhotoFragment(invalidPhotoData)).toThrow(AppError);
+    });
+  });
+
+  describe('transformAlbumFragment', () => {
+    const mockAlbumData = {
+      id: 'album-456',
+      title: 'Test Album',
+      thumbnailUrl: 'https://example.com/album-thumb.jpg',
+      slug: 'test-album',
+      createdAt: '2023-01-01T00:00:00Z',
+      description: 'Test Album Description',
+      playlist_photos: [
+        {
+          position: 0,
+          photo: {
+            id: 'photo-123',
+            source: 'https://example.com/photo.jpg',
+            mediumUrl: 'https://example.com/photo-medium.jpg',
+            thumbnailUrl: 'https://example.com/photo-thumb.jpg',
+            blurHash: 'LEHV6nWB2yk8pyo',
+            width: 1920,
+            height: 1080,
+            takenAt: '2023-01-01T00:00:00Z',
+            slug: 'test-photo',
+            createdAt: '2023-01-02T00:00:00Z',
+            user_id: 'user-123',
+          },
+        },
+      ],
+    };
+
+    it('should transform album fragment correctly', () => {
+      const result = transformAlbumFragment(
+        mockAlbumData as unknown as FragmentType<typeof AlbumFragment>,
+      );
+
+      expect(result).toEqual({
+        id: 'album-456',
+        title: 'Test Album',
+        thumbnailUrl: 'https://example.com/album-thumb.jpg',
+        slug: 'test-album',
+        createdAt: '2023-01-01T00:00:00Z',
+        description: 'Test Album Description',
+        photos: [
+          {
+            id: 'photo-123',
+            source: 'https://example.com/photo.jpg',
+            mediumUrl: 'https://example.com/photo-medium.jpg',
+            thumbnailUrl: 'https://example.com/photo-thumb.jpg',
+            blurHash: 'LEHV6nWB2yk8pyo',
+            width: 1920,
+            height: 1080,
+            takenAt: '2023-01-01T00:00:00Z',
+            slug: 'test-photo',
+          },
+        ],
+      });
+    });
+  });
+});

--- a/packages/core/src/look/query-hooks/transformers.ts
+++ b/packages/core/src/look/query-hooks/transformers.ts
@@ -1,0 +1,51 @@
+import { type FragmentType, getFragmentData } from '../../graphql';
+import { AppError } from '../../universal/error-boundary/app-error';
+import { AlbumFragment, PhotoFragment } from './fragments';
+
+const transformPhotoFragment = (
+  photoData: FragmentType<typeof PhotoFragment>,
+) => {
+  const photo = getFragmentData(PhotoFragment, photoData);
+  if (!photo.thumbnailUrl) {
+    // TODO
+    // Use error code instead of hard code strings
+    throw new AppError(
+      'Required photo fields are missing',
+      'Photo data is missing',
+      false,
+    );
+  }
+
+  return {
+    id: photo.id,
+    source: photo.source,
+    mediumUrl: photo.mediumUrl || '',
+    thumbnailUrl: photo.thumbnailUrl,
+    blurHash: photo.blurHash || '',
+    width: photo.width ?? null,
+    height: photo.height ?? null,
+    takenAt: photo.takenAt ?? null,
+    slug: photo.slug ?? null,
+  };
+};
+
+const transformAlbumFragment = (
+  albumData: FragmentType<typeof AlbumFragment>,
+) => {
+  const album = getFragmentData(AlbumFragment, albumData);
+  const photos = album.playlist_photos.map((playlistPhoto) =>
+    transformPhotoFragment(playlistPhoto.photo),
+  );
+
+  return {
+    id: album.id,
+    title: album.title,
+    thumbnailUrl: album.thumbnailUrl || '',
+    slug: album.slug,
+    createdAt: album.createdAt,
+    description: album.description || '',
+    photos,
+  };
+};
+
+export { transformAlbumFragment, transformPhotoFragment };

--- a/packages/core/src/look/query-hooks/types.ts
+++ b/packages/core/src/look/query-hooks/types.ts
@@ -1,0 +1,22 @@
+import type {
+  transformAlbumFragment,
+  transformPhotoFragment,
+} from './transformers';
+
+type TransformedPhoto = ReturnType<typeof transformPhotoFragment>;
+type TransformedAlbum = ReturnType<typeof transformAlbumFragment>;
+
+interface BaseQueryProps {
+  getAccessToken: () => Promise<string>;
+}
+
+interface DetailQueryProps extends BaseQueryProps {
+  id: string;
+}
+
+export type {
+  BaseQueryProps,
+  DetailQueryProps,
+  TransformedAlbum,
+  TransformedPhoto,
+};


### PR DESCRIPTION
## Summary

Adds the `packages/core` read layer for the Look app (SWO-611, part of SWO-607) — the data hooks the timeline, lightbox, and album UI will consume. Mirrors the `watch`/`listen` query-hook patterns exactly (generic `useRequest`, `graphql()` fragments, per-query transformer, `@cached`).

- **Fragments** — `PhotoFields` on `photos`, `AlbumFields` on `playlist` (with nested `playlist_photos → photo`).
- **Transformers** — `transformPhotoFragment` (throws `AppError` if `thumbnailUrl` missing, mirroring watch's `source` guard), `transformAlbumFragment`.
- **Hooks** — `useLoadPhotos` (flat, newest-first by `takenAt`; UI groups by month client-side), `useLoadPhotoDetail`, `useLoadAlbums` (`playlist` where `site = "look"`), `useLoadAlbumDetail`.
- Surfaced via `lookQueryHooks` from the core barrel, matching `watch`/`listen`.
- Regenerated `graphql.ts`/`gql.ts`/`schema.graphql` — churn is entirely the new `photos`/`playlist_photos` table family (zero types removed; verified).

## Test plan

- [x] `pnpm codegen` against **local** Hasura (which has the SWO-609 schema) — adds the 4 operations + 2 fragments cleanly
- [x] `pnpm --filter core typecheck` passes
- [x] `pnpm --filter core test` — 442 tests pass (incl. new look transformer tests)
- [x] Biome clean

Refs SWO-611.

🤖 Generated with [Claude Code](https://claude.com/claude-code)