### PR TITLE
fix(look): solid black lightbox with visible controls (SWO-619)

### DIFF
--- a/packages/ui/src/look/photo-detail-page/containers/index.tsx
+++ b/packages/ui/src/look/photo-detail-page/containers/index.tsx
@@ -32,6 +32,13 @@ const EDGE_BUTTON_SX = (theme: Theme) => ({
   color: CONTROL_COLOR,
   bgcolor: alpha(theme.palette.common.white, 0.12),
   '&:hover': { bgcolor: alpha(theme.palette.common.white, 0.24) },
+  // At the first/last photo the button is disabled; keep it dimmed-but-visible
+  // on black instead of MUI's default action.disabled, a near-invisible dark
+  // token here.
+  '&.Mui-disabled': {
+    color: alpha(theme.palette.common.white, 0.3),
+    bgcolor: alpha(theme.palette.common.white, 0.06),
+  },
 });
 
 // Full-screen photo viewer. MUI Dialog gives the focus trap, backdrop, and
@@ -82,9 +89,17 @@ const PhotoLightbox = (props: PhotoLightboxProps) => {
       slotProps={{
         // Solid black viewer, like Google Photos: the photo is letterboxed
         // (object-fit: contain) and everything around it stays pure black in
-        // both themes, not the app's tinted surface color.
+        // both themes, not the app's tinted surface color. Clear the
+        // glassmorphism paper's border + backdrop blur so nothing frames the
+        // black.
         paper: {
-          sx: { bgcolor: 'common.black', backgroundImage: 'none' },
+          sx: {
+            bgcolor: 'common.black',
+            backgroundImage: 'none',
+            border: 'none',
+            backdropFilter: 'none',
+            WebkitBackdropFilter: 'none',
+          },
         },
       }}
     >

--- a/packages/ui/src/look/photo-detail-page/containers/index.tsx
+++ b/packages/ui/src/look/photo-detail-page/containers/index.tsx
@@ -107,13 +107,17 @@ const PhotoLightbox = (props: PhotoLightboxProps) => {
         <IconButton
           aria-label="Close"
           onClick={onClose}
-          sx={{
+          sx={(theme) => ({
             position: 'absolute',
             top: 1,
             right: 1,
             zIndex: 1,
             color: CONTROL_COLOR,
-          }}
+            // Bare white X at rest (like Google Photos), but a translucent-white
+            // hover so it gets the same feedback as the nav arrows on black —
+            // the theme default hover is a near-invisible dark tint here.
+            '&:hover': { bgcolor: alpha(theme.palette.common.white, 0.24) },
+          })}
         >
           <CloseIcon />
         </IconButton>

--- a/packages/ui/src/look/photo-detail-page/containers/index.tsx
+++ b/packages/ui/src/look/photo-detail-page/containers/index.tsx
@@ -4,6 +4,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import Dialog from '@mui/material/Dialog';
 import IconButton from '@mui/material/IconButton';
 import Stack from '@mui/material/Stack';
+import { alpha, type Theme } from '@mui/material/styles';
 import type { TransformedPhoto } from 'core/look/query-hooks/types';
 import { useEffect, useMemo } from 'react';
 import { LightboxImage } from '../lightbox-image';
@@ -17,15 +18,21 @@ interface PhotoLightboxProps {
   onActiveIdChange: (id: string) => void;
 }
 
-const EDGE_BUTTON_SX = {
+// The viewer is always solid black (see the paper sx below), so the controls
+// can't use theme text/action tokens — those follow the app's light/dark mode
+// and vanish against black. Pin them to white with a translucent-white hover
+// scrim, derived from the palette (not a raw rgba), so they read on black and
+// over any photo.
+const CONTROL_COLOR = 'common.white';
+const EDGE_BUTTON_SX = (theme: Theme) => ({
   position: 'absolute',
   top: '50%',
   transform: 'translateY(-50%)',
   zIndex: 1,
-  color: 'text.primary',
-  bgcolor: 'action.hover',
-  '&:hover': { bgcolor: 'action.selected' },
-} as const;
+  color: CONTROL_COLOR,
+  bgcolor: alpha(theme.palette.common.white, 0.12),
+  '&:hover': { bgcolor: alpha(theme.palette.common.white, 0.24) },
+});
 
 // Full-screen photo viewer. MUI Dialog gives the focus trap, backdrop, and
 // Escape-to-close; a document-level key listener adds ←/→ navigation. Navigation
@@ -73,8 +80,11 @@ const PhotoLightbox = (props: PhotoLightboxProps) => {
       fullScreen
       aria-label="Photo viewer"
       slotProps={{
+        // Solid black viewer, like Google Photos: the photo is letterboxed
+        // (object-fit: contain) and everything around it stays pure black in
+        // both themes, not the app's tinted surface color.
         paper: {
-          sx: { bgcolor: 'background.default', backgroundImage: 'none' },
+          sx: { bgcolor: 'common.black', backgroundImage: 'none' },
         },
       }}
     >
@@ -87,7 +97,7 @@ const PhotoLightbox = (props: PhotoLightboxProps) => {
             top: 1,
             right: 1,
             zIndex: 1,
-            color: 'text.primary',
+            color: CONTROL_COLOR,
           }}
         >
           <CloseIcon />
@@ -96,7 +106,7 @@ const PhotoLightbox = (props: PhotoLightboxProps) => {
           aria-label="Previous photo"
           onClick={() => prevId && onActiveIdChange(prevId)}
           disabled={!prevId}
-          sx={{ ...EDGE_BUTTON_SX, left: 1 }}
+          sx={[EDGE_BUTTON_SX, { left: 1 }]}
         >
           <ChevronLeftIcon />
         </IconButton>
@@ -104,7 +114,7 @@ const PhotoLightbox = (props: PhotoLightboxProps) => {
           aria-label="Next photo"
           onClick={() => nextId && onActiveIdChange(nextId)}
           disabled={!nextId}
-          sx={{ ...EDGE_BUTTON_SX, right: 1 }}
+          sx={[EDGE_BUTTON_SX, { right: 1 }]}
         >
           <ChevronRightIcon />
         </IconButton>

--- a/packages/ui/src/look/photo-detail-page/lightbox-image/index.tsx
+++ b/packages/ui/src/look/photo-detail-page/lightbox-image/index.tsx
@@ -1,27 +1,24 @@
 import Stack from '@mui/material/Stack';
 import type { TransformedPhoto } from 'core/look/query-hooks/types';
-import { useEffect, useMemo, useRef, useState } from 'react';
-import { blurHashToDataUri } from '../../photos/blur-image/blurhash';
+import { useEffect, useRef, useState } from 'react';
 import { LightboxImageLayer } from './styled';
 
 interface LightboxImageProps {
   photo: TransformedPhoto;
 }
 
-// Progressive full-screen image: the blur-hash placeholder shows immediately,
-// the medium resolution fades in over it, then the full original fades in on
-// top once loaded. Mount this keyed by photo id so each photo starts fresh.
+// Progressive full-screen image: the medium resolution fades in first, then the
+// full original fades in on top once loaded. Both are letterboxed
+// (object-fit: contain) over the viewer's solid black, so the margins stay
+// black. No blur-hash background here — decoded to a fixed square it can't match
+// a photo's aspect ratio and would bleed into the black letterbox. Mount this
+// keyed by photo id so each photo starts fresh.
 const LightboxImage = (props: LightboxImageProps) => {
   const { photo } = props;
   const previewRef = useRef<HTMLImageElement>(null);
   const fullRef = useRef<HTMLImageElement>(null);
   const [previewLoaded, setPreviewLoaded] = useState(false);
   const [fullLoaded, setFullLoaded] = useState(false);
-
-  const placeholder = useMemo(
-    () => blurHashToDataUri(photo.blurHash),
-    [photo.blurHash],
-  );
 
   const previewSrc = photo.mediumUrl || photo.thumbnailUrl;
   const fullSrc = photo.source || previewSrc;
@@ -42,17 +39,7 @@ const LightboxImage = (props: LightboxImageProps) => {
   }, []);
 
   return (
-    <Stack
-      sx={{
-        position: 'relative',
-        width: '100%',
-        height: '100%',
-        backgroundImage: placeholder ? `url(${placeholder})` : undefined,
-        backgroundSize: 'contain',
-        backgroundRepeat: 'no-repeat',
-        backgroundPosition: 'center',
-      }}
-    >
+    <Stack sx={{ position: 'relative', width: '100%', height: '100%' }}>
       <LightboxImageLayer
         ref={previewRef}
         src={previewSrc}


### PR DESCRIPTION
## Summary

The full-screen photo viewer had a bad backdrop: the themed (glassmorphism purple) surface color, plus the blur-hash placeholder painted as a `contain` CSS background — decoded to a fixed 32×32 square, it bled into the letterbox bars on wide photos. Make the viewer **solid black like Google Photos**, with controls that stay visible on black in any theme.

Verified live on localhost before shipping.

## Changes

- **`photo-detail-page/containers/index.tsx`**
  - Dialog paper → `bgcolor: common.black`; also clear the theme paper's `border` + `backdropFilter` so nothing frames the black.
  - Close + prev/next controls pinned to white (`common.white`) with a palette-derived translucent hover (`alpha(common.white, …)`), since `text.primary`/`action.*` follow the app's light/dark mode and vanished on black.
  - Disabled (first/last photo) arrows kept dimmed-but-visible instead of MUI's default near-invisible `action.disabled` on black.
- **`photo-detail-page/lightbox-image/index.tsx`**
  - Remove the blur-hash background (the source of the letterbox bleed). The photo (medium → full) fades in over black; the card grid keeps its own blur-up, unaffected.

## Test plan

- `pnpm --filter ui typecheck` — clean
- `pnpm --filter core build` / `pnpm --filter ui build` — clean
- Biome — clean
- Verified on `localhost:3006`: open a photo → black margins, no purple tint, no blur bleed; ✕ and ‹ › read clearly on black; arrows dim (not vanish) at the ends.

Refs SWO-619

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Updated the photo lightbox with a solid black background and improved white control contrast.
  - Refined navigation and close button styling, including clearer disabled states.
  - Removed glassmorphism effects from the full-screen viewer.
  - Simplified image loading by removing blur-hash placeholders while preserving smooth preview-to-full-image transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->