### PR TITLE
[WIP] fix(look): restore content scroll and stop avatar-click sign-out (SWO-617)

### DIFF
--- a/apps/look/src/components/layout/index.tsx
+++ b/apps/look/src/components/layout/index.tsx
@@ -1,6 +1,7 @@
 import { Link, useLocation } from '@tanstack/react-router';
 import { Auth } from 'core';
-import type { ReactNode } from 'react';
+import { type ReactNode, useState } from 'react';
+import { LookSettingsPanel } from 'ui/look/settings';
 import { FullPageContainer } from 'ui/universal/containers/full-page';
 import { Header } from 'ui/universal/header';
 
@@ -46,14 +47,21 @@ const Nav = () => {
 const Layout = (props: LayoutProps) => {
   const { children } = props;
   const { user, signOut } = Auth.useAuthContext();
+  const [settingsOpen, setSettingsOpen] = useState(false);
 
   return (
     <FullPageContainer>
       <Header
         LinkComponent={Link}
         user={user}
-        onAvatarClick={signOut}
+        onAvatarClick={() => setSettingsOpen(true)}
         actions={<Nav />}
+      />
+      <LookSettingsPanel
+        open={settingsOpen}
+        onClose={() => setSettingsOpen(false)}
+        onSignOut={signOut}
+        userName={user?.name}
       />
       {children}
     </FullPageContainer>

--- a/packages/ui/src/look/albums/album-detail/index.tsx
+++ b/packages/ui/src/look/albums/album-detail/index.tsx
@@ -12,7 +12,15 @@ import { PhotoSkeleton } from '../../photos/photo-card/skeleton';
 import type { LinkComponentType } from '../../photos/types';
 import { formatPhotoCount } from '../utils';
 
-const CONTENT_SX = { py: 4, px: { xs: 2, sm: 3 } } as const;
+// Own scroll region: the page shell is a fixed-height column with overflow
+// hidden, so this flex child must shrink (`minHeight: 0`) and scroll itself.
+const CONTENT_SX = {
+  flex: 1,
+  minHeight: 0,
+  overflow: 'auto',
+  py: 4,
+  px: { xs: 2, sm: 3 },
+} as const;
 const SKELETON_KEYS = Array.from(
   { length: 12 },
   (_, index) => `album-photo-skeleton-${index}`,

--- a/packages/ui/src/look/albums/album-list/index.tsx
+++ b/packages/ui/src/look/albums/album-list/index.tsx
@@ -12,7 +12,15 @@ const SKELETON_KEYS = Array.from(
   { length: 8 },
   (_, index) => `album-skeleton-${index}`,
 );
-const GRID_SX = { py: 4, px: { xs: 2, sm: 3 } } as const;
+// Own scroll region: the page shell is a fixed-height column with overflow
+// hidden, so this flex child must shrink (`minHeight: 0`) and scroll itself.
+const GRID_SX = {
+  flex: 1,
+  minHeight: 0,
+  overflow: 'auto',
+  py: 4,
+  px: { xs: 2, sm: 3 },
+} as const;
 // Album tiles are larger than photo tiles: 2 up on phones, 3 on tablets, 4 on
 // desktop (out of MUI Grid's default 12 columns).
 const ALBUM_GRID_SIZE = { xs: 6, sm: 4, md: 3 } as const;

--- a/packages/ui/src/look/home-page/container/index.tsx
+++ b/packages/ui/src/look/home-page/container/index.tsx
@@ -27,9 +27,12 @@ const SKELETON_KEYS = Array.from(
   { length: 18 },
   (_, index) => `skeleton-${index}`,
 );
+// `minHeight: 0` lets this flex child shrink below its (very tall, virtualized)
+// content so `overflow: auto` scrolls it — without it the default
+// `min-height: auto` makes it grow past the fixed-height page and get clipped.
 const SCROLL_SX = {
   flex: 1,
-  height: 0,
+  minHeight: 0,
   py: 3,
   px: { xs: 2, sm: 3 },
   overflow: 'auto',

--- a/packages/ui/src/look/settings/index.tsx
+++ b/packages/ui/src/look/settings/index.tsx
@@ -1,0 +1,43 @@
+import LogoutIcon from '@mui/icons-material/Logout';
+import Button from '@mui/material/Button';
+import Drawer from '@mui/material/Drawer';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+
+interface LookSettingsPanelProps {
+  open: boolean;
+  onClose: () => void;
+  onSignOut: () => void;
+  userName?: string | null;
+}
+
+const PANEL_SX = { width: { xs: '80vw', sm: '20rem' }, p: 3 };
+
+// The account drawer for Look — a view app, so the avatar opens this panel
+// (sign-out, and settings later) instead of signing out on a single click.
+const LookSettingsPanel = (props: LookSettingsPanelProps) => {
+  const { open, onClose, onSignOut, userName } = props;
+
+  return (
+    <Drawer anchor="right" open={open} onClose={onClose}>
+      <Stack sx={PANEL_SX} spacing={3}>
+        {userName ? (
+          <Typography variant="subtitle1" color="text.primary">
+            {userName}
+          </Typography>
+        ) : null}
+        <Button
+          variant="outlined"
+          color="inherit"
+          startIcon={<LogoutIcon />}
+          onClick={onSignOut}
+          fullWidth
+        >
+          Sign out
+        </Button>
+      </Stack>
+    </Drawer>
+  );
+};
+
+export { LookSettingsPanel };


### PR DESCRIPTION
## Summary

Two usability bugs surfaced once the Look app was wired end-to-end and run locally:

1. **Content clipped, couldn't scroll.** `FullPageContainer` is a fixed-height (`100vh`, `overflow: hidden`) flex column, so each page must own an inner scroll region. The timeline, album list, and album detail containers were missing `minHeight: 0` (the flexbox `min-height: auto` trap), so `overflow: auto` never engaged and long content was clipped below the fold.
2. **Clicking the avatar signed you out.** The header avatar was wired straight to `signOut`. Replaced with a proper account drawer (`LookSettingsPanel`) — the avatar opens it, and sign-out lives on a button inside, matching the view-app pattern.

## Changes

- **New** `packages/ui/src/look/settings/index.tsx` — `LookSettingsPanel`, a right-anchored MUI Drawer showing the user name + a Sign out button.
- `apps/look/src/components/layout/index.tsx` — local `settingsOpen` state; avatar `onClick` opens the drawer instead of signing out; renders the panel.
- `packages/ui/src/look/home-page/container/index.tsx`, `albums/album-list`, `albums/album-detail` — add `minHeight: 0` so each container scrolls within the fixed-height shell.

## Test plan

- `pnpm --filter look typecheck` — clean
- `pnpm --filter look build` — clean
- Biome — clean (3 pre-existing `noNonNullAssertion` warnings in look's `main.tsx`/config, unrelated)
- Verified live on `localhost:3006`: timeline, album list, and album detail all scroll; avatar opens the account drawer; Sign out from the drawer works.

Refs SWO-617

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a settings panel accessible by selecting the user avatar.
  - Displayed the signed-in user’s name and added a sign-out action.

- **Bug Fixes**
  - Improved scrolling behavior for album lists, album details, and photo timelines.
  - Prevented content from overflowing within flexible layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->