### PR TITLE
[WIP] fix(look): pin sign-out to bottom of account drawer

### DIFF
--- a/packages/ui/src/look/settings/index.tsx
+++ b/packages/ui/src/look/settings/index.tsx
@@ -1,6 +1,10 @@
 import LogoutIcon from '@mui/icons-material/Logout';
-import Button from '@mui/material/Button';
+import Divider from '@mui/material/Divider';
 import Drawer from '@mui/material/Drawer';
+import List from '@mui/material/List';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 
@@ -11,30 +15,34 @@ interface LookSettingsPanelProps {
   userName?: string | null;
 }
 
-const PANEL_SX = { width: { xs: '80vw', sm: '20rem' }, p: 3 };
+const PANEL_SX = {
+  width: { xs: '80vw', sm: '20rem' },
+  height: '100%',
+};
 
 // The account drawer for Look — a view app, so the avatar opens this panel
 // (sign-out, and settings later) instead of signing out on a single click.
+// Sign-out is pinned to the bottom as a menu row, matching the Watch drawer.
 const LookSettingsPanel = (props: LookSettingsPanelProps) => {
   const { open, onClose, onSignOut, userName } = props;
 
   return (
     <Drawer anchor="right" open={open} onClose={onClose}>
-      <Stack sx={PANEL_SX} spacing={3}>
+      <Stack sx={PANEL_SX}>
         {userName ? (
-          <Typography variant="subtitle1" color="text.primary">
+          <Typography variant="subtitle1" color="text.primary" sx={{ p: 3 }}>
             {userName}
           </Typography>
         ) : null}
-        <Button
-          variant="outlined"
-          color="inherit"
-          startIcon={<LogoutIcon />}
-          onClick={onSignOut}
-          fullWidth
-        >
-          Sign out
-        </Button>
+        <Divider sx={{ mt: 'auto' }} />
+        <List>
+          <ListItemButton onClick={onSignOut}>
+            <ListItemIcon>
+              <LogoutIcon />
+            </ListItemIcon>
+            <ListItemText primary="Sign out" />
+          </ListItemButton>
+        </List>
       </Stack>
     </Drawer>
   );


### PR DESCRIPTION
## Summary

In the Look app, the account panel that slides out from the avatar now keeps **Sign out** pinned to the very bottom as a menu row with a logout icon, matching the Watch app's drawer. Before, sign-out sat right at the top as an outlined button. Fixes SWO-623.

## Test plan

- [ ] Open the **Look** app, log in, and tap your avatar (top right). The panel slides in from the right.
- [ ] Your name is at the top; **Sign out** (with a logout icon) sits pinned at the bottom of the panel, above nothing else.
- [ ] Tapping **Sign out** logs you out.
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Look settings panel layout for improved spacing and visual organization.
  * Redesigned the sign-out action as a menu row with an icon and label.
  * Added a divider to separate account information from the sign-out option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->