### PR TITLE
[WIP] feat(look): add Cloudflare Workers static-assets config (SWO-621)

### DIFF
--- a/apps/look/wrangler.jsonc
+++ b/apps/look/wrangler.jsonc
@@ -1,0 +1,14 @@
+{
+  // Cloudflare Workers config for the Look app — static-assets Worker (no server code).
+  // Built by Workers Builds from `main`; see SWO-621. The four existing apps stay on
+  // Cloudflare Pages for now (migration tracked in SWO-622).
+  "name": "look",
+  "compatibility_date": "2026-07-25",
+  "assets": {
+    // Vite build output for `look`; resolved relative to this file (apps/look/dist).
+    "directory": "./dist",
+    // SPA routing: serve index.html (200) for client-side routes like /albums
+    // instead of 404-ing, so TanStack Router can take over.
+    "not_found_handling": "single-page-application"
+  }
+}


### PR DESCRIPTION
## Summary

Adds `apps/look/wrangler.jsonc` so the **Look** app can deploy on **Cloudflare Workers** (static assets). Look's feature code is already merged (SWO-607), but it had no deploy target — the Worker build was failing with *"Missing entry-point to Worker script or to assets directory"* because this config didn't exist.

The config points the Worker at Look's Vite `dist` output and turns on SPA routing so client-side routes (e.g. `/albums`) serve `index.html` instead of 404ing.

Look is the first app on Workers; the four existing apps (main/watch/til/listen) stay on Cloudflare Pages for now — migrating them is tracked in **SWO-622**.

Refs SWO-621. Unblocks SWO-608 (prod verification).

## Not in this PR (dashboard / separate steps)

These are configured on the Cloudflare side, not in code:
- Workers Builds settings — build: `pnpm install && pnpx turbo build -F look`, deploy: `npx wrangler deploy --config apps/look/wrangler.jsonc`
- Service named `look`
- Env vars (same set as watch/listen)
- Custom domain `look.shinabr2.com`

## Test plan

- [x] `turbo build -F look` emits `apps/look/dist/index.html` + `assets/` (verified locally)
- [x] `wrangler.jsonc` `assets.directory: ./dist` resolves to `apps/look/dist`
- [ ] After merge, Workers Builds deploys from `main` without the missing-assets error
- [ ] `look.shinabr2.com` loads the app; deep-linking a client route (e.g. `/albums`) does not 404
