### PR TITLE
[WIP] feat(look): virtualized month timeline grid with blur-hash images

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -67,6 +67,8 @@
     "@mui/icons-material": "^9.1.1",
     "@mui/material": "^9.1.2",
     "@tanstack/react-router": "^1.170.16",
+    "@tanstack/react-virtual": "3.14.6",
+    "blurhash": "2.0.5",
     "core": "workspace:*",
     "echarts": "^6.1.0",
     "echarts-for-react": "^3.0.2",

--- a/packages/ui/src/look/home-page/columns.ts
+++ b/packages/ui/src/look/home-page/columns.ts
@@ -1,0 +1,11 @@
+// How many photo tiles fit one timeline row at each breakpoint. Denser than
+// the watch grid — photos read well small and the point is to see many at once.
+const COLUMNS_BY_BREAKPOINT = {
+  xs: 2,
+  sm: 3,
+  md: 4,
+  lg: 5,
+  xl: 6,
+} as const;
+
+export { COLUMNS_BY_BREAKPOINT };

--- a/packages/ui/src/look/home-page/container/index.stories.tsx
+++ b/packages/ui/src/look/home-page/container/index.stories.tsx
@@ -1,0 +1,75 @@
+import Stack from '@mui/material/Stack';
+import type { Meta, StoryObj } from '@storybook/tanstack-react';
+import type { TransformedPhoto } from 'core/look/query-hooks/types';
+import type { LinkComponentType } from '../../photos/types';
+import { PhotoTimelineContainer } from '.';
+
+const MockLink: LinkComponentType = ({ to, children, style }) => (
+  <a href={to} style={style}>
+    {children}
+  </a>
+);
+
+// Spread a large set across several months so the virtualized, month-grouped
+// layout is visible — only the on-screen rows should be in the DOM.
+const MONTHS = [
+  '2023-06',
+  '2023-05',
+  '2023-04',
+  '2023-03',
+  '2023-02',
+  '2023-01',
+];
+
+const makePhotos = (count: number): TransformedPhoto[] =>
+  Array.from({ length: count }, (_, index) => {
+    const month = MONTHS[index % MONTHS.length];
+    const day = String((index % 27) + 1).padStart(2, '0');
+    return {
+      id: `photo-${index}`,
+      source: `https://picsum.photos/seed/look-${index}/1200/1200`,
+      mediumUrl: `https://picsum.photos/seed/look-${index}/1200/1200`,
+      thumbnailUrl: `https://picsum.photos/seed/look-${index}/400/400`,
+      blurHash: 'LEHV6nWB2yk8pyo0adR*.7kCMdnj',
+      width: 1200,
+      height: 1200,
+      takenAt: `${month}-${day}T10:00:00Z`,
+      slug: `photo-${index}`,
+    };
+  });
+
+const meta: Meta<typeof PhotoTimelineContainer> = {
+  title: 'Look/PhotoTimelineContainer',
+  component: PhotoTimelineContainer,
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    (Story) => (
+      <Stack sx={{ height: '100vh' }}>
+        <Story />
+      </Stack>
+    ),
+  ],
+  args: { LinkComponent: MockLink },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof PhotoTimelineContainer>;
+
+export const Populated: Story = {
+  args: {
+    queryRs: { photos: makePhotos(240), isLoading: false, error: null },
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    queryRs: { photos: [], isLoading: true, error: null },
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    queryRs: { photos: [], isLoading: false, error: null },
+  },
+};

--- a/packages/ui/src/look/home-page/container/index.tsx
+++ b/packages/ui/src/look/home-page/container/index.tsx
@@ -63,6 +63,10 @@ const PhotoTimelineContainer = (props: PhotoTimelineContainerProps) => {
     getScrollElement: () => scrollRef.current,
     estimateSize: (index) =>
       rows[index].type === 'header' ? HEADER_ROW_ESTIMATE : PHOTO_ROW_ESTIMATE,
+    // Key measurements by the stable row key, not the default index — so a
+    // header's cached height isn't misapplied to a photo row when the column
+    // count changes and the rows re-chunk.
+    getItemKey: (index) => rows[index].key,
     overscan: OVERSCAN,
   });
 
@@ -107,7 +111,7 @@ const PhotoTimelineContainer = (props: PhotoTimelineContainerProps) => {
           const row = rows[virtualRow.index];
           return (
             <Stack
-              key={row.key}
+              key={virtualRow.key}
               data-index={virtualRow.index}
               ref={virtualizer.measureElement}
               sx={{

--- a/packages/ui/src/look/home-page/container/index.tsx
+++ b/packages/ui/src/look/home-page/container/index.tsx
@@ -1,0 +1,150 @@
+import Container from '@mui/material/Container';
+import Grid from '@mui/material/Grid';
+import Stack from '@mui/material/Stack';
+import { useTheme } from '@mui/material/styles';
+import Typography from '@mui/material/Typography';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import type { useLoadPhotos } from 'core/look/query-hooks/photos';
+import { useMemo, useRef } from 'react';
+import { PhotoCard } from '../../photos/photo-card';
+import { PhotoSkeleton } from '../../photos/photo-card/skeleton';
+import type { LinkComponentType } from '../../photos/types';
+import { LookEmptyState } from '../empty-state';
+import {
+  buildTimelineRows,
+  genPhotoLinkProps,
+  groupPhotosByMonth,
+  resolveColumns,
+} from '../utils';
+
+// Row-height estimates (px) the virtualizer starts from before it measures the
+// real DOM heights — a virtualizer API contract, not a styling value.
+const HEADER_ROW_ESTIMATE = 64;
+const PHOTO_ROW_ESTIMATE = 220;
+const OVERSCAN = 6;
+const SKELETON_KEYS = Array.from(
+  { length: 18 },
+  (_, index) => `skeleton-${index}`,
+);
+const SCROLL_SX = {
+  flex: 1,
+  height: 0,
+  py: 3,
+  px: { xs: 2, sm: 3 },
+  overflow: 'auto',
+} as const;
+
+interface PhotoTimelineContainerProps {
+  queryRs: ReturnType<typeof useLoadPhotos>;
+  LinkComponent: LinkComponentType;
+}
+
+const PhotoTimelineContainer = (props: PhotoTimelineContainerProps) => {
+  const { queryRs, LinkComponent } = props;
+  const { photos, isLoading } = queryRs;
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const theme = useTheme();
+
+  const columns = resolveColumns({
+    isSm: useMediaQuery(theme.breakpoints.up('sm')),
+    isMd: useMediaQuery(theme.breakpoints.up('md')),
+    isLg: useMediaQuery(theme.breakpoints.up('lg')),
+    isXl: useMediaQuery(theme.breakpoints.up('xl')),
+  });
+
+  const rows = useMemo(
+    () => buildTimelineRows(groupPhotosByMonth(photos), columns),
+    [photos, columns],
+  );
+
+  const virtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: (index) =>
+      rows[index].type === 'header' ? HEADER_ROW_ESTIMATE : PHOTO_ROW_ESTIMATE,
+    overscan: OVERSCAN,
+  });
+
+  if (isLoading) {
+    return (
+      <Container maxWidth={false} disableGutters sx={SCROLL_SX}>
+        <Grid container spacing={1} columns={columns}>
+          {SKELETON_KEYS.map((key) => (
+            <Grid size={1} key={key}>
+              <PhotoSkeleton />
+            </Grid>
+          ))}
+        </Grid>
+      </Container>
+    );
+  }
+
+  if (photos.length === 0) {
+    return (
+      <Container maxWidth={false} disableGutters sx={SCROLL_SX}>
+        <LookEmptyState />
+      </Container>
+    );
+  }
+
+  return (
+    <Container
+      ref={scrollRef}
+      maxWidth={false}
+      disableGutters
+      data-scroll-restoration-id="look-home"
+      sx={SCROLL_SX}
+    >
+      <Stack
+        sx={{
+          position: 'relative',
+          width: '100%',
+          height: `${virtualizer.getTotalSize()}px`,
+        }}
+      >
+        {virtualizer.getVirtualItems().map((virtualRow) => {
+          const row = rows[virtualRow.index];
+          return (
+            <Stack
+              key={row.key}
+              data-index={virtualRow.index}
+              ref={virtualizer.measureElement}
+              sx={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                transform: `translateY(${virtualRow.start}px)`,
+              }}
+            >
+              {row.type === 'header' ? (
+                <Typography
+                  variant="h6"
+                  component="h2"
+                  sx={{ pt: 3, pb: 1, color: 'text.primary' }}
+                >
+                  {row.label}
+                </Typography>
+              ) : (
+                <Grid container spacing={1} columns={columns} sx={{ pb: 1 }}>
+                  {row.photos.map((photo) => (
+                    <Grid size={1} key={photo.id}>
+                      <PhotoCard
+                        photo={photo}
+                        LinkComponent={LinkComponent}
+                        linkProps={genPhotoLinkProps(photo)}
+                      />
+                    </Grid>
+                  ))}
+                </Grid>
+              )}
+            </Stack>
+          );
+        })}
+      </Stack>
+    </Container>
+  );
+};
+
+export { PhotoTimelineContainer };

--- a/packages/ui/src/look/home-page/empty-state/index.tsx
+++ b/packages/ui/src/look/home-page/empty-state/index.tsx
@@ -1,0 +1,15 @@
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+
+const LookEmptyState = () => (
+  <Stack sx={{ alignItems: 'center', justifyContent: 'center', gap: 1, py: 8 }}>
+    <Typography variant="h6" component="p" sx={{ color: 'text.primary' }}>
+      No photos yet
+    </Typography>
+    <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+      Photos you add will appear here, grouped by month.
+    </Typography>
+  </Stack>
+);
+
+export { LookEmptyState };

--- a/packages/ui/src/look/home-page/utils.test.ts
+++ b/packages/ui/src/look/home-page/utils.test.ts
@@ -1,0 +1,150 @@
+import type { TransformedPhoto } from 'core/look/query-hooks/types';
+import { describe, expect, it } from 'vitest';
+import {
+  buildTimelineRows,
+  genPhotoLinkProps,
+  groupPhotosByMonth,
+  resolveColumns,
+} from './utils';
+
+const makePhoto = (
+  id: string,
+  takenAt: string | null,
+  overrides: Partial<TransformedPhoto> = {},
+): TransformedPhoto => ({
+  id,
+  source: `https://example.com/${id}.jpg`,
+  mediumUrl: `https://example.com/${id}-medium.jpg`,
+  thumbnailUrl: `https://example.com/${id}-thumb.jpg`,
+  blurHash: 'LEHV6nWB2yk8pyo0adR*.7kCMdnj',
+  width: 1920,
+  height: 1080,
+  takenAt,
+  slug: `slug-${id}`,
+  ...overrides,
+});
+
+describe('groupPhotosByMonth', () => {
+  it('groups photos by calendar month, newest month first', () => {
+    const photos = [
+      makePhoto('a', '2023-03-15T10:00:00Z'),
+      makePhoto('b', '2023-03-02T09:00:00Z'),
+      makePhoto('c', '2023-01-20T08:00:00Z'),
+    ];
+
+    const groups = groupPhotosByMonth(photos);
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0].key).toBe('2023-03');
+    expect(groups[0].label).toBe('March 2023');
+    expect(groups[0].photos).toHaveLength(2);
+    expect(groups[0].photos.map((photo) => photo.id)).toEqual(['a', 'b']);
+    expect(groups[1].key).toBe('2023-01');
+    expect(groups[1].label).toBe('January 2023');
+    expect(groups[1].photos.map((photo) => photo.id)).toEqual(['c']);
+  });
+
+  it('places undated photos in an "Undated" group at the very end', () => {
+    const photos = [
+      makePhoto('a', null),
+      makePhoto('b', '2023-05-01T00:00:00Z'),
+      makePhoto('c', null),
+    ];
+
+    const groups = groupPhotosByMonth(photos);
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0].key).toBe('2023-05');
+    expect(groups[1].key).toBe('undated');
+    expect(groups[1].label).toBe('Undated');
+    expect(groups[1].photos.map((photo) => photo.id)).toEqual(['a', 'c']);
+  });
+
+  it('returns an empty array for no photos', () => {
+    expect(groupPhotosByMonth([])).toEqual([]);
+  });
+});
+
+describe('buildTimelineRows', () => {
+  it('emits one header per month then photos chunked into rows of `columns`', () => {
+    const groups = groupPhotosByMonth([
+      makePhoto('a', '2023-03-15T10:00:00Z'),
+      makePhoto('b', '2023-03-14T10:00:00Z'),
+      makePhoto('c', '2023-03-13T10:00:00Z'),
+      makePhoto('d', '2023-01-20T08:00:00Z'),
+    ]);
+
+    const rows = buildTimelineRows(groups, 2);
+
+    expect(rows).toHaveLength(5);
+    expect(rows[0]).toEqual({
+      type: 'header',
+      key: 'header-2023-03',
+      label: 'March 2023',
+    });
+    expect(rows[1]).toEqual({
+      type: 'photos',
+      key: 'row-2023-03-0',
+      photos: [groups[0].photos[0], groups[0].photos[1]],
+    });
+    expect(rows[2]).toEqual({
+      type: 'photos',
+      key: 'row-2023-03-1',
+      photos: [groups[0].photos[2]],
+    });
+    expect(rows[3]).toEqual({
+      type: 'header',
+      key: 'header-2023-01',
+      label: 'January 2023',
+    });
+    expect(rows[4]).toEqual({
+      type: 'photos',
+      key: 'row-2023-01-0',
+      photos: [groups[1].photos[0]],
+    });
+  });
+
+  it('returns an empty array for no groups', () => {
+    expect(buildTimelineRows([], 4)).toEqual([]);
+  });
+});
+
+describe('resolveColumns', () => {
+  it('picks the largest matching breakpoint', () => {
+    expect(
+      resolveColumns({ isSm: true, isMd: true, isLg: true, isXl: true }),
+    ).toBe(6);
+    expect(
+      resolveColumns({ isSm: true, isMd: true, isLg: true, isXl: false }),
+    ).toBe(5);
+    expect(
+      resolveColumns({ isSm: true, isMd: true, isLg: false, isXl: false }),
+    ).toBe(4);
+    expect(
+      resolveColumns({ isSm: true, isMd: false, isLg: false, isXl: false }),
+    ).toBe(3);
+    expect(
+      resolveColumns({ isSm: false, isMd: false, isLg: false, isXl: false }),
+    ).toBe(2);
+  });
+});
+
+describe('genPhotoLinkProps', () => {
+  it('uses the slug as the route param when present', () => {
+    const result = genPhotoLinkProps(makePhoto('a', null, { slug: 'sunset' }));
+    expect(result).toEqual({
+      to: '/photo/$photoId',
+      params: { photoId: 'sunset' },
+    });
+  });
+
+  it('falls back to the id when the slug is null', () => {
+    const result = genPhotoLinkProps(
+      makePhoto('photo-1', null, { slug: null }),
+    );
+    expect(result).toEqual({
+      to: '/photo/$photoId',
+      params: { photoId: 'photo-1' },
+    });
+  });
+});

--- a/packages/ui/src/look/home-page/utils.test.ts
+++ b/packages/ui/src/look/home-page/utils.test.ts
@@ -60,6 +60,22 @@ describe('groupPhotosByMonth', () => {
     expect(groups[1].photos.map((photo) => photo.id)).toEqual(['a', 'c']);
   });
 
+  it('orders months newest-first even when the input is not sorted', () => {
+    const photos = [
+      makePhoto('a', '2023-01-20T08:00:00Z'),
+      makePhoto('b', '2023-03-15T10:00:00Z'),
+      makePhoto('c', '2022-12-01T00:00:00Z'),
+    ];
+
+    const groups = groupPhotosByMonth(photos);
+
+    expect(groups.map((group) => group.key)).toEqual([
+      '2023-03',
+      '2023-01',
+      '2022-12',
+    ]);
+  });
+
   it('returns an empty array for no photos', () => {
     expect(groupPhotosByMonth([])).toEqual([]);
   });

--- a/packages/ui/src/look/home-page/utils.ts
+++ b/packages/ui/src/look/home-page/utils.ts
@@ -1,0 +1,138 @@
+import type { TransformedPhoto } from 'core/look/query-hooks/types';
+import { COLUMNS_BY_BREAKPOINT } from './columns';
+
+interface MonthGroup {
+  key: string;
+  label: string;
+  photos: TransformedPhoto[];
+}
+
+type TimelineRow =
+  | { type: 'header'; key: string; label: string }
+  | { type: 'photos'; key: string; photos: TransformedPhoto[] };
+
+interface ColumnBreakpointFlags {
+  isSm: boolean;
+  isMd: boolean;
+  isLg: boolean;
+  isXl: boolean;
+}
+
+const MONTH_NAMES = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];
+const UNDATED_KEY = 'undated';
+const UNDATED_LABEL = 'Undated';
+const PHOTO_ROUTE = '/photo/$photoId';
+
+// Group by the stored timestamp's calendar month via a string slice
+// ('2023-01-01T…' -> '2023-01'). String-based, not Date-based, so grouping is
+// deterministic and free of local-timezone/DST conversion bugs. Assumes takenAt
+// is UTC-normalized (the Hasura timestamptz default), so the slice is the UTC month.
+const monthKeyOf = (takenAt: string | null): string => {
+  if (!takenAt) {
+    return UNDATED_KEY;
+  }
+  return takenAt.slice(0, 7);
+};
+
+const labelOf = (key: string): string => {
+  if (key === UNDATED_KEY) {
+    return UNDATED_LABEL;
+  }
+  const [year, month] = key.split('-');
+  return `${MONTH_NAMES[Number(month) - 1]} ${year}`;
+};
+
+const chunk = <T>(items: T[], size: number): T[][] => {
+  const step = Math.max(1, size);
+  const rows: T[][] = [];
+  for (let index = 0; index < items.length; index += step) {
+    rows.push(items.slice(index, index + step));
+  }
+  return rows;
+};
+
+// Bucket a flat, newest-first photo list into month groups. Insertion order
+// preserves the incoming order (newest month first); undated photos always sort
+// to the very end regardless of where they appeared in the input.
+const groupPhotosByMonth = (photos: TransformedPhoto[]): MonthGroup[] => {
+  const groups = new Map<string, MonthGroup>();
+
+  for (const photo of photos) {
+    const key = monthKeyOf(photo.takenAt);
+    const existing = groups.get(key);
+    if (existing) {
+      existing.photos.push(photo);
+      continue;
+    }
+    groups.set(key, { key, label: labelOf(key), photos: [photo] });
+  }
+
+  const ordered = Array.from(groups.values());
+  const dated = ordered.filter((group) => group.key !== UNDATED_KEY);
+  const undated = ordered.filter((group) => group.key === UNDATED_KEY);
+  return [...dated, ...undated];
+};
+
+// Flatten month groups into the virtualizer's row model: one header row per
+// month, then its photos chunked into rows of `columns`.
+const buildTimelineRows = (
+  groups: MonthGroup[],
+  columns: number,
+): TimelineRow[] => {
+  const rows: TimelineRow[] = [];
+
+  for (const group of groups) {
+    rows.push({
+      type: 'header',
+      key: `header-${group.key}`,
+      label: group.label,
+    });
+    chunk(group.photos, columns).forEach((photos, index) => {
+      rows.push({ type: 'photos', key: `row-${group.key}-${index}`, photos });
+    });
+  }
+
+  return rows;
+};
+
+const resolveColumns = (flags: ColumnBreakpointFlags): number => {
+  if (flags.isXl) {
+    return COLUMNS_BY_BREAKPOINT.xl;
+  }
+  if (flags.isLg) {
+    return COLUMNS_BY_BREAKPOINT.lg;
+  }
+  if (flags.isMd) {
+    return COLUMNS_BY_BREAKPOINT.md;
+  }
+  if (flags.isSm) {
+    return COLUMNS_BY_BREAKPOINT.sm;
+  }
+  return COLUMNS_BY_BREAKPOINT.xs;
+};
+
+const genPhotoLinkProps = (photo: TransformedPhoto) => ({
+  to: PHOTO_ROUTE,
+  params: { photoId: photo.slug ?? photo.id },
+});
+
+export {
+  buildTimelineRows,
+  genPhotoLinkProps,
+  groupPhotosByMonth,
+  resolveColumns,
+};
+export type { ColumnBreakpointFlags, MonthGroup, TimelineRow };

--- a/packages/ui/src/look/home-page/utils.ts
+++ b/packages/ui/src/look/home-page/utils.ts
@@ -64,9 +64,10 @@ const chunk = <T>(items: T[], size: number): T[][] => {
   return rows;
 };
 
-// Bucket a flat, newest-first photo list into month groups. Insertion order
-// preserves the incoming order (newest month first); undated photos always sort
-// to the very end regardless of where they appeared in the input.
+// Bucket photos into month groups, newest month first. Dated groups are sorted
+// by month key descending so the order holds regardless of input order (the
+// 'YYYY-MM' key sorts lexicographically = chronologically); undated photos
+// always come last. Photos keep their incoming order within each month.
 const groupPhotosByMonth = (photos: TransformedPhoto[]): MonthGroup[] => {
   const groups = new Map<string, MonthGroup>();
 
@@ -81,7 +82,9 @@ const groupPhotosByMonth = (photos: TransformedPhoto[]): MonthGroup[] => {
   }
 
   const ordered = Array.from(groups.values());
-  const dated = ordered.filter((group) => group.key !== UNDATED_KEY);
+  const dated = ordered
+    .filter((group) => group.key !== UNDATED_KEY)
+    .sort((a, b) => b.key.localeCompare(a.key));
   const undated = ordered.filter((group) => group.key === UNDATED_KEY);
   return [...dated, ...undated];
 };

--- a/packages/ui/src/look/photos/blur-image/blurhash.ts
+++ b/packages/ui/src/look/photos/blur-image/blurhash.ts
@@ -13,6 +13,10 @@ const blurHashToDataUri = (hash: string): string | undefined => {
     return undefined;
   }
 
+  if (typeof document === 'undefined') {
+    return undefined;
+  }
+
   const canvas = document.createElement('canvas');
   canvas.width = BLURHASH_SIZE;
   canvas.height = BLURHASH_SIZE;

--- a/packages/ui/src/look/photos/blur-image/blurhash.ts
+++ b/packages/ui/src/look/photos/blur-image/blurhash.ts
@@ -1,0 +1,36 @@
+import { decode } from 'blurhash';
+
+// A blur-hash decodes to a tiny pixel grid; 32x32 is enough for a soft
+// placeholder that scales up (via background-size: cover) without visible
+// blocks. Kept small so decoding the visible window stays cheap.
+const BLURHASH_SIZE = 32;
+
+// Turn a blur-hash string into a data URI usable as a CSS background-image.
+// Returns undefined when the hash is empty, invalid, or the canvas is
+// unavailable (e.g. a non-DOM environment) — callers fall back to a solid tint.
+const blurHashToDataUri = (hash: string): string | undefined => {
+  if (!hash) {
+    return undefined;
+  }
+
+  const canvas = document.createElement('canvas');
+  canvas.width = BLURHASH_SIZE;
+  canvas.height = BLURHASH_SIZE;
+
+  const context = canvas.getContext('2d');
+  if (!context) {
+    return undefined;
+  }
+
+  try {
+    const pixels = decode(hash, BLURHASH_SIZE, BLURHASH_SIZE);
+    const imageData = context.createImageData(BLURHASH_SIZE, BLURHASH_SIZE);
+    imageData.data.set(pixels);
+    context.putImageData(imageData, 0, 0);
+    return canvas.toDataURL();
+  } catch {
+    return undefined;
+  }
+};
+
+export { blurHashToDataUri };

--- a/packages/ui/src/look/photos/blur-image/index.stories.tsx
+++ b/packages/ui/src/look/photos/blur-image/index.stories.tsx
@@ -1,0 +1,50 @@
+import Card from '@mui/material/Card';
+import type { Meta, StoryObj } from '@storybook/tanstack-react';
+import { BlurImage } from '.';
+
+const meta: Meta<typeof BlurImage> = {
+  title: 'Look/BlurImage',
+  component: BlurImage,
+  parameters: { layout: 'centered' },
+  decorators: [
+    (Story) => (
+      <Card
+        sx={{
+          position: 'relative',
+          width: 300,
+          aspectRatio: '1 / 1',
+          overflow: 'hidden',
+        }}
+      >
+        <Story />
+      </Card>
+    ),
+  ],
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof BlurImage>;
+
+export const WithThumbnail: Story = {
+  args: {
+    src: 'https://picsum.photos/seed/look-blur/600/600',
+    alt: 'Sample photo',
+    blurHash: 'LEHV6nWB2yk8pyo0adR*.7kCMdnj',
+  },
+};
+
+export const PlaceholderOnly: Story = {
+  args: {
+    src: 'https://picsum.photos/seed/look-blur-slow/600/600?delay=3',
+    alt: 'Loading photo',
+    blurHash: 'LKN]Rv%2Tw=w]~RBVZRi};RPxuwH',
+  },
+};
+
+export const NoBlurHash: Story = {
+  args: {
+    src: 'https://picsum.photos/seed/look-no-hash/600/600',
+    alt: 'Photo without a blur hash',
+  },
+};

--- a/packages/ui/src/look/photos/blur-image/index.tsx
+++ b/packages/ui/src/look/photos/blur-image/index.tsx
@@ -1,0 +1,59 @@
+import Stack from '@mui/material/Stack';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { blurHashToDataUri } from './blurhash';
+import { FadeInImage } from './styled';
+
+interface BlurImageProps {
+  src: string;
+  alt: string;
+  blurHash?: string;
+}
+
+// A lazy image that shows its blur-hash placeholder first and fades to the
+// real thumbnail once it loads. Fills its positioned parent (the photo card),
+// which reserves the space — so there is no layout shift on load.
+const BlurImage = (props: BlurImageProps) => {
+  const { src, alt, blurHash } = props;
+  const imgRef = useRef<HTMLImageElement>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  const placeholder = useMemo(
+    () => (blurHash ? blurHashToDataUri(blurHash) : undefined),
+    [blurHash],
+  );
+
+  // A cached thumbnail can finish loading before React attaches `onLoad`, so
+  // the event never fires and the image would stay pinned at opacity 0 behind
+  // the placeholder. Catch that on mount. `naturalWidth > 0` excludes a cached
+  // error (complete is true for those too) so a broken image stays hidden.
+  useEffect(() => {
+    const img = imgRef.current;
+    if (img?.complete && img.naturalWidth > 0) {
+      setLoaded(true);
+    }
+  }, []);
+
+  return (
+    <Stack
+      sx={{
+        position: 'absolute',
+        inset: 0,
+        bgcolor: 'action.hover',
+        backgroundImage: placeholder ? `url(${placeholder})` : undefined,
+        backgroundSize: 'cover',
+        backgroundPosition: 'center',
+      }}
+    >
+      <FadeInImage
+        ref={imgRef}
+        src={src}
+        alt={alt}
+        loading="lazy"
+        loaded={loaded}
+        onLoad={() => setLoaded(true)}
+      />
+    </Stack>
+  );
+};
+
+export { BlurImage };

--- a/packages/ui/src/look/photos/blur-image/styled.tsx
+++ b/packages/ui/src/look/photos/blur-image/styled.tsx
@@ -1,0 +1,26 @@
+import { styled } from '@mui/material/styles';
+import type { ComponentType, ImgHTMLAttributes, Ref } from 'react';
+
+interface FadeInImageProps extends ImgHTMLAttributes<HTMLImageElement> {
+  loaded: boolean;
+  ref?: Ref<HTMLImageElement>;
+}
+
+// The thumbnail fades in over its blur-hash placeholder once decoded by the
+// browser. `loaded` is a transient prop, so it must not reach the DOM <img>.
+// The explicit ComponentType annotation keeps the emitted type portable
+// (avoids a non-portable @mui/system reference in the .d.ts).
+const FadeInImage = styled('img', {
+  shouldForwardProp: (prop) => prop !== 'loaded',
+})<{ loaded: boolean }>(({ loaded }) => ({
+  position: 'absolute',
+  inset: 0,
+  width: '100%',
+  height: '100%',
+  objectFit: 'cover',
+  display: 'block',
+  opacity: loaded ? 1 : 0,
+  transition: 'opacity 0.4s ease-in',
+})) as ComponentType<FadeInImageProps>;
+
+export { FadeInImage };

--- a/packages/ui/src/look/photos/photo-card/index.stories.tsx
+++ b/packages/ui/src/look/photos/photo-card/index.stories.tsx
@@ -1,0 +1,53 @@
+import Stack from '@mui/material/Stack';
+import type { Meta, StoryObj } from '@storybook/tanstack-react';
+import type { TransformedPhoto } from 'core/look/query-hooks/types';
+import type { LinkComponentType } from '../types';
+import { PhotoCard } from '.';
+
+const MockLink: LinkComponentType = ({ to, children, style }) => (
+  <a href={to} style={style}>
+    {children}
+  </a>
+);
+
+const mockPhoto: TransformedPhoto = {
+  id: 'photo-1',
+  source: 'https://picsum.photos/seed/look-card/1200/1200',
+  mediumUrl: 'https://picsum.photos/seed/look-card/1200/1200',
+  thumbnailUrl: 'https://picsum.photos/seed/look-card/400/400',
+  blurHash: 'LEHV6nWB2yk8pyo0adR*.7kCMdnj',
+  width: 1200,
+  height: 1200,
+  takenAt: '2023-03-15T10:00:00Z',
+  slug: 'a-sample-photo',
+};
+
+const meta: Meta<typeof PhotoCard> = {
+  title: 'Look/PhotoCard',
+  component: PhotoCard,
+  parameters: { layout: 'centered' },
+  decorators: [
+    (Story) => (
+      <Stack sx={{ width: 260 }}>
+        <Story />
+      </Stack>
+    ),
+  ],
+  args: { photo: mockPhoto },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof PhotoCard>;
+
+export const Static: Story = {};
+
+export const AsLink: Story = {
+  args: {
+    LinkComponent: MockLink,
+    linkProps: {
+      to: '/photo/a-sample-photo',
+      params: { photoId: 'a-sample-photo' },
+    },
+  },
+};

--- a/packages/ui/src/look/photos/photo-card/index.tsx
+++ b/packages/ui/src/look/photos/photo-card/index.tsx
@@ -1,0 +1,53 @@
+import Card from '@mui/material/Card';
+import type { TransformedPhoto } from 'core/look/query-hooks/types';
+import { BlurImage } from '../blur-image';
+import type { LinkComponentType, PhotoLinkProps } from '../types';
+
+interface PhotoCardProps {
+  photo: TransformedPhoto;
+  LinkComponent?: LinkComponentType;
+  linkProps?: PhotoLinkProps;
+}
+
+// One square tile in the timeline grid. Fixed aspect ratio + overflow hidden
+// gives the grid uniform, shift-free rows; the image is layered inside.
+const PhotoCard = (props: PhotoCardProps) => {
+  const { photo, LinkComponent, linkProps } = props;
+
+  const card = (
+    <Card
+      sx={{
+        position: 'relative',
+        aspectRatio: '1 / 1',
+        overflow: 'hidden',
+        boxShadow: 'none',
+        borderRadius: 1,
+        bgcolor: 'action.hover',
+        transition: 'transform 0.2s',
+        '&:hover': { transform: 'scale(1.02)' },
+      }}
+    >
+      <BlurImage
+        src={photo.thumbnailUrl}
+        alt={photo.slug ?? 'Photo'}
+        blurHash={photo.blurHash}
+      />
+    </Card>
+  );
+
+  if (!LinkComponent || !linkProps) {
+    return card;
+  }
+
+  return (
+    <LinkComponent
+      to={linkProps.to}
+      params={linkProps.params}
+      style={{ textDecoration: 'none' }}
+    >
+      {card}
+    </LinkComponent>
+  );
+};
+
+export { PhotoCard };

--- a/packages/ui/src/look/photos/photo-card/skeleton.tsx
+++ b/packages/ui/src/look/photos/photo-card/skeleton.tsx
@@ -1,0 +1,15 @@
+import Skeleton from '@mui/material/Skeleton';
+
+const PhotoSkeleton = () => (
+  <Skeleton
+    variant="rectangular"
+    sx={{
+      aspectRatio: '1 / 1',
+      width: '100%',
+      height: 'auto',
+      borderRadius: 1,
+    }}
+  />
+);
+
+export { PhotoSkeleton };

--- a/packages/ui/src/look/photos/types.ts
+++ b/packages/ui/src/look/photos/types.ts
@@ -1,0 +1,17 @@
+interface GenericLinkProps<T = Record<string, unknown>> {
+  to: string;
+  params?: T;
+  children: React.ReactNode;
+  style?: React.CSSProperties;
+}
+
+type LinkComponentType<T = Record<string, unknown>> = React.ComponentType<
+  GenericLinkProps<T>
+>;
+
+interface PhotoLinkProps<T = Record<string, unknown>> {
+  to: string;
+  params?: T;
+}
+
+export type { LinkComponentType, PhotoLinkProps };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -840,6 +840,12 @@ importers:
       '@tanstack/react-router':
         specifier: ^1.170.16
         version: 1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tanstack/react-virtual':
+        specifier: 3.14.6
+        version: 3.14.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      blurhash:
+        specifier: 2.0.5
+        version: 2.0.5
       core:
         specifier: workspace:*
         version: link:../core
@@ -5531,6 +5537,12 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  '@tanstack/react-virtual@3.14.6':
+    resolution: {integrity: sha512-4+Uq8m0/gzO4kMCHUEpTtGX1RnONK0C+g88b2ltwPMWUBiaVarBuWKoPJaz7gj1cKCVRAdyu+U8GcKhwCc2beA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@tanstack/router-core@1.171.13':
     resolution: {integrity: sha512-+NOwEj1kO/6IGmpHRIZHasYxYWpyBQGNIZAST9aNrk9Q3YlU9SgqVnl1pbLa9qAKfeNdXQIRve0RQb/0kyDeDA==}
     engines: {node: '>=20.19'}
@@ -5588,6 +5600,9 @@ packages:
 
   '@tanstack/store@0.9.3':
     resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
+
+  '@tanstack/virtual-core@3.17.4':
+    resolution: {integrity: sha512-nGm5KteqxasUdThLc2izl6dHUqLv0LQj7Nuyo5gYalTPf/U8a9ermvsl7reT+6ioBW1l8WfpP/mcU338nLXpqw==}
 
   '@tanstack/virtual-file-routes@1.162.0':
     resolution: {integrity: sha512-uhOeFyxLcU41HzvrxsGpiWdcMbScY1EDgbZ5K7DVRMYInbLYWAC0EA/kx9wXAoSM8q82bUG2hRl8+EAjE6XAbA==}
@@ -19348,6 +19363,12 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       use-sync-external-store: 1.6.0(react@19.2.7)
 
+  '@tanstack/react-virtual@3.14.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.4
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   '@tanstack/router-core@1.171.13':
     dependencies:
       '@tanstack/history': 1.162.0
@@ -19478,6 +19499,8 @@ snapshots:
       - supports-color
 
   '@tanstack/store@0.9.3': {}
+
+  '@tanstack/virtual-core@3.17.4': {}
 
   '@tanstack/virtual-file-routes@1.162.0': {}
 


### PR DESCRIPTION
## Summary

Adds the Look timeline UI to `packages/ui` (SWO-613, part of SWO-607) — the fast, month-grouped photo wall that stays smooth through thousands of images. All presentational; consumes the already-merged `useLoadPhotos` shape via a container that takes `queryRs` + `LinkComponent` (the watch container pattern).

- **`look/photos/blur-image/`** — `BlurImage`: a lazy `<img loading="lazy">` that fades in over a blur-hash placeholder once decoded, filling its positioned parent so there's **no layout shift** on load. `blurhash.ts` decodes the hash to a 32×32 canvas data-URI (falls back to a solid tint on empty/invalid hash or no canvas). The fade is a `styled('img')` with a transient `loaded` prop.
- **`look/photos/photo-card/`** — `PhotoCard` (square, `object-fit: cover`, optional link wrapper) + `PhotoSkeleton`.
- **`look/home-page/container/`** — `PhotoTimelineContainer`: **virtualized** month timeline via `@tanstack/react-virtual` (dynamic-measured rows — one header row per month, photos chunked into rows of N). Only on-screen rows are in the DOM. Loading → skeleton grid; empty → `LookEmptyState`.
- **`look/home-page/utils.ts`** — pure, unit-tested logic: `groupPhotosByMonth` (UTC/string-based month keys — deterministic, no timezone/DST bugs; undated photos sort last), `buildTimelineRows` (flatten to the virtualizer row model), `resolveColumns` (breakpoint → column count), `genPhotoLinkProps`.
- Storybook stories for `BlurImage`, `PhotoCard`, and the container (240-photo populated / loading / empty).

### Design decisions

- **Uniform square grid**, not justified/masonry — constant row heights virtualize cleanly and are inherently shift-free. `width`/`height` still drive the blur-hash placeholder aspect and are available for the lightbox (SWO-614).
- **No `packages/ui` barrel exists** — mirrors the repo's per-folder `index.tsx` + subpath-export convention (`ui/look/...`); the ticket's "export from `src/index.tsx`" was stale.

### Dependencies (exact-pinned, cooldown-clear per `supply-chain-security`)

- `@tanstack/react-virtual@3.14.6` (published 2026-07-12, >7 days aged)
- `blurhash@2.0.5` (matches the version already in `apps/backend`)

## Test plan

- [x] `pnpm --filter ui typecheck` passes
- [x] `pnpm --filter ui test` — 596 pass (incl. new `utils.test.ts`: grouping, undated-last, chunking, breakpoint columns, link props — exact assertions)
- [x] `pnpm --filter ui build` (tsup) — emits `dist/look/**`
- [x] `pnpm --filter ui build-storybook` passes
- [x] Biome clean on `src/look`
- [ ] Live wiring into `apps/look` is SWO-616; lightbox is SWO-614

Refs SWO-613.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a responsive photo timeline that groups photos by month and supports loading and empty states.
  * Added photo cards with navigation, hover styling, and square layouts.
  * Added blur-hash image placeholders with smooth image fade-in.
  * Added responsive photo skeletons while content loads.
* **Documentation**
  * Added Storybook examples for photo timelines, photo cards, and blurred image loading.
* **Tests**
  * Added coverage for timeline grouping, responsive layouts, and photo navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->