### PR TITLE
[WIP] feat(look): full-screen photo lightbox with keyboard navigation

### DIFF
--- a/packages/ui/src/look/photo-detail-page/containers/index.stories.tsx
+++ b/packages/ui/src/look/photo-detail-page/containers/index.stories.tsx
@@ -1,0 +1,70 @@
+import Button from '@mui/material/Button';
+import Stack from '@mui/material/Stack';
+import type { Meta, StoryObj } from '@storybook/tanstack-react';
+import type { TransformedPhoto } from 'core/look/query-hooks/types';
+import { useState } from 'react';
+import { PhotoLightbox } from '.';
+
+const makePhotos = (count: number): TransformedPhoto[] =>
+  Array.from({ length: count }, (_, index) => ({
+    id: `photo-${index}`,
+    source: `https://picsum.photos/seed/look-${index}/1600/1200`,
+    mediumUrl: `https://picsum.photos/seed/look-${index}/1200/900`,
+    thumbnailUrl: `https://picsum.photos/seed/look-${index}/400/300`,
+    blurHash: 'LEHV6nWB2yk8pyo0adR*.7kCMdnj',
+    width: 1600,
+    height: 1200,
+    takenAt: '2023-03-15T10:00:00Z',
+    slug: `photo-${index}`,
+  }));
+
+const photos = makePhotos(6);
+
+// A stateful harness so the story exercises open/close and ←/→ navigation.
+const LightboxHarness = () => {
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  return (
+    <Stack sx={{ p: 3, gap: 2 }}>
+      <Button variant="contained" onClick={() => setActiveId(photos[0].id)}>
+        Open lightbox
+      </Button>
+      <PhotoLightbox
+        photos={photos}
+        activeId={activeId ?? photos[0].id}
+        open={activeId !== null}
+        onClose={() => setActiveId(null)}
+        onActiveIdChange={setActiveId}
+      />
+    </Stack>
+  );
+};
+
+const meta: Meta<typeof PhotoLightbox> = {
+  title: 'Look/PhotoLightbox',
+  component: PhotoLightbox,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof PhotoLightbox>;
+
+export const Interactive: Story = {
+  render: () => <LightboxHarness />,
+};
+
+export const OpenOnLast: Story = {
+  render: () => {
+    const [activeId, setActiveId] = useState(photos[photos.length - 1].id);
+    return (
+      <PhotoLightbox
+        photos={photos}
+        activeId={activeId}
+        open
+        onClose={() => undefined}
+        onActiveIdChange={setActiveId}
+      />
+    );
+  },
+};

--- a/packages/ui/src/look/photo-detail-page/containers/index.tsx
+++ b/packages/ui/src/look/photo-detail-page/containers/index.tsx
@@ -1,0 +1,119 @@
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import CloseIcon from '@mui/icons-material/Close';
+import Dialog from '@mui/material/Dialog';
+import IconButton from '@mui/material/IconButton';
+import Stack from '@mui/material/Stack';
+import type { TransformedPhoto } from 'core/look/query-hooks/types';
+import { useEffect, useMemo } from 'react';
+import { LightboxImage } from '../lightbox-image';
+import { stepPhotoId } from '../utils';
+
+interface PhotoLightboxProps {
+  photos: TransformedPhoto[];
+  activeId: string;
+  open: boolean;
+  onClose: () => void;
+  onActiveIdChange: (id: string) => void;
+}
+
+const EDGE_BUTTON_SX = {
+  position: 'absolute',
+  top: '50%',
+  transform: 'translateY(-50%)',
+  zIndex: 1,
+  color: 'text.primary',
+  bgcolor: 'action.hover',
+  '&:hover': { bgcolor: 'action.selected' },
+} as const;
+
+// Full-screen photo viewer. MUI Dialog gives the focus trap, backdrop, and
+// Escape-to-close; a document-level key listener adds ←/→ navigation. Navigation
+// is controlled — the active photo comes from an in-memory list by id, so moving
+// between photos never refetches.
+const PhotoLightbox = (props: PhotoLightboxProps) => {
+  const { photos, activeId, open, onClose, onActiveIdChange } = props;
+
+  const activePhoto = useMemo(
+    () => photos.find((photo) => photo.id === activeId) ?? null,
+    [photos, activeId],
+  );
+  const prevId = useMemo(
+    () => stepPhotoId(photos, activeId, -1),
+    [photos, activeId],
+  );
+  const nextId = useMemo(
+    () => stepPhotoId(photos, activeId, 1),
+    [photos, activeId],
+  );
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'ArrowLeft' && prevId) {
+        event.preventDefault();
+        onActiveIdChange(prevId);
+        return;
+      }
+      if (event.key === 'ArrowRight' && nextId) {
+        event.preventDefault();
+        onActiveIdChange(nextId);
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [open, prevId, nextId, onActiveIdChange]);
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullScreen
+      aria-label="Photo viewer"
+      slotProps={{
+        paper: {
+          sx: { bgcolor: 'background.default', backgroundImage: 'none' },
+        },
+      }}
+    >
+      <Stack sx={{ position: 'relative', width: '100%', height: '100%' }}>
+        <IconButton
+          aria-label="Close"
+          onClick={onClose}
+          sx={{
+            position: 'absolute',
+            top: 1,
+            right: 1,
+            zIndex: 1,
+            color: 'text.primary',
+          }}
+        >
+          <CloseIcon />
+        </IconButton>
+        <IconButton
+          aria-label="Previous photo"
+          onClick={() => prevId && onActiveIdChange(prevId)}
+          disabled={!prevId}
+          sx={{ ...EDGE_BUTTON_SX, left: 1 }}
+        >
+          <ChevronLeftIcon />
+        </IconButton>
+        <IconButton
+          aria-label="Next photo"
+          onClick={() => nextId && onActiveIdChange(nextId)}
+          disabled={!nextId}
+          sx={{ ...EDGE_BUTTON_SX, right: 1 }}
+        >
+          <ChevronRightIcon />
+        </IconButton>
+        {activePhoto ? (
+          <LightboxImage key={activePhoto.id} photo={activePhoto} />
+        ) : null}
+      </Stack>
+    </Dialog>
+  );
+};
+
+export { PhotoLightbox };

--- a/packages/ui/src/look/photo-detail-page/lightbox-image/index.tsx
+++ b/packages/ui/src/look/photo-detail-page/lightbox-image/index.tsx
@@ -1,0 +1,74 @@
+import Stack from '@mui/material/Stack';
+import type { TransformedPhoto } from 'core/look/query-hooks/types';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { blurHashToDataUri } from '../../photos/blur-image/blurhash';
+import { LightboxImageLayer } from './styled';
+
+interface LightboxImageProps {
+  photo: TransformedPhoto;
+}
+
+// Progressive full-screen image: the blur-hash placeholder shows immediately,
+// the medium resolution fades in over it, then the full original fades in on
+// top once loaded. Mount this keyed by photo id so each photo starts fresh.
+const LightboxImage = (props: LightboxImageProps) => {
+  const { photo } = props;
+  const previewRef = useRef<HTMLImageElement>(null);
+  const fullRef = useRef<HTMLImageElement>(null);
+  const [previewLoaded, setPreviewLoaded] = useState(false);
+  const [fullLoaded, setFullLoaded] = useState(false);
+
+  const placeholder = useMemo(
+    () => blurHashToDataUri(photo.blurHash),
+    [photo.blurHash],
+  );
+
+  const previewSrc = photo.mediumUrl || photo.thumbnailUrl;
+  const fullSrc = photo.source || previewSrc;
+  const alt = photo.slug ?? 'Photo';
+
+  // A cached image can finish loading before React attaches onLoad, leaving the
+  // layer pinned at opacity 0. Catch that on mount. naturalWidth > 0 excludes a
+  // cached error so a broken image stays hidden.
+  useEffect(() => {
+    const preview = previewRef.current;
+    if (preview?.complete && preview.naturalWidth > 0) {
+      setPreviewLoaded(true);
+    }
+    const full = fullRef.current;
+    if (full?.complete && full.naturalWidth > 0) {
+      setFullLoaded(true);
+    }
+  }, []);
+
+  return (
+    <Stack
+      sx={{
+        position: 'relative',
+        width: '100%',
+        height: '100%',
+        backgroundImage: placeholder ? `url(${placeholder})` : undefined,
+        backgroundSize: 'contain',
+        backgroundRepeat: 'no-repeat',
+        backgroundPosition: 'center',
+      }}
+    >
+      <LightboxImageLayer
+        ref={previewRef}
+        src={previewSrc}
+        alt=""
+        loaded={previewLoaded}
+        onLoad={() => setPreviewLoaded(true)}
+      />
+      <LightboxImageLayer
+        ref={fullRef}
+        src={fullSrc}
+        alt={alt}
+        loaded={fullLoaded}
+        onLoad={() => setFullLoaded(true)}
+      />
+    </Stack>
+  );
+};
+
+export { LightboxImage };

--- a/packages/ui/src/look/photo-detail-page/lightbox-image/styled.tsx
+++ b/packages/ui/src/look/photo-detail-page/lightbox-image/styled.tsx
@@ -1,0 +1,25 @@
+import { styled } from '@mui/material/styles';
+import type { ComponentType, ImgHTMLAttributes, Ref } from 'react';
+
+interface LightboxImageLayerProps extends ImgHTMLAttributes<HTMLImageElement> {
+  loaded: boolean;
+  ref?: Ref<HTMLImageElement>;
+}
+
+// A full-frame image layer that fades in once loaded. `contain` (not `cover`)
+// so the whole photo is visible, letterboxed. `loaded` is a transient prop kept
+// off the DOM; the ComponentType cast keeps the emitted type portable.
+const LightboxImageLayer = styled('img', {
+  shouldForwardProp: (prop) => prop !== 'loaded',
+})<{ loaded: boolean }>(({ loaded }) => ({
+  position: 'absolute',
+  inset: 0,
+  width: '100%',
+  height: '100%',
+  objectFit: 'contain',
+  display: 'block',
+  opacity: loaded ? 1 : 0,
+  transition: 'opacity 0.4s ease-in',
+})) as ComponentType<LightboxImageLayerProps>;
+
+export { LightboxImageLayer };

--- a/packages/ui/src/look/photo-detail-page/skeleton.stories.tsx
+++ b/packages/ui/src/look/photo-detail-page/skeleton.stories.tsx
@@ -1,0 +1,22 @@
+import Stack from '@mui/material/Stack';
+import type { Meta, StoryObj } from '@storybook/tanstack-react';
+import { PhotoLightboxSkeleton } from './skeleton';
+
+const meta: Meta<typeof PhotoLightboxSkeleton> = {
+  title: 'Look/PhotoLightboxSkeleton',
+  component: PhotoLightboxSkeleton,
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    (Story) => (
+      <Stack sx={{ height: '100vh' }}>
+        <Story />
+      </Stack>
+    ),
+  ],
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof PhotoLightboxSkeleton>;
+
+export const Default: Story = {};

--- a/packages/ui/src/look/photo-detail-page/skeleton.tsx
+++ b/packages/ui/src/look/photo-detail-page/skeleton.tsx
@@ -1,0 +1,27 @@
+import Skeleton from '@mui/material/Skeleton';
+import Stack from '@mui/material/Stack';
+
+// Loading placeholder for a deep-linked photo route, before the photo resolves.
+const PhotoLightboxSkeleton = () => (
+  <Stack
+    sx={{
+      width: '100%',
+      height: '100%',
+      alignItems: 'center',
+      justifyContent: 'center',
+      p: 4,
+    }}
+  >
+    <Skeleton
+      variant="rounded"
+      sx={{
+        width: '100%',
+        height: '100%',
+        maxWidth: '80vw',
+        maxHeight: '80vh',
+      }}
+    />
+  </Stack>
+);
+
+export { PhotoLightboxSkeleton };

--- a/packages/ui/src/look/photo-detail-page/utils.test.ts
+++ b/packages/ui/src/look/photo-detail-page/utils.test.ts
@@ -1,0 +1,45 @@
+import type { TransformedPhoto } from 'core/look/query-hooks/types';
+import { describe, expect, it } from 'vitest';
+import { stepPhotoId } from './utils';
+
+const makePhoto = (id: string): TransformedPhoto => ({
+  id,
+  source: `https://example.com/${id}.jpg`,
+  mediumUrl: `https://example.com/${id}-medium.jpg`,
+  thumbnailUrl: `https://example.com/${id}-thumb.jpg`,
+  blurHash: 'LEHV6nWB2yk8pyo0adR*.7kCMdnj',
+  width: 1920,
+  height: 1080,
+  takenAt: '2023-01-01T00:00:00Z',
+  slug: `slug-${id}`,
+});
+
+const photos = [makePhoto('a'), makePhoto('b'), makePhoto('c')];
+
+describe('stepPhotoId', () => {
+  it('returns the next photo id going forward', () => {
+    expect(stepPhotoId(photos, 'b', 1)).toBe('c');
+  });
+
+  it('returns the previous photo id going backward', () => {
+    expect(stepPhotoId(photos, 'b', -1)).toBe('a');
+  });
+
+  it('returns null past the last photo (no wrap)', () => {
+    expect(stepPhotoId(photos, 'c', 1)).toBe(null);
+  });
+
+  it('returns null before the first photo (no wrap)', () => {
+    expect(stepPhotoId(photos, 'a', -1)).toBe(null);
+  });
+
+  it('returns null when the active id is not in the list', () => {
+    expect(stepPhotoId(photos, 'missing', 1)).toBe(null);
+  });
+
+  it('returns null for a single-photo list in either direction', () => {
+    const single = [makePhoto('only')];
+    expect(stepPhotoId(single, 'only', 1)).toBe(null);
+    expect(stepPhotoId(single, 'only', -1)).toBe(null);
+  });
+});

--- a/packages/ui/src/look/photo-detail-page/utils.ts
+++ b/packages/ui/src/look/photo-detail-page/utils.ts
@@ -1,0 +1,23 @@
+import type { TransformedPhoto } from 'core/look/query-hooks/types';
+
+// The id of the photo `delta` positions from the active one, or null at the
+// ends (no wrap) or when the active id isn't in the list. Drives ←/→ navigation.
+const stepPhotoId = (
+  photos: TransformedPhoto[],
+  activeId: string,
+  delta: number,
+): string | null => {
+  const index = photos.findIndex((photo) => photo.id === activeId);
+  if (index === -1) {
+    return null;
+  }
+
+  const nextIndex = index + delta;
+  if (nextIndex < 0 || nextIndex >= photos.length) {
+    return null;
+  }
+
+  return photos[nextIndex].id;
+};
+
+export { stepPhotoId };


### PR DESCRIPTION
## Summary

Adds the full-screen photo lightbox to `packages/ui` (SWO-614, part of SWO-607) — how you look closely at one photo and move through the set without friction. All presentational; reuses the blur-hash primitive from SWO-613.

- **`look/photo-detail-page/containers/`** — `PhotoLightbox`: a MUI `Dialog fullScreen` (focus-trap, backdrop, and Escape-to-close for free) with prev/next/close `IconButton`s and a document-level `keydown` listener for **←/→ navigation**. Controlled by an in-memory `photos` array + `activeId` + `onActiveIdChange` — moving between photos never refetches (mirrors watch's `VideoDetailContainer.find(id)`), so navigation is instant.
- **`look/photo-detail-page/lightbox-image/`** — `LightboxImage`: **progressive** blur-hash → medium → full-res. Two `object-fit: contain` layers fade in over the blur placeholder as each resolution loads (`mediumUrl` then the original `source`), keyed by photo id so each photo starts fresh. Reuses `blurHashToDataUri` from SWO-613 — no duplicated decode.
- **`look/photo-detail-page/utils.ts`** — `stepPhotoId` (pure, unit-tested): the id one step from the active photo, `null` at the ends (no wrap) or when the id isn't in the list.
- **`skeleton.tsx`** — `PhotoLightboxSkeleton` for the deep-linked route's loading state (SWO-616).
- Storybook: an interactive open/close + ←/→ harness, an "open on last" edge story, and the skeleton.

### Design decisions

- **Overlay, not a refetching route.** The lightbox takes the already-loaded `TransformedPhoto` list and navigates in memory — `useLoadPhotoDetail` returns the identical shape, so a per-photo refetch buys nothing and would add latency. Instant ←/→ serves the "no friction" goal.
- **No `LinkComponent`.** The ticket's scope note mentioned one, but an overlay doesn't navigate via links — it's controlled via `activeId`/`onActiveIdChange`, which lets the wiring (SWO-616) sync the URL if it wants deep-linking, without coupling this component to the router.
- Reuses MUI `Dialog` (the repo's established full-screen-overlay pattern) rather than hand-rolling focus-trap/Escape.

## Test plan

- [x] `pnpm --filter ui typecheck` passes
- [x] `pnpm --filter ui test` — 603 pass (incl. new `stepPhotoId` tests: forward/back, both ends no-wrap, missing id, single-photo — exact assertions)
- [x] `pnpm --filter ui build` (tsup) — emits `dist/look/photo-detail-page/**`
- [x] `pnpm --filter ui build-storybook` passes (interactive lightbox + skeleton stories)
- [x] Biome clean on `src/look/photo-detail-page`
- [ ] Live wiring into `apps/look` (the `/photo/$id` route + URL sync) is SWO-616

Refs SWO-614.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
