### PR TITLE
[WIP] feat(look): album list + album detail views (SWO-615)

### DIFF
--- a/packages/ui/src/look/albums/album-card/index.stories.tsx
+++ b/packages/ui/src/look/albums/album-card/index.stories.tsx
@@ -1,0 +1,80 @@
+import Stack from '@mui/material/Stack';
+import type { Meta, StoryObj } from '@storybook/tanstack-react';
+import type {
+  TransformedAlbum,
+  TransformedPhoto,
+} from 'core/look/query-hooks/types';
+import type { LinkComponentType } from '../../photos/types';
+import { AlbumCard } from '.';
+
+const MockLink: LinkComponentType = ({ to, children, style }) => (
+  <a href={to} style={style}>
+    {children}
+  </a>
+);
+
+const makePhotos = (count: number): TransformedPhoto[] =>
+  Array.from({ length: count }, (_, index) => ({
+    id: `photo-${index}`,
+    source: `https://picsum.photos/seed/album-photo-${index}/1200/1200`,
+    mediumUrl: `https://picsum.photos/seed/album-photo-${index}/1200/1200`,
+    thumbnailUrl: `https://picsum.photos/seed/album-photo-${index}/400/400`,
+    blurHash: 'LEHV6nWB2yk8pyo0adR*.7kCMdnj',
+    width: 1200,
+    height: 1200,
+    takenAt: `2023-06-${String((index % 27) + 1).padStart(2, '0')}T10:00:00Z`,
+    slug: `photo-${index}`,
+  }));
+
+const makeAlbum = (
+  overrides: Partial<TransformedAlbum> = {},
+): TransformedAlbum => ({
+  id: 'album-1',
+  title: 'Summer 2023',
+  thumbnailUrl: 'https://picsum.photos/seed/album-cover-1/600/600',
+  slug: 'summer-2023',
+  createdAt: '2023-06-01T00:00:00Z',
+  description: '',
+  photos: makePhotos(42),
+  ...overrides,
+});
+
+const meta: Meta<typeof AlbumCard> = {
+  title: 'Look/AlbumCard',
+  component: AlbumCard,
+  args: {
+    LinkComponent: MockLink,
+    linkProps: { to: '/album/$albumId', params: { albumId: 'summer-2023' } },
+  },
+  decorators: [
+    (Story) => (
+      <Stack sx={{ width: '16rem', p: 2 }}>
+        <Story />
+      </Stack>
+    ),
+  ],
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof AlbumCard>;
+
+export const WithCover: Story = {
+  args: { album: makeAlbum() },
+};
+
+// No own thumbnail — the cover falls back to the first photo's thumbnail.
+export const CoverFromFirstPhoto: Story = {
+  args: { album: makeAlbum({ thumbnailUrl: '' }) },
+};
+
+// No thumbnail and no photos — the cover is a plain tinted square.
+export const NoCover: Story = {
+  args: {
+    album: makeAlbum({ title: 'Empty Album', thumbnailUrl: '', photos: [] }),
+  },
+};
+
+export const SinglePhoto: Story = {
+  args: { album: makeAlbum({ title: 'One Shot', photos: makePhotos(1) }) },
+};

--- a/packages/ui/src/look/albums/album-card/index.tsx
+++ b/packages/ui/src/look/albums/album-card/index.tsx
@@ -1,0 +1,66 @@
+import Card from '@mui/material/Card';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import type { TransformedAlbum } from 'core/look/query-hooks/types';
+import { BlurImage } from '../../photos/blur-image';
+import type { LinkComponentType, PhotoLinkProps } from '../../photos/types';
+import { formatPhotoCount } from '../utils';
+
+interface AlbumCardProps {
+  album: TransformedAlbum;
+  LinkComponent?: LinkComponentType;
+  linkProps?: PhotoLinkProps;
+}
+
+// One album tile: a square cover with the album title and photo count beneath.
+// The cover prefers the album's own thumbnail and falls back to its first
+// photo; an album with neither shows a plain tinted square. The cover reuses
+// BlurImage so albums fade in exactly the way photos do.
+const AlbumCard = (props: AlbumCardProps) => {
+  const { album, LinkComponent, linkProps } = props;
+  const coverSrc = album.thumbnailUrl || album.photos[0]?.thumbnailUrl;
+  const count = album.photos.length;
+
+  const card = (
+    <Stack sx={{ gap: 1 }}>
+      <Card
+        sx={{
+          position: 'relative',
+          aspectRatio: '1 / 1',
+          overflow: 'hidden',
+          boxShadow: 'none',
+          borderRadius: 1,
+          bgcolor: 'action.hover',
+          transition: 'transform 0.2s',
+          '&:hover': { transform: 'scale(1.02)' },
+        }}
+      >
+        {coverSrc ? <BlurImage src={coverSrc} alt={album.title} /> : null}
+      </Card>
+      <Stack sx={{ px: 0.5 }}>
+        <Typography variant="subtitle1" color="text.primary" noWrap>
+          {album.title}
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          {formatPhotoCount(count)}
+        </Typography>
+      </Stack>
+    </Stack>
+  );
+
+  if (!LinkComponent || !linkProps) {
+    return card;
+  }
+
+  return (
+    <LinkComponent
+      to={linkProps.to}
+      params={linkProps.params}
+      style={{ textDecoration: 'none' }}
+    >
+      {card}
+    </LinkComponent>
+  );
+};
+
+export { AlbumCard };

--- a/packages/ui/src/look/albums/album-card/skeleton.tsx
+++ b/packages/ui/src/look/albums/album-card/skeleton.tsx
@@ -1,0 +1,16 @@
+import Skeleton from '@mui/material/Skeleton';
+import Stack from '@mui/material/Stack';
+
+// Loading placeholder for an album tile: a square cover plus two text lines,
+// matching AlbumCard's shape so the grid does not shift when albums resolve.
+const AlbumCardSkeleton = () => (
+  <Stack sx={{ gap: 1 }}>
+    <Skeleton variant="rounded" sx={{ width: '100%', aspectRatio: '1 / 1' }} />
+    <Stack sx={{ px: 0.5, gap: 0.5 }}>
+      <Skeleton variant="text" sx={{ width: '70%' }} />
+      <Skeleton variant="text" sx={{ width: '40%' }} />
+    </Stack>
+  </Stack>
+);
+
+export { AlbumCardSkeleton };

--- a/packages/ui/src/look/albums/album-detail/index.stories.tsx
+++ b/packages/ui/src/look/albums/album-detail/index.stories.tsx
@@ -1,0 +1,86 @@
+import Stack from '@mui/material/Stack';
+import type { Meta, StoryObj } from '@storybook/tanstack-react';
+import type {
+  TransformedAlbum,
+  TransformedPhoto,
+} from 'core/look/query-hooks/types';
+import type { LinkComponentType } from '../../photos/types';
+import { AlbumDetailContainer } from '.';
+
+const MockLink: LinkComponentType = ({ to, children, style }) => (
+  <a href={to} style={style}>
+    {children}
+  </a>
+);
+
+const makePhotos = (count: number): TransformedPhoto[] =>
+  Array.from({ length: count }, (_, index) => ({
+    id: `photo-${index}`,
+    source: `https://picsum.photos/seed/detail-${index}/1200/1200`,
+    mediumUrl: `https://picsum.photos/seed/detail-${index}/1200/1200`,
+    thumbnailUrl: `https://picsum.photos/seed/detail-${index}/400/400`,
+    blurHash: 'LEHV6nWB2yk8pyo0adR*.7kCMdnj',
+    width: 1200,
+    height: 1200,
+    takenAt: `2023-06-${String((index % 27) + 1).padStart(2, '0')}T10:00:00Z`,
+    slug: `photo-${index}`,
+  }));
+
+const makeAlbum = (
+  overrides: Partial<TransformedAlbum> = {},
+): TransformedAlbum => ({
+  id: 'album-1',
+  title: '5cm Per Second',
+  thumbnailUrl: 'https://picsum.photos/seed/detail-cover/600/600',
+  slug: '5cm-per-second',
+  createdAt: '2023-06-01T00:00:00Z',
+  description: 'A quiet set of stills.',
+  photos: makePhotos(24),
+  ...overrides,
+});
+
+const meta: Meta<typeof AlbumDetailContainer> = {
+  title: 'Look/AlbumDetailContainer',
+  component: AlbumDetailContainer,
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    (Story) => (
+      <Stack sx={{ height: '100vh' }}>
+        <Story />
+      </Stack>
+    ),
+  ],
+  args: { LinkComponent: MockLink },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof AlbumDetailContainer>;
+
+export const Populated: Story = {
+  args: {
+    queryRs: { album: makeAlbum(), isLoading: false, error: null },
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    queryRs: { album: null, isLoading: true, error: null },
+  },
+};
+
+export const NotFound: Story = {
+  args: {
+    queryRs: { album: null, isLoading: false, error: null },
+  },
+};
+
+export const NoPhotos: Story = {
+  args: {
+    queryRs: {
+      album: makeAlbum({ description: '', photos: [] }),
+      isLoading: false,
+      error: null,
+    },
+  },
+};

--- a/packages/ui/src/look/albums/album-detail/index.tsx
+++ b/packages/ui/src/look/albums/album-detail/index.tsx
@@ -1,0 +1,109 @@
+import Container from '@mui/material/Container';
+import Grid from '@mui/material/Grid';
+import Skeleton from '@mui/material/Skeleton';
+import Stack from '@mui/material/Stack';
+import { useTheme } from '@mui/material/styles';
+import Typography from '@mui/material/Typography';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import type { useLoadAlbumDetail } from 'core/look/query-hooks/albums';
+import { genPhotoLinkProps, resolveColumns } from '../../home-page/utils';
+import { PhotoCard } from '../../photos/photo-card';
+import { PhotoSkeleton } from '../../photos/photo-card/skeleton';
+import type { LinkComponentType } from '../../photos/types';
+import { formatPhotoCount } from '../utils';
+
+const CONTENT_SX = { py: 4, px: { xs: 2, sm: 3 } } as const;
+const SKELETON_KEYS = Array.from(
+  { length: 12 },
+  (_, index) => `album-photo-skeleton-${index}`,
+);
+
+interface AlbumDetailContainerProps {
+  queryRs: ReturnType<typeof useLoadAlbumDetail>;
+  LinkComponent: LinkComponentType;
+}
+
+// One album's photos, in stored position order. Reuses the same square PhotoCard
+// + blur placeholder as the timeline, but laid out as a plain responsive grid —
+// an album is a bounded, ordered set, so it is not month-grouped or virtualized.
+const AlbumDetailContainer = (props: AlbumDetailContainerProps) => {
+  const { queryRs, LinkComponent } = props;
+  const { album, isLoading } = queryRs;
+  const theme = useTheme();
+
+  const columns = resolveColumns({
+    isSm: useMediaQuery(theme.breakpoints.up('sm')),
+    isMd: useMediaQuery(theme.breakpoints.up('md')),
+    isLg: useMediaQuery(theme.breakpoints.up('lg')),
+    isXl: useMediaQuery(theme.breakpoints.up('xl')),
+  });
+
+  if (isLoading) {
+    return (
+      <Container maxWidth={false} sx={CONTENT_SX}>
+        <Stack sx={{ gap: 1, pb: 3 }}>
+          <Skeleton variant="text" sx={{ width: '40%', fontSize: '2rem' }} />
+          <Skeleton variant="text" sx={{ width: '20%' }} />
+        </Stack>
+        <Grid container spacing={1} columns={columns}>
+          {SKELETON_KEYS.map((key) => (
+            <Grid size={1} key={key}>
+              <PhotoSkeleton />
+            </Grid>
+          ))}
+        </Grid>
+      </Container>
+    );
+  }
+
+  if (!album) {
+    return (
+      <Container maxWidth={false} sx={CONTENT_SX}>
+        <Stack sx={{ alignItems: 'center', py: 8 }}>
+          <Typography variant="body1" color="text.secondary">
+            Album not found
+          </Typography>
+        </Stack>
+      </Container>
+    );
+  }
+
+  return (
+    <Container maxWidth={false} sx={CONTENT_SX}>
+      <Stack sx={{ gap: 0.5, pb: 3 }}>
+        <Typography variant="h5" component="h1" color="text.primary">
+          {album.title}
+        </Typography>
+        {album.description ? (
+          <Typography variant="body1" color="text.secondary">
+            {album.description}
+          </Typography>
+        ) : null}
+        <Typography variant="body2" color="text.secondary">
+          {formatPhotoCount(album.photos.length)}
+        </Typography>
+      </Stack>
+      {album.photos.length === 0 ? (
+        <Stack sx={{ alignItems: 'center', py: 8 }}>
+          <Typography variant="body1" color="text.secondary">
+            No photos in this album
+          </Typography>
+        </Stack>
+      ) : (
+        <Grid container spacing={1} columns={columns}>
+          {album.photos.map((photo) => (
+            <Grid size={1} key={photo.id}>
+              <PhotoCard
+                photo={photo}
+                LinkComponent={LinkComponent}
+                linkProps={genPhotoLinkProps(photo)}
+              />
+            </Grid>
+          ))}
+        </Grid>
+      )}
+    </Container>
+  );
+};
+
+export { AlbumDetailContainer };

--- a/packages/ui/src/look/albums/album-list/index.stories.tsx
+++ b/packages/ui/src/look/albums/album-list/index.stories.tsx
@@ -1,0 +1,83 @@
+import Stack from '@mui/material/Stack';
+import type { Meta, StoryObj } from '@storybook/tanstack-react';
+import type {
+  TransformedAlbum,
+  TransformedPhoto,
+} from 'core/look/query-hooks/types';
+import type { LinkComponentType } from '../../photos/types';
+import { AlbumListContainer } from '.';
+
+const MockLink: LinkComponentType = ({ to, children, style }) => (
+  <a href={to} style={style}>
+    {children}
+  </a>
+);
+
+const makePhotos = (albumIndex: number, count: number): TransformedPhoto[] =>
+  Array.from({ length: count }, (_, index) => ({
+    id: `photo-${albumIndex}-${index}`,
+    source: `https://picsum.photos/seed/al-${albumIndex}-${index}/1200/1200`,
+    mediumUrl: `https://picsum.photos/seed/al-${albumIndex}-${index}/1200/1200`,
+    thumbnailUrl: `https://picsum.photos/seed/al-${albumIndex}-${index}/400/400`,
+    blurHash: 'LEHV6nWB2yk8pyo0adR*.7kCMdnj',
+    width: 1200,
+    height: 1200,
+    takenAt: `2023-0${(albumIndex % 9) + 1}-01T10:00:00Z`,
+    slug: `photo-${albumIndex}-${index}`,
+  }));
+
+const TITLES = [
+  'Summer 2023',
+  '5cm Per Second',
+  'City Nights',
+  'Mountains',
+  'Studio',
+  'Roadtrip',
+];
+
+const makeAlbums = (count: number): TransformedAlbum[] =>
+  Array.from({ length: count }, (_, index) => ({
+    id: `album-${index}`,
+    title: TITLES[index % TITLES.length],
+    thumbnailUrl: `https://picsum.photos/seed/album-cover-${index}/600/600`,
+    slug: `album-${index}`,
+    createdAt: `2023-0${(index % 9) + 1}-01T00:00:00Z`,
+    description: '',
+    photos: makePhotos(index, ((index * 7) % 40) + 1),
+  }));
+
+const meta: Meta<typeof AlbumListContainer> = {
+  title: 'Look/AlbumListContainer',
+  component: AlbumListContainer,
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    (Story) => (
+      <Stack sx={{ height: '100vh' }}>
+        <Story />
+      </Stack>
+    ),
+  ],
+  args: { LinkComponent: MockLink },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof AlbumListContainer>;
+
+export const Populated: Story = {
+  args: {
+    queryRs: { albums: makeAlbums(6), isLoading: false, error: null },
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    queryRs: { albums: [], isLoading: true, error: null },
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    queryRs: { albums: [], isLoading: false, error: null },
+  },
+};

--- a/packages/ui/src/look/albums/album-list/index.tsx
+++ b/packages/ui/src/look/albums/album-list/index.tsx
@@ -1,0 +1,75 @@
+import Container from '@mui/material/Container';
+import Grid from '@mui/material/Grid';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import type { useLoadAlbums } from 'core/look/query-hooks/albums';
+import type { LinkComponentType } from '../../photos/types';
+import { AlbumCard } from '../album-card';
+import { AlbumCardSkeleton } from '../album-card/skeleton';
+import { genAlbumLinkProps } from '../utils';
+
+const SKELETON_KEYS = Array.from(
+  { length: 8 },
+  (_, index) => `album-skeleton-${index}`,
+);
+const GRID_SX = { py: 4, px: { xs: 2, sm: 3 } } as const;
+// Album tiles are larger than photo tiles: 2 up on phones, 3 on tablets, 4 on
+// desktop (out of MUI Grid's default 12 columns).
+const ALBUM_GRID_SIZE = { xs: 6, sm: 4, md: 3 } as const;
+
+interface AlbumListContainerProps {
+  queryRs: ReturnType<typeof useLoadAlbums>;
+  LinkComponent: LinkComponentType;
+}
+
+// The album index: a responsive grid of album covers. Albums are a curated,
+// small set, so this renders plainly (no virtualization) — the virtualized
+// timeline is only for the full, unbounded photo stream.
+const AlbumListContainer = (props: AlbumListContainerProps) => {
+  const { queryRs, LinkComponent } = props;
+  const { albums, isLoading } = queryRs;
+
+  if (isLoading) {
+    return (
+      <Container maxWidth={false} sx={GRID_SX}>
+        <Grid container spacing={2}>
+          {SKELETON_KEYS.map((key) => (
+            <Grid size={ALBUM_GRID_SIZE} key={key}>
+              <AlbumCardSkeleton />
+            </Grid>
+          ))}
+        </Grid>
+      </Container>
+    );
+  }
+
+  if (albums.length === 0) {
+    return (
+      <Container maxWidth={false} sx={GRID_SX}>
+        <Stack sx={{ alignItems: 'center', py: 8 }}>
+          <Typography variant="body1" color="text.secondary">
+            No albums yet
+          </Typography>
+        </Stack>
+      </Container>
+    );
+  }
+
+  return (
+    <Container maxWidth={false} sx={GRID_SX}>
+      <Grid container spacing={2}>
+        {albums.map((album) => (
+          <Grid size={ALBUM_GRID_SIZE} key={album.id}>
+            <AlbumCard
+              album={album}
+              LinkComponent={LinkComponent}
+              linkProps={genAlbumLinkProps(album)}
+            />
+          </Grid>
+        ))}
+      </Grid>
+    </Container>
+  );
+};
+
+export { AlbumListContainer };

--- a/packages/ui/src/look/albums/utils.test.ts
+++ b/packages/ui/src/look/albums/utils.test.ts
@@ -1,0 +1,48 @@
+import type { TransformedAlbum } from 'core/look/query-hooks/types';
+import { describe, expect, it } from 'vitest';
+import { formatPhotoCount, genAlbumLinkProps } from './utils';
+
+const makeAlbum = (
+  overrides: Partial<TransformedAlbum> = {},
+): TransformedAlbum => ({
+  id: 'album-1',
+  title: 'Test Album',
+  thumbnailUrl: 'https://example.com/cover.jpg',
+  slug: 'test-album',
+  createdAt: '2023-01-01T00:00:00Z',
+  description: '',
+  photos: [],
+  ...overrides,
+});
+
+describe('genAlbumLinkProps', () => {
+  it('uses the slug as the route param when present', () => {
+    const result = genAlbumLinkProps(makeAlbum({ slug: 'holiday' }));
+    expect(result).toEqual({
+      to: '/album/$albumId',
+      params: { albumId: 'holiday' },
+    });
+  });
+
+  it('falls back to the id when the slug is empty', () => {
+    const result = genAlbumLinkProps(makeAlbum({ id: 'album-9', slug: '' }));
+    expect(result).toEqual({
+      to: '/album/$albumId',
+      params: { albumId: 'album-9' },
+    });
+  });
+});
+
+describe('formatPhotoCount', () => {
+  it('uses the singular noun for exactly one photo', () => {
+    expect(formatPhotoCount(1)).toBe('1 photo');
+  });
+
+  it('uses the plural noun for zero photos', () => {
+    expect(formatPhotoCount(0)).toBe('0 photos');
+  });
+
+  it('uses the plural noun for many photos', () => {
+    expect(formatPhotoCount(87)).toBe('87 photos');
+  });
+});

--- a/packages/ui/src/look/albums/utils.ts
+++ b/packages/ui/src/look/albums/utils.ts
@@ -1,0 +1,13 @@
+import type { TransformedAlbum } from 'core/look/query-hooks/types';
+
+const ALBUM_ROUTE = '/album/$albumId';
+
+const genAlbumLinkProps = (album: TransformedAlbum) => ({
+  to: ALBUM_ROUTE,
+  params: { albumId: album.slug || album.id },
+});
+
+const formatPhotoCount = (count: number): string =>
+  count === 1 ? '1 photo' : `${count} photos`;
+
+export { formatPhotoCount, genAlbumLinkProps };


### PR DESCRIPTION
## Summary

Adds the two album views to `packages/ui` (SWO-615, part of SWO-607) — the album index and a single album's photos. Both are presentational; both **reuse** the timeline's `PhotoCard` + blur-hash image (SWO-613) rather than duplicating any grid/image logic.

- **`look/albums/album-card/`** — `AlbumCard`: a square cover (reusing `BlurImage`) with the album title and photo count beneath. The cover prefers the album's own `thumbnailUrl` and falls back to the first photo's thumbnail; an album with neither shows a plain tinted square. `+ AlbumCardSkeleton`.
- **`look/albums/album-list/`** — `AlbumListContainer({ queryRs, LinkComponent })`: a responsive grid of `AlbumCard`s from a `useLoadAlbums` result. Albums are a curated, bounded set, so this renders plainly — the virtualized timeline is only for the unbounded photo stream. Loading → skeletons, empty → "No albums yet".
- **`look/albums/album-detail/`** — `AlbumDetailContainer({ queryRs, LinkComponent })`: one album's photos **in stored position order**, laid out with the shared `PhotoCard` in a plain responsive grid (reusing `resolveColumns` + `genPhotoLinkProps` from the timeline). Header shows title / optional description / count. Handles loading, `null` album ("Album not found"), and empty album.
- **`look/albums/utils.ts`** — `genAlbumLinkProps` (album → `/album/$albumId` route params, slug-or-id) and `formatPhotoCount` (singular/plural), both pure and unit-tested.
- Storybook: `AlbumCard` (cover / cover-from-first-photo / no-cover / single-photo), `AlbumListContainer` and `AlbumDetailContainer` (populated / loading / empty / not-found).

### Design decisions

- **Not virtualized.** An album is a bounded, ordered set and the index is a handful of tiles — the `@tanstack/react-virtual` machinery earns its keep only on the unbounded, month-grouped main timeline. A plain MUI `Grid` here is simpler and shift-free.
- **Position order, not month-grouped.** `TransformedAlbum.photos` already arrives in `playlist_photos.position` order from core; the album shows exactly that curated sequence, so no regrouping.
- **Reuse over duplication.** Covers and cells are the same `PhotoCard` / `BlurImage` as the timeline; columns come from the timeline's `resolveColumns`; photo links from its `genPhotoLinkProps`. The only new shared helpers are album-specific (`genAlbumLinkProps`, `formatPhotoCount`).

## Test plan

- [x] `pnpm --filter ui typecheck` passes
- [x] `pnpm --filter ui test` — new `genAlbumLinkProps` (slug / id-fallback) and `formatPhotoCount` (1 / 0 / many) tests pass, exact assertions
- [x] `pnpm --filter ui build` (tsup) — emits `dist/look/albums/**` (containers resolve via the `./*` → `dist/*/index.mjs` export)
- [x] `pnpm --filter ui build-storybook` passes (album card + list + detail stories)
- [x] Biome clean on `src/look/albums`
- [ ] Live wiring into `apps/look` (the `/albums` + `/album/$albumId` routes) is SWO-616

Refs SWO-615.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
