### PR TITLE
[WIP] feat(look): virtualize the album-detail photo grid (SWO-618)

### DIFF
--- a/packages/ui/src/look/albums/album-detail/index.tsx
+++ b/packages/ui/src/look/albums/album-detail/index.tsx
@@ -5,13 +5,24 @@ import Stack from '@mui/material/Stack';
 import { useTheme } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
 import useMediaQuery from '@mui/material/useMediaQuery';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import type { useLoadAlbumDetail } from 'core/look/query-hooks/albums';
+import { useMemo, useRef } from 'react';
 import { genPhotoLinkProps, resolveColumns } from '../../home-page/utils';
 import { PhotoCard } from '../../photos/photo-card';
 import { PhotoSkeleton } from '../../photos/photo-card/skeleton';
 import type { LinkComponentType } from '../../photos/types';
-import { formatPhotoCount } from '../utils';
+import { buildAlbumRows, formatPhotoCount } from '../utils';
 
+// Row-height estimates (px) the virtualizer starts from before it measures the
+// real DOM heights — a virtualizer API contract, not a styling value.
+const HEADER_ROW_ESTIMATE = 96;
+const PHOTO_ROW_ESTIMATE = 220;
+const OVERSCAN = 6;
+const SKELETON_KEYS = Array.from(
+  { length: 12 },
+  (_, index) => `album-photo-skeleton-${index}`,
+);
 // Own scroll region: the page shell is a fixed-height column with overflow
 // hidden, so this flex child must shrink (`minHeight: 0`) and scroll itself.
 const CONTENT_SX = {
@@ -21,10 +32,6 @@ const CONTENT_SX = {
   py: 4,
   px: { xs: 2, sm: 3 },
 } as const;
-const SKELETON_KEYS = Array.from(
-  { length: 12 },
-  (_, index) => `album-photo-skeleton-${index}`,
-);
 
 interface AlbumDetailContainerProps {
   queryRs: ReturnType<typeof useLoadAlbumDetail>;
@@ -32,11 +39,13 @@ interface AlbumDetailContainerProps {
 }
 
 // One album's photos, in stored position order. Reuses the same square PhotoCard
-// + blur placeholder as the timeline, but laid out as a plain responsive grid —
-// an album is a bounded, ordered set, so it is not month-grouped or virtualized.
+// + blur placeholder as the timeline, and the same virtualized row model so a
+// large album mounts only the visible rows — but as a flat header + grid (no
+// month grouping), since an album is a single ordered set.
 const AlbumDetailContainer = (props: AlbumDetailContainerProps) => {
   const { queryRs, LinkComponent } = props;
   const { album, isLoading } = queryRs;
+  const scrollRef = useRef<HTMLDivElement>(null);
   const theme = useTheme();
 
   const columns = resolveColumns({
@@ -44,6 +53,22 @@ const AlbumDetailContainer = (props: AlbumDetailContainerProps) => {
     isMd: useMediaQuery(theme.breakpoints.up('md')),
     isLg: useMediaQuery(theme.breakpoints.up('lg')),
     isXl: useMediaQuery(theme.breakpoints.up('xl')),
+  });
+
+  const rows = useMemo(
+    () => buildAlbumRows(album?.photos ?? [], columns),
+    [album?.photos, columns],
+  );
+
+  const virtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: (index) =>
+      rows[index].type === 'photos' ? PHOTO_ROW_ESTIMATE : HEADER_ROW_ESTIMATE,
+    // Key by the stable row key, not the default index, so a measured height
+    // isn't misapplied to a different row when the column count re-chunks.
+    getItemKey: (index) => rows[index].key,
+    overscan: OVERSCAN,
   });
 
   if (isLoading) {
@@ -77,39 +102,68 @@ const AlbumDetailContainer = (props: AlbumDetailContainerProps) => {
   }
 
   return (
-    <Container maxWidth={false} sx={CONTENT_SX}>
-      <Stack sx={{ gap: 0.5, pb: 3 }}>
-        <Typography variant="h5" component="h1" color="text.primary">
-          {album.title}
-        </Typography>
-        {album.description ? (
-          <Typography variant="body1" color="text.secondary">
-            {album.description}
-          </Typography>
-        ) : null}
-        <Typography variant="body2" color="text.secondary">
-          {formatPhotoCount(album.photos.length)}
-        </Typography>
+    <Container ref={scrollRef} maxWidth={false} sx={CONTENT_SX}>
+      <Stack
+        sx={{
+          position: 'relative',
+          width: '100%',
+          height: `${virtualizer.getTotalSize()}px`,
+        }}
+      >
+        {virtualizer.getVirtualItems().map((virtualRow) => {
+          const row = rows[virtualRow.index];
+          return (
+            <Stack
+              key={virtualRow.key}
+              data-index={virtualRow.index}
+              ref={virtualizer.measureElement}
+              sx={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                transform: `translateY(${virtualRow.start}px)`,
+              }}
+            >
+              {row.type === 'header' ? (
+                <Stack sx={{ gap: 0.5, pb: 3 }}>
+                  <Typography variant="h5" component="h1" color="text.primary">
+                    {album.title}
+                  </Typography>
+                  {album.description ? (
+                    <Typography variant="body1" color="text.secondary">
+                      {album.description}
+                    </Typography>
+                  ) : null}
+                  <Typography variant="body2" color="text.secondary">
+                    {formatPhotoCount(album.photos.length)}
+                  </Typography>
+                </Stack>
+              ) : null}
+              {row.type === 'empty' ? (
+                <Stack sx={{ alignItems: 'center', py: 8 }}>
+                  <Typography variant="body1" color="text.secondary">
+                    No photos in this album
+                  </Typography>
+                </Stack>
+              ) : null}
+              {row.type === 'photos' ? (
+                <Grid container spacing={1} columns={columns} sx={{ pb: 1 }}>
+                  {row.photos.map((photo) => (
+                    <Grid size={1} key={photo.id}>
+                      <PhotoCard
+                        photo={photo}
+                        LinkComponent={LinkComponent}
+                        linkProps={genPhotoLinkProps(photo)}
+                      />
+                    </Grid>
+                  ))}
+                </Grid>
+              ) : null}
+            </Stack>
+          );
+        })}
       </Stack>
-      {album.photos.length === 0 ? (
-        <Stack sx={{ alignItems: 'center', py: 8 }}>
-          <Typography variant="body1" color="text.secondary">
-            No photos in this album
-          </Typography>
-        </Stack>
-      ) : (
-        <Grid container spacing={1} columns={columns}>
-          {album.photos.map((photo) => (
-            <Grid size={1} key={photo.id}>
-              <PhotoCard
-                photo={photo}
-                LinkComponent={LinkComponent}
-                linkProps={genPhotoLinkProps(photo)}
-              />
-            </Grid>
-          ))}
-        </Grid>
-      )}
     </Container>
   );
 };

--- a/packages/ui/src/look/albums/utils.test.ts
+++ b/packages/ui/src/look/albums/utils.test.ts
@@ -1,6 +1,9 @@
-import type { TransformedAlbum } from 'core/look/query-hooks/types';
+import type {
+  TransformedAlbum,
+  TransformedPhoto,
+} from 'core/look/query-hooks/types';
 import { describe, expect, it } from 'vitest';
-import { formatPhotoCount, genAlbumLinkProps } from './utils';
+import { buildAlbumRows, formatPhotoCount, genAlbumLinkProps } from './utils';
 
 const makeAlbum = (
   overrides: Partial<TransformedAlbum> = {},
@@ -14,6 +17,19 @@ const makeAlbum = (
   photos: [],
   ...overrides,
 });
+
+const makePhotos = (count: number): TransformedPhoto[] =>
+  Array.from({ length: count }, (_, index) => ({
+    id: `photo-${index}`,
+    source: `https://example.com/${index}.jpg`,
+    mediumUrl: `https://example.com/${index}-medium.jpg`,
+    thumbnailUrl: `https://example.com/${index}-thumb.jpg`,
+    blurHash: 'LEHV6nWB2yk8pyo0adR*.7kCMdnj',
+    width: 1200,
+    height: 1200,
+    takenAt: '2023-06-01T10:00:00Z',
+    slug: `photo-${index}`,
+  }));
 
 describe('genAlbumLinkProps', () => {
   it('uses the album id as the route param', () => {
@@ -38,5 +54,35 @@ describe('formatPhotoCount', () => {
 
   it('uses the plural noun for many photos', () => {
     expect(formatPhotoCount(87)).toBe('87 photos');
+  });
+});
+
+describe('buildAlbumRows', () => {
+  it('emits a header row then an empty row when there are no photos', () => {
+    const rows = buildAlbumRows([], 3);
+    expect(rows).toEqual([
+      { type: 'header', key: 'album-header' },
+      { type: 'empty', key: 'album-empty' },
+    ]);
+  });
+
+  it('chunks photos into rows of `columns` after the header, in order', () => {
+    const photos = makePhotos(5);
+    const rows = buildAlbumRows(photos, 2);
+    expect(rows).toEqual([
+      { type: 'header', key: 'album-header' },
+      { type: 'photos', key: 'album-row-0', photos: [photos[0], photos[1]] },
+      { type: 'photos', key: 'album-row-1', photos: [photos[2], photos[3]] },
+      { type: 'photos', key: 'album-row-2', photos: [photos[4]] },
+    ]);
+  });
+
+  it('puts every photo in a single row when columns exceeds the count', () => {
+    const photos = makePhotos(3);
+    const rows = buildAlbumRows(photos, 6);
+    expect(rows).toEqual([
+      { type: 'header', key: 'album-header' },
+      { type: 'photos', key: 'album-row-0', photos },
+    ]);
   });
 });

--- a/packages/ui/src/look/albums/utils.ts
+++ b/packages/ui/src/look/albums/utils.ts
@@ -1,6 +1,36 @@
-import type { TransformedAlbum } from 'core/look/query-hooks/types';
+import type {
+  TransformedAlbum,
+  TransformedPhoto,
+} from 'core/look/query-hooks/types';
+import { chunk } from '../home-page/utils';
 
 const ALBUM_ROUTE = '/album/$albumId';
+
+// The virtualizer's row model for one album: a single header row (album title,
+// description, count), then either an empty-state row or the photos chunked into
+// rows of `columns`. Unlike the timeline there is no month grouping — an album
+// is one ordered set — so this is a flat list with a fixed leading header.
+type AlbumRow =
+  | { type: 'header'; key: string }
+  | { type: 'empty'; key: string }
+  | { type: 'photos'; key: string; photos: TransformedPhoto[] };
+
+const buildAlbumRows = (
+  photos: TransformedPhoto[],
+  columns: number,
+): AlbumRow[] => {
+  const rows: AlbumRow[] = [{ type: 'header', key: 'album-header' }];
+
+  if (photos.length === 0) {
+    rows.push({ type: 'empty', key: 'album-empty' });
+    return rows;
+  }
+
+  chunk(photos, columns).forEach((rowPhotos, index) => {
+    rows.push({ type: 'photos', key: `album-row-${index}`, photos: rowPhotos });
+  });
+  return rows;
+};
 
 // The route param is the album id (uuid): the detail route fetches by primary
 // key, so the id — not the slug — is what the URL must carry.
@@ -12,4 +42,5 @@ const genAlbumLinkProps = (album: TransformedAlbum) => ({
 const formatPhotoCount = (count: number): string =>
   count === 1 ? '1 photo' : `${count} photos`;
 
-export { formatPhotoCount, genAlbumLinkProps };
+export { buildAlbumRows, formatPhotoCount, genAlbumLinkProps };
+export type { AlbumRow };

--- a/packages/ui/src/look/home-page/utils.ts
+++ b/packages/ui/src/look/home-page/utils.ts
@@ -137,6 +137,7 @@ const genPhotoLinkProps = (photo: TransformedPhoto) => ({
 
 export {
   buildTimelineRows,
+  chunk,
   genPhotoLinkProps,
   groupPhotosByMonth,
   resolveColumns,


### PR DESCRIPTION
## Summary

Album detail rendered **every** photo at once as a plain MUI `Grid`. On a large album that mounts hundreds of `PhotoCard`s, hurting scroll performance and memory. The home timeline already solved this with `@tanstack/react-virtual`; this applies the same proven pattern to album detail.

Follow-up to #544 / SWO-617 (which noted album detail wasn't virtualized).

## Approach

Reuse the timeline's virtualizer row model, but **flat** — an album is a single ordered set, so there's no month grouping:

- `buildAlbumRows(photos, columns)` (in `albums/utils.ts`) → a header row, then either an empty-state row (0 photos) or photo rows chunked by column count. Pure and unit-tested.
- The album header (title/description/count) is virtual **row 0**, measured dynamically via `measureElement` — same mechanism as timeline month headers. No `scrollMargin`, no header duplication, one loaded-album render path.
- Extracted the shared `chunk` helper from `home-page/utils` (albums already import `resolveColumns`/`genPhotoLinkProps` from there) rather than duplicating it.

## Changes

- `packages/ui/src/look/albums/album-detail/index.tsx` — `useVirtualizer` over the album rows; loading/not-found early-returns unchanged.
- `packages/ui/src/look/albums/utils.ts` — new `buildAlbumRows` + `AlbumRow` type.
- `packages/ui/src/look/albums/utils.test.ts` — tests for `buildAlbumRows` (empty, multi-row chunking, columns > count).
- `packages/ui/src/look/home-page/utils.ts` — export the existing `chunk` helper.

## Test plan

- `pnpm --filter ui typecheck` / `pnpm --filter look typecheck` — clean
- `pnpm --filter core build` / `pnpm --filter ui build` — clean
- `pnpm --filter ui test` — 609 passed (incl. new `buildAlbumRows` cases)
- Biome — clean

Refs SWO-618

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved album photo browsing with virtualized scrolling, helping large albums load and navigate more smoothly.
  - Album layouts now measure content dynamically for more consistent positioning across varying photo sizes.

- **User Experience**
  - Preserved album headers, photo ordering, responsive rows, and empty-album states while improving rendering efficiency.
  - Enhanced handling of albums with different photo counts and layout widths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->