### PR TITLE
feat(look): render video in grid and lightbox

### DIFF
--- a/packages/ui/src/look/photo-detail-page/containers/index.tsx
+++ b/packages/ui/src/look/photo-detail-page/containers/index.tsx
@@ -8,6 +8,7 @@ import { alpha, type Theme } from '@mui/material/styles';
 import type { TransformedPhoto } from 'core/look/query-hooks/types';
 import { useEffect, useMemo } from 'react';
 import { LightboxImage } from '../lightbox-image';
+import { LightboxVideo } from '../lightbox-video';
 import { stepPhotoId } from '../utils';
 
 interface PhotoLightboxProps {
@@ -138,7 +139,11 @@ const PhotoLightbox = (props: PhotoLightboxProps) => {
           <ChevronRightIcon />
         </IconButton>
         {activePhoto ? (
-          <LightboxImage key={activePhoto.id} photo={activePhoto} />
+          activePhoto.type === 'video' ? (
+            <LightboxVideo key={activePhoto.id} photo={activePhoto} />
+          ) : (
+            <LightboxImage key={activePhoto.id} photo={activePhoto} />
+          )
         ) : null}
       </Stack>
     </Dialog>

--- a/packages/ui/src/look/photo-detail-page/lightbox-video/index.tsx
+++ b/packages/ui/src/look/photo-detail-page/lightbox-video/index.tsx
@@ -1,0 +1,64 @@
+import Box from '@mui/material/Box';
+import type { TransformedPhoto } from 'core/look/query-hooks/types';
+import { lazy, Suspense } from 'react';
+
+interface LightboxVideoProps {
+  photo: TransformedPhoto;
+}
+
+// react-player is CJS; rolldown-vite's prebundle exposes its exports object as
+// the ESM default instead of unwrapping `.default`, so unwrap both shapes here
+// (same pattern as the watch player).
+const ReactPlayer = lazy(async () => {
+  const mod = await import('react-player');
+  const unwrapped = (mod.default as unknown as { default?: typeof mod.default })
+    .default;
+  return { default: unwrapped ?? mod.default };
+});
+
+// Full-screen video for the viewer. A look video's `source` is an HLS manifest
+// (.m3u8); react-player handles it via hls.js. The player fills the viewer and
+// the <video> is letterboxed (object-fit: contain) over the solid black, so the
+// margins stay black exactly like the still-image lightbox. `light` shows the
+// poster with a play glyph first, so opening a video doesn't autoplay or eagerly
+// fetch the stream — the viewer taps to start. Mount keyed by photo id so each
+// video starts fresh.
+const LightboxVideo = (props: LightboxVideoProps) => {
+  const { photo } = props;
+  const poster = photo.mediumUrl || photo.thumbnailUrl;
+
+  return (
+    <Box
+      sx={{
+        position: 'relative',
+        width: '100%',
+        height: '100%',
+        '& video': { objectFit: 'contain' },
+      }}
+    >
+      <Suspense fallback={null}>
+        <ReactPlayer
+          url={photo.source ?? undefined}
+          controls={true}
+          width="100%"
+          height="100%"
+          light={poster || false}
+          playing
+          config={{
+            file: {
+              // Pin a current hls.js — react-player's default (1.1.4) mis-builds
+              // the AAC decoder config for some streams, producing garbled audio
+              // on desktop. Same fix as the watch player.
+              hlsVersion: '1.5.20',
+              attributes: {
+                playsInline: true, // Important for iOS
+              },
+            },
+          }}
+        />
+      </Suspense>
+    </Box>
+  );
+};
+
+export { LightboxVideo };

--- a/packages/ui/src/look/photos/format-duration.test.ts
+++ b/packages/ui/src/look/photos/format-duration.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { formatDuration } from './format-duration';
+
+describe('formatDuration', () => {
+  it('returns an empty string for missing, non-positive, or non-finite values', () => {
+    expect(formatDuration(null)).toBe('');
+    expect(formatDuration(undefined)).toBe('');
+    expect(formatDuration(0)).toBe('');
+    expect(formatDuration(-5)).toBe('');
+    expect(formatDuration(Number.NaN)).toBe('');
+    expect(formatDuration(Number.POSITIVE_INFINITY)).toBe('');
+  });
+
+  it('formats sub-hour durations as m:ss with a zero-padded seconds field', () => {
+    expect(formatDuration(5)).toBe('0:05');
+    expect(formatDuration(9)).toBe('0:09');
+    expect(formatDuration(65)).toBe('1:05');
+    expect(formatDuration(600)).toBe('10:00');
+  });
+
+  it('formats hour-plus durations as h:mm:ss with zero-padded minutes and seconds', () => {
+    expect(formatDuration(3600)).toBe('1:00:00');
+    expect(formatDuration(3661)).toBe('1:01:01');
+    expect(formatDuration(7325)).toBe('2:02:05');
+  });
+
+  it('floors fractional seconds', () => {
+    expect(formatDuration(65.9)).toBe('1:05');
+  });
+});

--- a/packages/ui/src/look/photos/format-duration.ts
+++ b/packages/ui/src/look/photos/format-duration.ts
@@ -1,0 +1,21 @@
+// Formats a video's length in seconds as a compact badge label: `m:ss`, or
+// `h:mm:ss` once it passes an hour. Returns '' for missing / non-positive /
+// non-finite values so callers can simply skip rendering the badge (an image
+// has no duration).
+const formatDuration = (seconds: number | null | undefined): string => {
+  if (!seconds || seconds <= 0 || !Number.isFinite(seconds)) {
+    return '';
+  }
+
+  const total = Math.floor(seconds);
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  const secs = total % 60;
+  const pad = (value: number) => String(value).padStart(2, '0');
+
+  return hours > 0
+    ? `${hours}:${pad(minutes)}:${pad(secs)}`
+    : `${minutes}:${pad(secs)}`;
+};
+
+export { formatDuration };

--- a/packages/ui/src/look/photos/photo-card/index.tsx
+++ b/packages/ui/src/look/photos/photo-card/index.tsx
@@ -1,6 +1,9 @@
+import PlayArrowRoundedIcon from '@mui/icons-material/PlayArrowRounded';
+import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import type { TransformedPhoto } from 'core/look/query-hooks/types';
 import { BlurImage } from '../blur-image';
+import { formatDuration } from '../format-duration';
 import type { LinkComponentType, PhotoLinkProps } from '../types';
 
 interface PhotoCardProps {
@@ -13,6 +16,9 @@ interface PhotoCardProps {
 // gives the grid uniform, shift-free rows; the image is layered inside.
 const PhotoCard = (props: PhotoCardProps) => {
   const { photo, LinkComponent, linkProps } = props;
+
+  const isVideo = photo.type === 'video';
+  const durationLabel = formatDuration(photo.duration);
 
   const card = (
     <Card
@@ -32,6 +38,52 @@ const PhotoCard = (props: PhotoCardProps) => {
         alt={photo.slug ?? 'Photo'}
         blurHash={photo.blurHash}
       />
+      {isVideo ? (
+        <>
+          {/* Centered play glyph so a video reads as playable at a glance in the
+              grid. Pinned white on a translucent-black disc so it stays legible
+              over any thumbnail, in both themes. */}
+          <Box
+            sx={{
+              position: 'absolute',
+              top: '50%',
+              left: '50%',
+              transform: 'translate(-50%, -50%)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 44,
+              height: 44,
+              borderRadius: '50%',
+              color: 'common.white',
+              bgcolor: 'rgba(0, 0, 0, 0.55)',
+              pointerEvents: 'none',
+            }}
+          >
+            <PlayArrowRoundedIcon />
+          </Box>
+          {durationLabel ? (
+            <Box
+              sx={{
+                position: 'absolute',
+                bottom: 8,
+                right: 8,
+                px: 0.75,
+                py: 0.25,
+                borderRadius: 1,
+                bgcolor: 'rgba(0, 0, 0, 0.75)',
+                color: 'common.white',
+                fontSize: 12,
+                fontWeight: 500,
+                lineHeight: 1.4,
+                pointerEvents: 'none',
+              }}
+            >
+              {durationLabel}
+            </Box>
+          ) : null}
+        </>
+      ) : null}
     </Card>
   );
 


### PR DESCRIPTION
## Summary

The Look library now holds videos as well as images (a video is stored as a `type='video'` photo whose `source` is an HLS manifest). This wires the frontend to actually show them:

- **Grid** — a video tile gets a centered play glyph and a duration badge (bottom-right, `m:ss` / `h:mm:ss`), so it reads as playable at a glance, like Google Photos.
- **Lightbox** — opening a video plays it with `react-player` (HLS via hls.js) instead of trying to render the `.m3u8` manifest as an `<img>`. Poster-first: it shows the medium/thumbnail with a play button and only loads the stream when tapped. Letterboxed on the same solid black as the still-image viewer.

Images are completely unaffected — the grid tile and lightbox only branch when `photo.type === 'video'`.

Reuses the proven watch-player setup: the react-player CJS-unwrap lazy import, `hlsVersion: '1.5.20'` (the default 1.1.4 garbles audio on some streams), and `playsInline` for iOS. `react-player` is already a `packages/ui` dependency.

## Test plan

- `formatDuration` has unit coverage for missing/zero/negative/NaN/Infinity → `''`, sub-hour → `m:ss`, hour-plus → `h:mm:ss`, and fractional flooring (30/30 ui look tests pass).
- Typecheck (`tsconfig.typecheck.json`) and biome both clean on the changed files.
- Manual (once a video is ingested): a video tile in the timeline shows the play glyph + duration; opening it plays the HLS stream in the black viewer; an image tile/lightbox is unchanged; ←/→ still navigate between mixed image/video items.