### PR TITLE
[WIP] feat(look): wire timeline, lightbox, and album routes (SWO-616)

### DIFF
--- a/apps/look/src/components/layout/index.tsx
+++ b/apps/look/src/components/layout/index.tsx
@@ -1,4 +1,4 @@
-import { Link } from '@tanstack/react-router';
+import { Link, useLocation } from '@tanstack/react-router';
 import { Auth } from 'core';
 import type { ReactNode } from 'react';
 import { FullPageContainer } from 'ui/universal/containers/full-page';
@@ -14,25 +14,34 @@ const NAV_LINK_ACTIVE_STYLE = { ...NAV_LINK_STYLE, fontWeight: 700 };
 // Timeline ↔ albums nav, rendered in the shared Header's actions slot. These are
 // route declarations (they name the app's paths), so they live in the app, not
 // in packages/ui; the chrome around them is the shared Header component.
-const Nav = () => (
-  <>
-    <Link
-      to="/"
-      activeOptions={{ exact: true }}
-      style={NAV_LINK_STYLE}
-      activeProps={{ style: NAV_LINK_ACTIVE_STYLE }}
-    >
-      Photos
-    </Link>
-    <Link
-      to="/albums"
-      style={NAV_LINK_STYLE}
-      activeProps={{ style: NAV_LINK_ACTIVE_STYLE }}
-    >
-      Albums
-    </Link>
-  </>
-);
+//
+// Active state is derived from the path rather than Link's activeOptions because
+// each section spans two routes: Photos covers the timeline (/) and the open
+// lightbox (/photo/$photoId), Albums covers the list (/albums) and a single
+// album (/album/$albumId). A single `to` can't match both without also matching
+// the other section.
+const Nav = () => {
+  const { pathname } = useLocation();
+  const photosActive = pathname === '/' || pathname.startsWith('/photo/');
+  const albumsActive = pathname === '/albums' || pathname.startsWith('/album/');
+
+  return (
+    <>
+      <Link
+        to="/"
+        style={photosActive ? NAV_LINK_ACTIVE_STYLE : NAV_LINK_STYLE}
+      >
+        Photos
+      </Link>
+      <Link
+        to="/albums"
+        style={albumsActive ? NAV_LINK_ACTIVE_STYLE : NAV_LINK_STYLE}
+      >
+        Albums
+      </Link>
+    </>
+  );
+};
 
 const Layout = (props: LayoutProps) => {
   const { children } = props;

--- a/apps/look/src/components/layout/index.tsx
+++ b/apps/look/src/components/layout/index.tsx
@@ -1,14 +1,54 @@
+import { Link } from '@tanstack/react-router';
+import { Auth } from 'core';
 import type { ReactNode } from 'react';
 import { FullPageContainer } from 'ui/universal/containers/full-page';
+import { Header } from 'ui/universal/header';
 
 interface LayoutProps {
   children: ReactNode;
 }
 
+const NAV_LINK_STYLE = { textDecoration: 'none', color: 'inherit' };
+const NAV_LINK_ACTIVE_STYLE = { ...NAV_LINK_STYLE, fontWeight: 700 };
+
+// Timeline ↔ albums nav, rendered in the shared Header's actions slot. These are
+// route declarations (they name the app's paths), so they live in the app, not
+// in packages/ui; the chrome around them is the shared Header component.
+const Nav = () => (
+  <>
+    <Link
+      to="/"
+      activeOptions={{ exact: true }}
+      style={NAV_LINK_STYLE}
+      activeProps={{ style: NAV_LINK_ACTIVE_STYLE }}
+    >
+      Photos
+    </Link>
+    <Link
+      to="/albums"
+      style={NAV_LINK_STYLE}
+      activeProps={{ style: NAV_LINK_ACTIVE_STYLE }}
+    >
+      Albums
+    </Link>
+  </>
+);
+
 const Layout = (props: LayoutProps) => {
   const { children } = props;
+  const { user, signOut } = Auth.useAuthContext();
 
-  return <FullPageContainer>{children}</FullPageContainer>;
+  return (
+    <FullPageContainer>
+      <Header
+        LinkComponent={Link}
+        user={user}
+        onAvatarClick={signOut}
+        actions={<Nav />}
+      />
+      {children}
+    </FullPageContainer>
+  );
 };
 
 export { Layout };

--- a/apps/look/src/components/timeline-page/index.tsx
+++ b/apps/look/src/components/timeline-page/index.tsx
@@ -32,7 +32,7 @@ const TimelinePage = (props: TimelinePageProps) => {
         photos={photos}
         activeId={activePhotoId ?? ''}
         open={isPhotoOpen}
-        onClose={() => navigate({ to: '/' })}
+        onClose={() => navigate({ to: '/', replace: true })}
         onActiveIdChange={(id) =>
           navigate({
             to: '/photo/$photoId',

--- a/apps/look/src/components/timeline-page/index.tsx
+++ b/apps/look/src/components/timeline-page/index.tsx
@@ -1,0 +1,48 @@
+import { Link, useNavigate } from '@tanstack/react-router';
+import { useLoadPhotos } from 'core/look/query-hooks/photos';
+import { useAuthContext } from 'core/providers/auth';
+import { PhotoTimelineContainer } from 'ui/look/home-page/container';
+import { PhotoLightbox } from 'ui/look/photo-detail-page/containers';
+import { Layout } from '../layout';
+
+interface TimelinePageProps {
+  activePhotoId?: string;
+}
+
+// The timeline and the full-screen lightbox are one view: the URL decides
+// whether a photo is open. The lightbox steps ←/→ through the same in-memory
+// list the grid shows, so opening a photo never refetches. An unknown id (bad
+// link, deleted photo, load error → empty list) leaves the lightbox closed and
+// the user on the grid rather than a blank screen. Stepping replaces the URL so
+// Back leaves the lightbox in one step instead of walking every photo visited.
+const TimelinePage = (props: TimelinePageProps) => {
+  const { activePhotoId } = props;
+  const navigate = useNavigate();
+  const { getAccessToken } = useAuthContext();
+  const photosResult = useLoadPhotos({ getAccessToken });
+  const { photos } = photosResult;
+  const isPhotoOpen =
+    activePhotoId !== undefined &&
+    photos.some((photo) => photo.id === activePhotoId);
+
+  return (
+    <Layout>
+      <PhotoTimelineContainer queryRs={photosResult} LinkComponent={Link} />
+      <PhotoLightbox
+        photos={photos}
+        activeId={activePhotoId ?? ''}
+        open={isPhotoOpen}
+        onClose={() => navigate({ to: '/' })}
+        onActiveIdChange={(id) =>
+          navigate({
+            to: '/photo/$photoId',
+            params: { photoId: id },
+            replace: true,
+          })
+        }
+      />
+    </Layout>
+  );
+};
+
+export { TimelinePage };

--- a/apps/look/src/routeTree.gen.ts
+++ b/apps/look/src/routeTree.gen.ts
@@ -12,38 +12,79 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { Route as rootRouteImport } from './routes/__root'
 
+const AlbumsLazyRouteImport = createFileRoute('/albums')()
 const IndexLazyRouteImport = createFileRoute('/')()
+const PhotoPhotoIdLazyRouteImport = createFileRoute('/photo/$photoId')()
+const AlbumAlbumIdLazyRouteImport = createFileRoute('/album/$albumId')()
 
+const AlbumsLazyRoute = AlbumsLazyRouteImport.update({
+  id: '/albums',
+  path: '/albums',
+  getParentRoute: () => rootRouteImport,
+} as any).lazy(() => import('./routes/albums.lazy').then((d) => d.Route))
 const IndexLazyRoute = IndexLazyRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any).lazy(() => import('./routes/index.lazy').then((d) => d.Route))
+const PhotoPhotoIdLazyRoute = PhotoPhotoIdLazyRouteImport.update({
+  id: '/photo/$photoId',
+  path: '/photo/$photoId',
+  getParentRoute: () => rootRouteImport,
+} as any).lazy(() =>
+  import('./routes/photo.$photoId.lazy').then((d) => d.Route),
+)
+const AlbumAlbumIdLazyRoute = AlbumAlbumIdLazyRouteImport.update({
+  id: '/album/$albumId',
+  path: '/album/$albumId',
+  getParentRoute: () => rootRouteImport,
+} as any).lazy(() =>
+  import('./routes/album.$albumId.lazy').then((d) => d.Route),
+)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexLazyRoute
+  '/albums': typeof AlbumsLazyRoute
+  '/album/$albumId': typeof AlbumAlbumIdLazyRoute
+  '/photo/$photoId': typeof PhotoPhotoIdLazyRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexLazyRoute
+  '/albums': typeof AlbumsLazyRoute
+  '/album/$albumId': typeof AlbumAlbumIdLazyRoute
+  '/photo/$photoId': typeof PhotoPhotoIdLazyRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexLazyRoute
+  '/albums': typeof AlbumsLazyRoute
+  '/album/$albumId': typeof AlbumAlbumIdLazyRoute
+  '/photo/$photoId': typeof PhotoPhotoIdLazyRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/'
+  fullPaths: '/' | '/albums' | '/album/$albumId' | '/photo/$photoId'
   fileRoutesByTo: FileRoutesByTo
-  to: '/'
-  id: '__root__' | '/'
+  to: '/' | '/albums' | '/album/$albumId' | '/photo/$photoId'
+  id: '__root__' | '/' | '/albums' | '/album/$albumId' | '/photo/$photoId'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexLazyRoute: typeof IndexLazyRoute
+  AlbumsLazyRoute: typeof AlbumsLazyRoute
+  AlbumAlbumIdLazyRoute: typeof AlbumAlbumIdLazyRoute
+  PhotoPhotoIdLazyRoute: typeof PhotoPhotoIdLazyRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/albums': {
+      id: '/albums'
+      path: '/albums'
+      fullPath: '/albums'
+      preLoaderRoute: typeof AlbumsLazyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -51,11 +92,28 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexLazyRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/photo/$photoId': {
+      id: '/photo/$photoId'
+      path: '/photo/$photoId'
+      fullPath: '/photo/$photoId'
+      preLoaderRoute: typeof PhotoPhotoIdLazyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/album/$albumId': {
+      id: '/album/$albumId'
+      path: '/album/$albumId'
+      fullPath: '/album/$albumId'
+      preLoaderRoute: typeof AlbumAlbumIdLazyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexLazyRoute: IndexLazyRoute,
+  AlbumsLazyRoute: AlbumsLazyRoute,
+  AlbumAlbumIdLazyRoute: AlbumAlbumIdLazyRoute,
+  PhotoPhotoIdLazyRoute: PhotoPhotoIdLazyRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/look/src/routes/album.$albumId.lazy.tsx
+++ b/apps/look/src/routes/album.$albumId.lazy.tsx
@@ -1,22 +1,23 @@
 import { createLazyFileRoute, Link } from '@tanstack/react-router';
-import { useLoadPhotos } from 'core/look/query-hooks/photos';
+import { useLoadAlbumDetail } from 'core/look/query-hooks/albums';
 import { useAuthContext } from 'core/providers/auth';
-import { PhotoTimelineContainer } from 'ui/look/home-page/container';
+import { AlbumDetailContainer } from 'ui/look/albums/album-detail';
 import { AuthRoute } from 'ui/universal/authRoute';
 import { Layout } from '../components/layout';
 
 const Content = () => {
+  const { albumId } = Route.useParams();
   const { getAccessToken } = useAuthContext();
-  const photosResult = useLoadPhotos({ getAccessToken });
+  const albumResult = useLoadAlbumDetail({ id: albumId, getAccessToken });
 
   return (
     <Layout>
-      <PhotoTimelineContainer queryRs={photosResult} LinkComponent={Link} />
+      <AlbumDetailContainer queryRs={albumResult} LinkComponent={Link} />
     </Layout>
   );
 };
 
-export const Route = createLazyFileRoute('/')({
+export const Route = createLazyFileRoute('/album/$albumId')({
   component: () => {
     return (
       <AuthRoute>

--- a/apps/look/src/routes/albums.lazy.tsx
+++ b/apps/look/src/routes/albums.lazy.tsx
@@ -1,22 +1,22 @@
 import { createLazyFileRoute, Link } from '@tanstack/react-router';
-import { useLoadPhotos } from 'core/look/query-hooks/photos';
+import { useLoadAlbums } from 'core/look/query-hooks/albums';
 import { useAuthContext } from 'core/providers/auth';
-import { PhotoTimelineContainer } from 'ui/look/home-page/container';
+import { AlbumListContainer } from 'ui/look/albums/album-list';
 import { AuthRoute } from 'ui/universal/authRoute';
 import { Layout } from '../components/layout';
 
 const Content = () => {
   const { getAccessToken } = useAuthContext();
-  const photosResult = useLoadPhotos({ getAccessToken });
+  const albumsResult = useLoadAlbums({ getAccessToken });
 
   return (
     <Layout>
-      <PhotoTimelineContainer queryRs={photosResult} LinkComponent={Link} />
+      <AlbumListContainer queryRs={albumsResult} LinkComponent={Link} />
     </Layout>
   );
 };
 
-export const Route = createLazyFileRoute('/')({
+export const Route = createLazyFileRoute('/albums')({
   component: () => {
     return (
       <AuthRoute>

--- a/apps/look/src/routes/index.lazy.tsx
+++ b/apps/look/src/routes/index.lazy.tsx
@@ -1,26 +1,12 @@
-import { createLazyFileRoute, Link } from '@tanstack/react-router';
-import { useLoadPhotos } from 'core/look/query-hooks/photos';
-import { useAuthContext } from 'core/providers/auth';
-import { PhotoTimelineContainer } from 'ui/look/home-page/container';
+import { createLazyFileRoute } from '@tanstack/react-router';
 import { AuthRoute } from 'ui/universal/authRoute';
-import { Layout } from '../components/layout';
-
-const Content = () => {
-  const { getAccessToken } = useAuthContext();
-  const photosResult = useLoadPhotos({ getAccessToken });
-
-  return (
-    <Layout>
-      <PhotoTimelineContainer queryRs={photosResult} LinkComponent={Link} />
-    </Layout>
-  );
-};
+import { TimelinePage } from '../components/timeline-page';
 
 export const Route = createLazyFileRoute('/')({
   component: () => {
     return (
       <AuthRoute>
-        <Content />
+        <TimelinePage />
       </AuthRoute>
     );
   },

--- a/apps/look/src/routes/photo.$photoId.lazy.tsx
+++ b/apps/look/src/routes/photo.$photoId.lazy.tsx
@@ -1,35 +1,11 @@
 import { createLazyFileRoute } from '@tanstack/react-router';
-import { useLoadPhotos } from 'core/look/query-hooks/photos';
-import { useAuthContext } from 'core/providers/auth';
-import { PhotoLightbox } from 'ui/look/photo-detail-page/containers';
 import { AuthRoute } from 'ui/universal/authRoute';
+import { TimelinePage } from '../components/timeline-page';
 
-// The lightbox steps ←/→ through the whole timeline in memory, so the route
-// loads the same photo list as the home page (a React Query cache hit when the
-// user opened it from there) rather than fetching one photo. The URL's photoId
-// is the active photo; closing returns to the timeline, and stepping replaces
-// the URL so the back button leaves the lightbox instead of walking every photo.
 const Content = () => {
   const { photoId } = Route.useParams();
-  const navigate = Route.useNavigate();
-  const { getAccessToken } = useAuthContext();
-  const { photos } = useLoadPhotos({ getAccessToken });
 
-  return (
-    <PhotoLightbox
-      photos={photos}
-      activeId={photoId}
-      open
-      onClose={() => navigate({ to: '/' })}
-      onActiveIdChange={(id) =>
-        navigate({
-          to: '/photo/$photoId',
-          params: { photoId: id },
-          replace: true,
-        })
-      }
-    />
-  );
+  return <TimelinePage activePhotoId={photoId} />;
 };
 
 export const Route = createLazyFileRoute('/photo/$photoId')({

--- a/apps/look/src/routes/photo.$photoId.lazy.tsx
+++ b/apps/look/src/routes/photo.$photoId.lazy.tsx
@@ -1,0 +1,43 @@
+import { createLazyFileRoute } from '@tanstack/react-router';
+import { useLoadPhotos } from 'core/look/query-hooks/photos';
+import { useAuthContext } from 'core/providers/auth';
+import { PhotoLightbox } from 'ui/look/photo-detail-page/containers';
+import { AuthRoute } from 'ui/universal/authRoute';
+
+// The lightbox steps ←/→ through the whole timeline in memory, so the route
+// loads the same photo list as the home page (a React Query cache hit when the
+// user opened it from there) rather than fetching one photo. The URL's photoId
+// is the active photo; closing returns to the timeline, and stepping replaces
+// the URL so the back button leaves the lightbox instead of walking every photo.
+const Content = () => {
+  const { photoId } = Route.useParams();
+  const navigate = Route.useNavigate();
+  const { getAccessToken } = useAuthContext();
+  const { photos } = useLoadPhotos({ getAccessToken });
+
+  return (
+    <PhotoLightbox
+      photos={photos}
+      activeId={photoId}
+      open
+      onClose={() => navigate({ to: '/' })}
+      onActiveIdChange={(id) =>
+        navigate({
+          to: '/photo/$photoId',
+          params: { photoId: id },
+          replace: true,
+        })
+      }
+    />
+  );
+};
+
+export const Route = createLazyFileRoute('/photo/$photoId')({
+  component: () => {
+    return (
+      <AuthRoute>
+        <Content />
+      </AuthRoute>
+    );
+  },
+});

--- a/packages/ui/src/look/albums/utils.test.ts
+++ b/packages/ui/src/look/albums/utils.test.ts
@@ -16,16 +16,10 @@ const makeAlbum = (
 });
 
 describe('genAlbumLinkProps', () => {
-  it('uses the slug as the route param when present', () => {
-    const result = genAlbumLinkProps(makeAlbum({ slug: 'holiday' }));
-    expect(result).toEqual({
-      to: '/album/$albumId',
-      params: { albumId: 'holiday' },
-    });
-  });
-
-  it('falls back to the id when the slug is empty', () => {
-    const result = genAlbumLinkProps(makeAlbum({ id: 'album-9', slug: '' }));
+  it('uses the album id as the route param', () => {
+    const result = genAlbumLinkProps(
+      makeAlbum({ id: 'album-9', slug: 'holiday' }),
+    );
     expect(result).toEqual({
       to: '/album/$albumId',
       params: { albumId: 'album-9' },

--- a/packages/ui/src/look/albums/utils.ts
+++ b/packages/ui/src/look/albums/utils.ts
@@ -2,9 +2,11 @@ import type { TransformedAlbum } from 'core/look/query-hooks/types';
 
 const ALBUM_ROUTE = '/album/$albumId';
 
+// The route param is the album id (uuid): the detail route fetches by primary
+// key, so the id — not the slug — is what the URL must carry.
 const genAlbumLinkProps = (album: TransformedAlbum) => ({
   to: ALBUM_ROUTE,
-  params: { albumId: album.slug || album.id },
+  params: { albumId: album.id },
 });
 
 const formatPhotoCount = (count: number): string =>

--- a/packages/ui/src/look/home-page/utils.test.ts
+++ b/packages/ui/src/look/home-page/utils.test.ts
@@ -146,17 +146,9 @@ describe('resolveColumns', () => {
 });
 
 describe('genPhotoLinkProps', () => {
-  it('uses the slug as the route param when present', () => {
-    const result = genPhotoLinkProps(makePhoto('a', null, { slug: 'sunset' }));
-    expect(result).toEqual({
-      to: '/photo/$photoId',
-      params: { photoId: 'sunset' },
-    });
-  });
-
-  it('falls back to the id when the slug is null', () => {
+  it('uses the photo id as the route param', () => {
     const result = genPhotoLinkProps(
-      makePhoto('photo-1', null, { slug: null }),
+      makePhoto('photo-1', null, { slug: 'sunset' }),
     );
     expect(result).toEqual({
       to: '/photo/$photoId',

--- a/packages/ui/src/look/home-page/utils.ts
+++ b/packages/ui/src/look/home-page/utils.ts
@@ -127,9 +127,12 @@ const resolveColumns = (flags: ColumnBreakpointFlags): number => {
   return COLUMNS_BY_BREAKPOINT.xs;
 };
 
+// The route param is the photo id (uuid): the detail route fetches by primary
+// key and the lightbox matches the active photo by id, so the id — not the
+// slug — is what the URL must carry.
 const genPhotoLinkProps = (photo: TransformedPhoto) => ({
   to: PHOTO_ROUTE,
-  params: { photoId: photo.slug ?? photo.id },
+  params: { photoId: photo.id },
 });
 
 export {

--- a/packages/ui/src/look/home-page/utils.ts
+++ b/packages/ui/src/look/home-page/utils.ts
@@ -127,9 +127,9 @@ const resolveColumns = (flags: ColumnBreakpointFlags): number => {
   return COLUMNS_BY_BREAKPOINT.xs;
 };
 
-// The route param is the photo id (uuid): the detail route fetches by primary
-// key and the lightbox matches the active photo by id, so the id — not the
-// slug — is what the URL must carry.
+// The route param is the photo id (uuid): the timeline loads the photo list
+// and the lightbox matches the active photo by id, so the id — not the slug —
+// is what the URL must carry.
 const genPhotoLinkProps = (photo: TransformedPhoto) => ({
   to: PHOTO_ROUTE,
   params: { photoId: photo.id },


### PR DESCRIPTION
## Summary

Wires `apps/look` to the core hooks and `packages/ui` containers built across SWO-609–615 — the app now shows live images behind login (SWO-616, the last sub-issue of SWO-607). Every route is a thin wrapper: it pulls a core hook and hands `queryRs` + `Link` to the matching presentational container. No UI logic is added in the app.

- **`/` and `/photo/$photoId`** — one shared `TimelinePage`: the month-grouped virtualized timeline with the full-screen `PhotoLightbox` open over it. The URL's `photoId` selects the active photo; the lightbox steps ←/→ through the same in-memory list (no refetch). An unknown id (bad link, deleted photo, load error) leaves the lightbox closed on the grid — the same not-found grace the album route has — instead of a blank dialog.
- **`/albums`** — `useLoadAlbums` → `AlbumListContainer`.
- **`/album/$albumId`** — `useLoadAlbumDetail` → `AlbumDetailContainer`.
- **Layout** — the shared `Header` with Photos/Albums nav in its actions slot and avatar → sign-out. All routes are wrapped in `AuthRoute`; logged-out users see the login dialog.

### The one cross-package change, and why

The two link generators (`genPhotoLinkProps`, `genAlbumLinkProps`) now emit the entity **id** (uuid) as the route param instead of `slug ?? id`. This is the integration point where the parallel work meets: the detail routes fetch by primary key (`playlist_by_pk(id)`) and the lightbox matches the active photo by `photo.id`, so the URL must carry the id, not the slug. Emitting the slug (which for seed data is a filename-derived string like `10639`) would break every deep-link and album-detail fetch. Their unit tests are updated to assert the id-based params.

### Design notes (deliberate, for v1)

- **Not `useLoadPhotoDetail`.** The photo route uses `useLoadPhotos` (the whole list, a React Query cache hit from the timeline) because the lightbox is list-based — it needs the neighbours for ←/→. `useLoadPhotoDetail` (SWO-611) is currently unused; left in place rather than removed in a wiring PR — candidate for a follow-up (deep-link fetch optimization, or removal).
- Album-detail photo clicks open the **global** timeline lightbox, not the album subset — acceptable for v1.
- `look` is intentionally **not** added to the shared site switcher (`SiteChoices`) here — that's a cross-app change (every app's switcher config) and belongs in its own ticket.

## Test plan

- [x] `pnpm --filter look build` — TanStack router plugin regenerates `routeTree.gen.ts`; all four route chunks emit
- [x] `pnpm --filter look typecheck` passes
- [x] `pnpm --filter ui test` — `genPhotoLinkProps` / `genAlbumLinkProps` assert id-based params; all look tests pass
- [x] `biome lint` clean on the new app files
- [ ] Manual E2E against prod Hasura once logged in: timeline loads the `5cmPerSecond` seed images, a photo opens full-screen with ←/→, albums list + detail work, a bad `/photo/<id>` URL lands on the grid

Refs SWO-616.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticated navigation between the Photos timeline and Albums.
  * Added album listing and album detail pages.
  * Added photo detail URLs with full-screen lightbox viewing and navigation.
  * Added shared user profile and sign-out controls.

* **Bug Fixes**
  * Updated album and photo links to use reliable IDs, improving detail-page loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->