### PR TITLE
feat(look): ingest Takeout videos via a shared video-ingest module

### DIFF
--- a/apps/backend/src/cli/google-photos.ts
+++ b/apps/backend/src/cli/google-photos.ts
@@ -35,6 +35,13 @@
  * `photos/<userId>/<photoId>/{original,medium,thumb}.<ext>`, and the `insert_photos_one`
  * row — matches `image.ts` exactly, so photos ingested by either tool look identical.
  *
+ * VIDEOS in the export are ingested too: each is transcoded to HLS + a poster
+ * frame via the shared `./lib/video-ingest` pipeline and stored as a `type='video'`
+ * photo (HLS manifest in `source`, `duration` in seconds) under the same
+ * `photos/<userId>/<photoId>/` prefix. Date, dedup, and album linking are identical
+ * to an image — a video is "just another type of image". Formats Look still can't
+ * take (HEIC, …) are skipped and reported.
+ *
  * Dedup is by owner + slug: a photo Google placed in both an album and a year
  * bucket (Takeout duplicates it into each folder) is uploaded once; the second
  * sighting just links the existing photo into the album. Re-runs are idempotent.
@@ -64,6 +71,11 @@ import { GraphQLClient } from 'graphql-request';
 import sharp from 'sharp';
 import { v4 as uuidv4 } from 'uuid';
 import { flushThenExit } from './cli-exit';
+import {
+  isVideoFile,
+  probeVideo,
+  processVideoToStorage,
+} from './lib/video-ingest';
 
 // ─── Validation exit ─────────────────────────────────────────────────────────
 
@@ -262,25 +274,41 @@ const deriveMeta = (filePath: string): ImageMeta => {
   return { ext, slug };
 };
 
-/** The images in one folder, in filename (natural/numeric) order — the album order. */
-const imagesInFolder = (dir: string): string[] =>
-  readdirSync(dir)
-    .filter(
-      (name) =>
-        IMAGE_EXTENSIONS.has(path.extname(name).toLowerCase()) &&
-        statSync(path.join(dir, name)).isFile(),
-    )
-    .map((name) => path.join(dir, name))
-    // `img2` sorts before `img10`, not after — and this ordering is the album's.
-    .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+type MediaKind = 'image' | 'video';
 
-/** Media Look can't take (video, HEIC, …), for the skipped-files report. */
+interface MediaFile {
+  path: string;
+  kind: MediaKind;
+}
+
+/**
+ * The ingestable media in one folder — images AND videos — in filename
+ * (natural/numeric) order, which is the album order. Each file is tagged with its
+ * kind so the caller dispatches to the image or the video ingest path. Videos are
+ * transcoded to HLS (see `./lib/video-ingest`); everything else about a video —
+ * date, dedup, album linking — is identical to an image.
+ */
+const mediaInFolder = (dir: string): MediaFile[] =>
+  readdirSync(dir)
+    .filter((name) => statSync(path.join(dir, name)).isFile())
+    .map((name) => path.join(dir, name))
+    .flatMap((full): MediaFile[] => {
+      const ext = path.extname(full).toLowerCase();
+      if (IMAGE_EXTENSIONS.has(ext)) return [{ path: full, kind: 'image' }];
+      if (isVideoFile(full)) return [{ path: full, kind: 'video' }];
+      return [];
+    })
+    // `img2` sorts before `img10`, not after — and this ordering is the album's.
+    .sort((a, b) => a.path.localeCompare(b.path, undefined, { numeric: true }));
+
+/** Media Look can't take (HEIC, …) — neither image nor video — for the skipped-files report. */
 const skippedMediaInFolder = (dir: string): string[] =>
   readdirSync(dir).filter((name) => {
     const ext = path.extname(name).toLowerCase();
     return (
       ext !== '.json' &&
       !IMAGE_EXTENSIONS.has(ext) &&
+      !isVideoFile(name) &&
       statSync(path.join(dir, name)).isFile()
     );
   });
@@ -602,6 +630,47 @@ const createPhoto = async (
   return data.insert_photos_one.id;
 };
 
+interface VideoPhotoRow {
+  id: string;
+  /** HLS manifest URL (playlist.m3u8) — stored in `source`, exactly like a video. */
+  source: string;
+  mediumUrl: string;
+  thumbnailUrl: string;
+  blurHash: string;
+  width: number;
+  height: number;
+  duration: number;
+  takenAt: string;
+  slug: string;
+}
+
+/** Insert one `type='video'` photos row (HLS manifest in `source`, poster + duration). */
+const createVideoPhoto = async (
+  args: GooglePhotosArgs,
+  row: VideoPhotoRow,
+): Promise<string> => {
+  const data = await makeClient(args).request<{
+    insert_photos_one: { id: string };
+  }>(CREATE_PHOTO_MUTATION, {
+    object: {
+      id: row.id,
+      type: 'video',
+      source: row.source,
+      mediumUrl: row.mediumUrl,
+      thumbnailUrl: row.thumbnailUrl,
+      blurHash: row.blurHash,
+      width: row.width,
+      height: row.height,
+      duration: row.duration,
+      takenAt: row.takenAt,
+      slug: row.slug,
+      user_id: args.userId,
+      public: args.isPublic,
+    },
+  });
+  return data.insert_photos_one.id;
+};
+
 /**
  * Find-or-create the `site='look'` album by slug, returning its id and the next
  * free position. The cover (`thumbnail_url`) is set to the first photo's thumb
@@ -789,6 +858,114 @@ const ingestOne = async (
   return { outcome: 'created', photo: { id, thumbnailUrl }, source };
 };
 
+/**
+ * Ingest one video: resolve date (the same Takeout-aware sidecar → EXIF → mtime
+ * order as an image — Google writes the sidecar for videos too), dup-check by
+ * owner+slug, transcode to HLS + poster via the shared pipeline, upload, and
+ * insert a `type='video'` row. The container's own duration/date from the probe
+ * is not used here: the sidecar is the better date, exactly as for images.
+ */
+const ingestVideo = async (
+  args: GooglePhotosArgs,
+  bucket: Bucket | undefined,
+  localFile: string,
+  seenSlugs: Set<string>,
+): Promise<IngestResult> => {
+  let meta: ImageMeta;
+  try {
+    meta = deriveMeta(localFile);
+  } catch (error) {
+    console.error(
+      `  ✗ ${path.basename(localFile)}: ${(error as Error).message}`,
+    );
+    return { outcome: 'failed' };
+  }
+
+  // Same per-folder slug guard as images: two DISTINCT files that slugify alike
+  // would otherwise silently swallow the second — surface it so the operator
+  // renames one. (A video and an image that share a basename, e.g. `clip.jpg` +
+  // `clip.mp4`, also collide here by design — one photo per slug.)
+  if (seenSlugs.has(meta.slug)) {
+    console.error(
+      `  ✗ ${path.basename(localFile)}: slug "${meta.slug}" collides with another file in this folder — rename to ingest both.`,
+    );
+    return { outcome: 'failed' };
+  }
+  seenSlugs.add(meta.slug);
+
+  if (args.dryRun) {
+    const { takenAt, source } = await resolveTakenAt(localFile);
+    // Duration is best-effort in a dry run — a probe failure shouldn't abort the
+    // preview, so report the date regardless.
+    let duration: number | undefined;
+    try {
+      duration = (await probeVideo(localFile)).duration;
+    } catch {
+      duration = undefined;
+    }
+    console.log(`  • ${path.basename(localFile)} (slug: ${meta.slug}) [video]`);
+    console.log(
+      `      taken_at: ${takenAt}  [${source}]${duration != null ? `  duration: ${duration}s` : ''}`,
+    );
+    return { outcome: 'dry-run', source };
+  }
+
+  // Already imported (same owner + slug): reuse the existing row for album linking.
+  if (!args.skipDb) {
+    const existing = await findPhoto(args, meta.slug);
+    if (existing) {
+      console.warn(`  ⚠ ${meta.slug} — already imported, reusing.`);
+      return { outcome: 'existed', photo: existing };
+    }
+  }
+
+  // bucket is only undefined on a dry run, which returned above.
+  if (!bucket) throw new Error('Storage bucket not initialised.');
+
+  const { takenAt, source: dateSource } = await resolveTakenAt(localFile);
+  const photoId = uuidv4();
+  const storageDir = `photos/${args.userId}/${photoId}`;
+
+  const result = await processVideoToStorage({
+    bucket,
+    bucketName: args.gcpBucket,
+    inputPath: localFile,
+    storageDir,
+  });
+  console.log(
+    `  ↑ ${storageDir}/ (${result.hlsFileCount} HLS files + poster medium/thumb)`,
+  );
+
+  if (args.skipDb) {
+    console.log(
+      `  ✓ ${meta.slug} (${result.width}×${result.height}, ${result.duration}s video, uploaded, DB skipped)`,
+    );
+    return { outcome: 'created', source: dateSource };
+  }
+
+  const id = await createVideoPhoto(args, {
+    id: photoId,
+    source: result.source,
+    mediumUrl: result.mediumUrl,
+    thumbnailUrl: result.thumbnailUrl,
+    blurHash: result.blurHash,
+    width: result.width,
+    height: result.height,
+    duration: result.duration,
+    takenAt,
+    slug: meta.slug,
+  });
+
+  console.log(
+    `  ✓ ${meta.slug} (${result.width}×${result.height}, ${result.duration}s video) [${dateSource}] → ${id}`,
+  );
+  return {
+    outcome: 'created',
+    photo: { id, thumbnailUrl: result.thumbnailUrl },
+    source: dateSource,
+  };
+};
+
 // ─── Per-folder ingest ───────────────────────────────────────────────────────
 
 interface Tallies {
@@ -813,16 +990,18 @@ const ingestFolder = async (
   albumName: string | null,
   tallies: Tallies,
 ): Promise<void> => {
-  const files = imagesInFolder(folder);
+  const media = mediaInFolder(folder);
+  const imageCount = media.filter((item) => item.kind === 'image').length;
+  const videoCount = media.length - imageCount;
 
-  for (const media of skippedMediaInFolder(folder)) {
-    const ext = path.extname(media).toLowerCase();
+  for (const skipped of skippedMediaInFolder(folder)) {
+    const ext = path.extname(skipped).toLowerCase();
     tallies.skipped[ext] = (tallies.skipped[ext] ?? 0) + 1;
   }
 
   const label = albumName ? `album "${albumName}"` : 'loose (no album)';
   console.log(
-    `\n── ${path.basename(folder)} → ${label} (${files.length} images)`,
+    `\n── ${path.basename(folder)} → ${label} (${imageCount} images, ${videoCount} videos)`,
   );
 
   // Per-folder slug guard: only catches two DISTINCT files in THIS folder that
@@ -830,14 +1009,17 @@ const ingestFolder = async (
   const seenSlugs = new Set<string>();
   let albumState: { id: string; nextPosition: number } | undefined;
 
-  for (const localFile of files) {
+  for (const item of media) {
     // One bad file in a folder shouldn't abort the rest — record it and move on.
     try {
-      const result = await ingestOne(args, bucket, localFile, seenSlugs);
+      const result =
+        item.kind === 'video'
+          ? await ingestVideo(args, bucket, item.path, seenSlugs)
+          : await ingestOne(args, bucket, item.path, seenSlugs);
       if (result.source) tallies.source[result.source] += 1;
       if (result.source === 'mtime') {
         tallies.mtimeFallback.push(
-          path.relative(args.takeout ?? folder, localFile),
+          path.relative(args.takeout ?? folder, item.path),
         );
       }
 
@@ -866,7 +1048,7 @@ const ingestFolder = async (
       tallies.outcome[result.outcome] += 1;
     } catch (error) {
       console.error(
-        `  ✗ ${path.basename(localFile)}: ${(error as Error).message}`,
+        `  ✗ ${path.basename(item.path)}: ${(error as Error).message}`,
       );
       tallies.outcome.failed += 1;
     }
@@ -986,7 +1168,7 @@ const handle = async (rawArgs: string[]): Promise<void> => {
   if (skippedEntries.length > 0) {
     const summary = skippedEntries.map(([ext, n]) => `${n}${ext}`).join(', ');
     console.log(
-      `\n  Skipped non-image media (Look is images-only): ${summary}`,
+      `\n  Skipped unsupported media (neither image nor video): ${summary}`,
     );
   }
 
@@ -1051,6 +1233,9 @@ const main = (): void => {
     );
     console.log('');
     console.log('Dates resolve: sidecar photoTakenTime → EXIF → file mtime.');
+    console.log(
+      'Videos in the export are transcoded to HLS and stored as type=video photos.',
+    );
     return;
   }
 

--- a/apps/backend/src/cli/google-photos.ts
+++ b/apps/backend/src/cli/google-photos.ts
@@ -39,8 +39,10 @@
  * frame via the shared `./lib/video-ingest` pipeline and stored as a `type='video'`
  * photo (HLS manifest in `source`, `duration` in seconds) under the same
  * `photos/<userId>/<photoId>/` prefix. Date, dedup, and album linking are identical
- * to an image — a video is "just another type of image". Formats Look still can't
- * take (HEIC, …) are skipped and reported.
+ * to an image — a video is "just another type of image". A Live/Motion Photo (a
+ * still plus a same-named video clip) ingests as just the still; the paired video is
+ * its motion component and is skipped, exactly as before video support. Formats Look
+ * still can't take (HEIC, …) are skipped and reported.
  *
  * Dedup is by owner + slug: a photo Google placed in both an album and a year
  * bucket (Takeout duplicates it into each folder) is uploaded once; the second
@@ -299,7 +301,17 @@ const mediaInFolder = (dir: string): MediaFile[] =>
       return [];
     })
     // `img2` sorts before `img10`, not after — and this ordering is the album's.
-    .sort((a, b) => a.path.localeCompare(b.path, undefined, { numeric: true }));
+    // On a tie in the base name (a Live/Motion Photo's still + its video clip share
+    // one, e.g. `IMG_1.jpg` + `IMG_1.mp4`), the image sorts first so the STILL takes
+    // the slug and the video is recognised as its motion component (skipped below).
+    .sort((a, b) => {
+      const baseA = path.basename(a.path, path.extname(a.path));
+      const baseB = path.basename(b.path, path.extname(b.path));
+      const byBase = baseA.localeCompare(baseB, undefined, { numeric: true });
+      if (byBase !== 0) return byBase;
+      if (a.kind !== b.kind) return a.kind === 'image' ? -1 : 1;
+      return a.path.localeCompare(b.path, undefined, { numeric: true });
+    });
 
 /** Media Look can't take (HEIC, …) — neither image nor video — for the skipped-files report. */
 const skippedMediaInFolder = (dir: string): string[] =>
@@ -746,7 +758,7 @@ const linkPhoto = async (
 
 // ─── Per-file ingest ─────────────────────────────────────────────────────────
 
-type IngestOutcome = 'created' | 'existed' | 'dry-run' | 'failed';
+type IngestOutcome = 'created' | 'existed' | 'skipped' | 'dry-run' | 'failed';
 
 interface IngestResult {
   outcome: IngestOutcome;
@@ -885,11 +897,17 @@ const ingestVideo = async (
   // would otherwise silently swallow the second — surface it so the operator
   // renames one. (A video and an image that share a basename, e.g. `clip.jpg` +
   // `clip.mp4`, also collide here by design — one photo per slug.)
+  // A video whose slug is already taken in this folder is, almost always, the
+  // motion component of a Live/Motion Photo whose still we just ingested (the
+  // still sorts first — see `mediaInFolder`). The still IS the photo, so skip the
+  // video: the same benign outcome it had before video support, not a failure that
+  // would fail the whole batch. (A genuine two-distinct-file collision is still
+  // surfaced by this ⚠ line for the operator to notice.)
   if (seenSlugs.has(meta.slug)) {
-    console.error(
-      `  ✗ ${path.basename(localFile)}: slug "${meta.slug}" collides with another file in this folder — rename to ingest both.`,
+    console.warn(
+      `  ⚠ ${meta.slug} — a still with this name was already ingested (likely a Live Photo); skipping the video.`,
     );
-    return { outcome: 'failed' };
+    return { outcome: 'skipped' };
   }
   seenSlugs.add(meta.slug);
 
@@ -1138,7 +1156,7 @@ const handle = async (rawArgs: string[]): Promise<void> => {
     : createStorage(args.gcpKeyPath).bucket(args.gcpBucket);
 
   const tallies: Tallies = {
-    outcome: { created: 0, existed: 0, 'dry-run': 0, failed: 0 },
+    outcome: { created: 0, existed: 0, skipped: 0, 'dry-run': 0, failed: 0 },
     source: { sidecar: 0, exif: 0, mtime: 0 },
     mtimeFallback: [],
     skipped: {},
@@ -1151,7 +1169,7 @@ const handle = async (rawArgs: string[]): Promise<void> => {
   // ─── Report ────────────────────────────────────────────────────────────────
   console.log('\n=== Done ===');
   console.log(
-    `  Created: ${tallies.outcome.created}  Existed: ${tallies.outcome.existed}  Planned: ${tallies.outcome['dry-run']}  Failed: ${tallies.outcome.failed}`,
+    `  Created: ${tallies.outcome.created}  Existed: ${tallies.outcome.existed}  Skipped: ${tallies.outcome.skipped}  Planned: ${tallies.outcome['dry-run']}  Failed: ${tallies.outcome.failed}`,
   );
   console.log(
     `  Dates → sidecar: ${tallies.source.sidecar}  exif: ${tallies.source.exif}  mtime: ${tallies.source.mtime}`,

--- a/apps/backend/src/cli/google-photos.ts
+++ b/apps/backend/src/cli/google-photos.ts
@@ -772,7 +772,7 @@ const ingestOne = async (
   args: GooglePhotosArgs,
   bucket: Bucket | undefined,
   localFile: string,
-  seenSlugs: Set<string>,
+  seenSlugs: Map<string, MediaKind>,
 ): Promise<IngestResult> => {
   let meta: ImageMeta;
   try {
@@ -803,7 +803,7 @@ const ingestOne = async (
     );
     return { outcome: 'failed' };
   }
-  seenSlugs.add(meta.slug);
+  seenSlugs.set(meta.slug, 'image');
 
   if (args.dryRun) {
     const { takenAt, source } = await resolveTakenAt(localFile);
@@ -881,7 +881,7 @@ const ingestVideo = async (
   args: GooglePhotosArgs,
   bucket: Bucket | undefined,
   localFile: string,
-  seenSlugs: Set<string>,
+  seenSlugs: Map<string, MediaKind>,
 ): Promise<IngestResult> => {
   let meta: ImageMeta;
   try {
@@ -897,19 +897,26 @@ const ingestVideo = async (
   // would otherwise silently swallow the second — surface it so the operator
   // renames one. (A video and an image that share a basename, e.g. `clip.jpg` +
   // `clip.mp4`, also collide here by design — one photo per slug.)
-  // A video whose slug is already taken in this folder is, almost always, the
-  // motion component of a Live/Motion Photo whose still we just ingested (the
-  // still sorts first — see `mediaInFolder`). The still IS the photo, so skip the
-  // video: the same benign outcome it had before video support, not a failure that
-  // would fail the whole batch. (A genuine two-distinct-file collision is still
-  // surfaced by this ⚠ line for the operator to notice.)
-  if (seenSlugs.has(meta.slug)) {
+  // What already claimed this slug in the folder decides the outcome. A prior
+  // IMAGE is the still of a Live/Motion Photo (the still sorts first — see
+  // `mediaInFolder`): the still IS the photo, so skip its motion video benignly,
+  // the same outcome it had before video support. A prior VIDEO is instead a
+  // genuine two-distinct-file collision — surface it loudly like the image path
+  // does, so the operator renames one rather than silently losing the second clip.
+  const priorKind = seenSlugs.get(meta.slug);
+  if (priorKind === 'image') {
     console.warn(
-      `  ⚠ ${meta.slug} — a still with this name was already ingested (likely a Live Photo); skipping the video.`,
+      `  ⚠ ${meta.slug} — a still with this name was already ingested (a Live Photo); skipping its motion video.`,
     );
     return { outcome: 'skipped' };
   }
-  seenSlugs.add(meta.slug);
+  if (priorKind === 'video') {
+    console.error(
+      `  ✗ ${path.basename(localFile)}: slug "${meta.slug}" collides with another video in this folder — rename to ingest both.`,
+    );
+    return { outcome: 'failed' };
+  }
+  seenSlugs.set(meta.slug, 'video');
 
   if (args.dryRun) {
     const { takenAt, source } = await resolveTakenAt(localFile);
@@ -1024,7 +1031,7 @@ const ingestFolder = async (
 
   // Per-folder slug guard: only catches two DISTINCT files in THIS folder that
   // slugify alike. The same photo appearing across folders is deduped by the DB.
-  const seenSlugs = new Set<string>();
+  const seenSlugs = new Map<string, MediaKind>();
   let albumState: { id: string; nextPosition: number } | undefined;
 
   for (const item of media) {

--- a/apps/backend/src/cli/lib/video-ingest.test.ts
+++ b/apps/backend/src/cli/lib/video-ingest.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { isVideoFile, VIDEO_EXTENSIONS } from './video-ingest';
+
+describe('isVideoFile', () => {
+  it('accepts every supported video container', () => {
+    for (const ext of VIDEO_EXTENSIONS) {
+      expect(isVideoFile(`clip${ext}`)).toBe(true);
+    }
+  });
+
+  it('is case-insensitive on the extension', () => {
+    expect(isVideoFile('CLIP.MP4')).toBe(true);
+    expect(isVideoFile('holiday.MoV')).toBe(true);
+  });
+
+  it('matches on a full path, using only the final extension', () => {
+    expect(isVideoFile('/Takeout/Google Photos/2019/clip.mp4')).toBe(true);
+    // A `.json` sidecar that merely mentions a video name is not a video.
+    expect(isVideoFile('clip.mp4.supplemental-metadata.json')).toBe(false);
+  });
+
+  it('rejects images and other non-video files', () => {
+    expect(isVideoFile('photo.jpg')).toBe(false);
+    expect(isVideoFile('photo.jpeg')).toBe(false);
+    expect(isVideoFile('shot.png')).toBe(false);
+    expect(isVideoFile('image.webp')).toBe(false);
+    expect(isVideoFile('live.heic')).toBe(false);
+    expect(isVideoFile('meta.json')).toBe(false);
+  });
+
+  it('rejects a file with no extension', () => {
+    expect(isVideoFile('README')).toBe(false);
+    expect(isVideoFile('/a/b/noext')).toBe(false);
+  });
+});

--- a/apps/backend/src/cli/lib/video-ingest.ts
+++ b/apps/backend/src/cli/lib/video-ingest.ts
@@ -120,7 +120,11 @@ const probeVideo = (inputPath: string): Promise<VideoMeta> =>
         parsed && !Number.isNaN(parsed.getTime())
           ? parsed.toISOString()
           : statSync(inputPath).mtime.toISOString();
-      resolve({ duration: Math.floor(duration), takenAt });
+      // Floor to whole seconds, but never below 1 for a real clip: a sub-second
+      // video (0 < d < 1) passed the truthiness guard above, and flooring it to 0
+      // would finalize the "bogus duration" the guard exists to prevent (and hide
+      // the duration badge in the UI). Clamp to a 1s minimum instead.
+      resolve({ duration: Math.max(1, Math.floor(duration)), takenAt });
     });
   });
 

--- a/apps/backend/src/cli/lib/video-ingest.ts
+++ b/apps/backend/src/cli/lib/video-ingest.ts
@@ -1,0 +1,382 @@
+/**
+ * Shared video-ingest pipeline for the Look CLIs.
+ *
+ * A Look video is "just another type of image": it lives in the same `photos`
+ * table as a still, discriminated by `type='video'`, with the HLS manifest URL in
+ * `source`, a poster frame driving the grid thumbnail + blur-hash, and `duration`
+ * in seconds. Turning a local video file into those GCS assets is identical work
+ * whether the source is a bare `--file` (look-video.ts) or a video sitting inside a
+ * Google Photos Takeout export (google-photos.ts) — so that work lives here, once.
+ *
+ * The transcode itself is the SHARED core: `processVideoToStorage` calls the very
+ * same `convertToHLS` the compute convert handler and `convert.ts` use (fMP4/CMAF:
+ * playlist.m3u8 + init.mp4 + .m4s), so the output format can never drift. Only the
+ * CLI-side plumbing — local temp dirs, poster frame, GCS upload, URL shapes — is
+ * here. Everything above the storage layer (dup-check, the `insert_photos_one` row,
+ * album linking, which date wins) stays in each CLI, because those differ per tool
+ * (e.g. Takeout resolves the date from a sidecar, not the container).
+ *
+ * This module is pure library code: no CLI side effects, no `main()`, no reads of
+ * `process.argv` or the shared config — every dependency is passed in explicitly,
+ * so it is safe to `import` from any CLI without executing anything.
+ */
+
+import { mkdtempSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import ffprobeInstaller from '@ffprobe-installer/ffprobe';
+import type { Bucket } from '@google-cloud/storage';
+import { encode } from 'blurhash';
+import ffmpeg from 'fluent-ffmpeg';
+import sharp from 'sharp';
+// The transcode is the SHARED core — the exact function the compute convert
+// handler runs (so the output format can never drift). convertToHLS sets the
+// ffmpeg binary path on the fluent-ffmpeg singleton at its module load; we set
+// ffprobe here for the duration/metadata probe below.
+import { convertToHLS } from 'src/services/videos/helpers/ffmpeg';
+
+ffmpeg.setFfprobePath(ffprobeInstaller.path);
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+const CACHE_CONTROL = 'public, max-age=31536000';
+/** The HLS manifest filename `convertToHLS` writes; stored in `photos.source`. */
+const PLAYLIST_NAME = 'playlist.m3u8';
+/** Poster rendition filenames written alongside the HLS output in GCS. */
+const POSTER_MEDIUM_NAME = 'medium.jpg';
+const POSTER_THUMB_NAME = 'thumb.jpg';
+/** Filename for the poster frame grabbed from the source video. */
+const FRAME_NAME = 'frame.jpg';
+
+/** Video containers ffmpeg can transcode for the Look library. */
+const VIDEO_EXTENSIONS = new Set([
+  '.mp4',
+  '.mov',
+  '.m4v',
+  '.webm',
+  '.mkv',
+  '.avi',
+]);
+
+/** Longest-edge caps for the two poster renditions (px), mirroring image.ts. */
+const THUMB_MAX_EDGE = 300;
+const MEDIUM_MAX_EDGE = 1200;
+/** Blur-hash: downscale to this longest edge, then encode with 4x4 components. */
+const BLURHASH_MAX_EDGE = 32;
+const BLURHASH_COMPONENTS_X = 4;
+const BLURHASH_COMPONENTS_Y = 4;
+
+/** Default parallel HLS-segment uploads when a caller doesn't specify. */
+const DEFAULT_UPLOAD_CONCURRENCY = 5;
+
+/**
+ * Per-extension content types for the HLS output. GCS auto-detection doesn't
+ * know `.m4s`, so we set them explicitly here (the convert output is fMP4).
+ */
+const CONTENT_TYPES: Record<string, string> = {
+  '.m3u8': 'application/vnd.apple.mpegurl',
+  '.m4s': 'video/iso.segment',
+  '.mp4': 'video/mp4',
+  '.ts': 'video/mp2t',
+};
+
+/** True when a file's extension is a video container this pipeline can ingest. */
+const isVideoFile = (filePath: string): boolean =>
+  VIDEO_EXTENSIONS.has(path.extname(filePath).toLowerCase());
+
+// ─── ffprobe (duration + date taken) ─────────────────────────────────────────
+
+interface VideoMeta {
+  /** Whole-second duration; finalizing a row with a bogus duration is worse than stopping. */
+  duration: number;
+  /** ISO date-taken: the container's creation_time if present, else the file's mtime. */
+  takenAt: string;
+}
+
+/**
+ * Probe a video for its duration and best-effort capture date. The date is a
+ * fallback only — a caller with a better source (e.g. a Takeout sidecar) should
+ * prefer its own and ignore `takenAt`.
+ */
+const probeVideo = (inputPath: string): Promise<VideoMeta> =>
+  new Promise((resolve, reject) => {
+    ffmpeg.ffprobe(inputPath, (err, metadata) => {
+      if (err) {
+        reject(new Error(`ffprobe failed for ${inputPath}: ${err.message}`));
+        return;
+      }
+      const duration = metadata?.format?.duration;
+      if (!duration) {
+        reject(new Error(`Could not determine duration for ${inputPath}`));
+        return;
+      }
+      // Prefer the container's recorded capture time; fall back to the file mtime
+      // (many downloaded/exported clips carry no creation_time tag).
+      const creationTime = metadata?.format?.tags?.creation_time;
+      const parsed =
+        typeof creationTime === 'string' ? new Date(creationTime) : undefined;
+      const takenAt =
+        parsed && !Number.isNaN(parsed.getTime())
+          ? parsed.toISOString()
+          : statSync(inputPath).mtime.toISOString();
+      resolve({ duration: Math.floor(duration), takenAt });
+    });
+  });
+
+// ─── HLS transcode + poster frame (self-cleaning temp dirs) ──────────────────
+
+/**
+ * Convert a local video to HLS into a fresh temp dir, delegating the actual
+ * transcode to the SHARED `convertToHLS` core. Only the temp-dir lifecycle is
+ * CLI-local. Returns the output dir and a cleanup(); self-cleans on failure so a
+ * mid-transcode error never orphans the just-created dir.
+ */
+const convertLocalToHls = async (
+  inputPath: string,
+): Promise<{ outputDir: string; cleanup: () => Promise<void> }> => {
+  // mkdtemp creates the dir (convertToHLS writes playlist.m3u8 into it but does
+  // not create it). convertToHLS requires absolute input + output paths.
+  const outputDir = mkdtempSync(path.join(os.tmpdir(), 'sworld-look-video-'));
+  try {
+    await convertToHLS(path.resolve(inputPath), outputDir);
+  } catch (error) {
+    await rm(outputDir, { recursive: true, force: true });
+    throw error;
+  }
+  return {
+    outputDir,
+    cleanup: async () => {
+      await rm(outputDir, { recursive: true, force: true });
+    },
+  };
+};
+
+/**
+ * Grab a single JPEG frame from the source video as the poster. Written to a
+ * standalone temp dir (NOT the HLS output dir) so it is never uploaded verbatim —
+ * only the derived medium/thumb renditions are. `atSeconds` is clamped below the
+ * duration so we never seek past the end (which yields no frame). Returns the
+ * frame path and cleanup(); self-cleans on failure.
+ */
+const extractPosterFrame = async (
+  inputPath: string,
+  duration: number,
+): Promise<{ framePath: string; cleanup: () => Promise<void> }> => {
+  const frameDir = mkdtempSync(path.join(os.tmpdir(), 'sworld-look-poster-'));
+  const at = Math.min(1, Math.max(duration - 1, 0));
+  try {
+    await new Promise<void>((resolve, reject) => {
+      ffmpeg(inputPath)
+        .on('end', () => resolve())
+        .on('error', (err) =>
+          reject(new Error(`Poster extraction failed: ${err.message}`)),
+        )
+        .screenshots({
+          timestamps: [at],
+          filename: FRAME_NAME,
+          folder: frameDir,
+        });
+    });
+  } catch (error) {
+    await rm(frameDir, { recursive: true, force: true });
+    throw error;
+  }
+  return {
+    framePath: path.join(frameDir, FRAME_NAME),
+    cleanup: async () => {
+      await rm(frameDir, { recursive: true, force: true });
+    },
+  };
+};
+
+// ─── Poster renditions (sharp + blurhash), mirroring image.ts ────────────────
+
+interface Poster {
+  width: number;
+  height: number;
+  blurHash: string;
+  medium: Buffer;
+  thumb: Buffer;
+}
+
+/** Resize longest edge to `maxEdge`, preserving aspect ratio, never upscaling. */
+const resizeLongestEdge = (input: Buffer, maxEdge: number): Promise<Buffer> =>
+  sharp(input)
+    .resize(maxEdge, maxEdge, { fit: 'inside', withoutEnlargement: true })
+    .jpeg()
+    .toBuffer();
+
+/** Encode a blur-hash from a tiny downscaled RGBA version of the frame. */
+const encodeBlurHash = async (input: Buffer): Promise<string> => {
+  const { data, info } = await sharp(input)
+    .raw()
+    .ensureAlpha()
+    .resize(BLURHASH_MAX_EDGE, BLURHASH_MAX_EDGE, { fit: 'inside' })
+    .toBuffer({ resolveWithObject: true });
+  return encode(
+    new Uint8ClampedArray(data.buffer, data.byteOffset, data.byteLength),
+    info.width,
+    info.height,
+    BLURHASH_COMPONENTS_X,
+    BLURHASH_COMPONENTS_Y,
+  );
+};
+
+/** Read dimensions + generate the medium, thumb, and blur-hash from a poster frame. */
+const buildPoster = async (frame: Buffer): Promise<Poster> => {
+  const meta = await sharp(frame).metadata();
+  if (!meta.width || !meta.height) {
+    throw new Error('Could not read poster frame dimensions.');
+  }
+  // The frame comes straight out of ffmpeg at the video's display resolution, so
+  // its pixel dimensions ARE the video's — no EXIF orientation to reconcile.
+  const [medium, thumb, blurHash] = await Promise.all([
+    resizeLongestEdge(frame, MEDIUM_MAX_EDGE),
+    resizeLongestEdge(frame, THUMB_MAX_EDGE),
+    encodeBlurHash(frame),
+  ]);
+  return { width: meta.width, height: meta.height, blurHash, medium, thumb };
+};
+
+// ─── GCS upload helpers ──────────────────────────────────────────────────────
+
+const getDownloadUrl = (bucketName: string, storagePath: string): string =>
+  `https://storage.googleapis.com/${bucketName}/${storagePath}`;
+
+/** Upload every file in a flat directory to `storagePath/`, with correct content-types. */
+const uploadDir = async (
+  bucket: Bucket,
+  localDir: string,
+  storagePath: string,
+  concurrency: number,
+): Promise<number> => {
+  const files = readdirSync(localDir).filter((name) =>
+    statSync(path.join(localDir, name)).isFile(),
+  );
+  let next = 0;
+  const worker = async () => {
+    while (next < files.length) {
+      const name = files[next++];
+      const contentType = CONTENT_TYPES[path.extname(name).toLowerCase()];
+      await bucket.upload(path.join(localDir, name), {
+        destination: `${storagePath}/${name}`,
+        resumable: false,
+        metadata: {
+          cacheControl: CACHE_CONTROL,
+          ...(contentType ? { contentType } : {}),
+        },
+      });
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, files.length) }, worker),
+  );
+  return files.length;
+};
+
+/** Upload one in-memory rendition buffer to `storagePath`. */
+const uploadBuffer = async (
+  bucket: Bucket,
+  buffer: Buffer,
+  storagePath: string,
+  contentType: string,
+): Promise<void> => {
+  await bucket.file(storagePath).save(buffer, {
+    resumable: false,
+    metadata: { cacheControl: CACHE_CONTROL, contentType },
+  });
+};
+
+// ─── The whole storage pipeline ──────────────────────────────────────────────
+
+interface ProcessVideoOptions {
+  bucket: Bucket;
+  /** Bucket name for building the public download URLs (bucket.name isn't relied on). */
+  bucketName: string;
+  /** Absolute or relative path to the local source video. */
+  inputPath: string;
+  /** GCS prefix for this photo's assets, e.g. `photos/<userId>/<photoId>`. */
+  storageDir: string;
+  /** Parallel HLS-segment uploads. Defaults to 5. */
+  concurrency?: number;
+}
+
+interface ProcessVideoResult {
+  /** HLS manifest URL → `photos.source`. */
+  source: string;
+  mediumUrl: string;
+  thumbnailUrl: string;
+  blurHash: string;
+  width: number;
+  height: number;
+  duration: number;
+  /** Container/mtime capture date; a caller with a better date should ignore this. */
+  probedTakenAt: string;
+  /** Number of HLS files uploaded (for the operator log). */
+  hlsFileCount: number;
+}
+
+/**
+ * Transcode one local video to HLS, grab a poster, and upload the HLS bundle plus
+ * the medium/thumb poster renditions under `storageDir`. Returns the resulting GCS
+ * URLs and the probed duration/date. Does NOT touch Hasura — the caller owns the
+ * `photos` row, so it can apply its own date source, public flag, slug, and album.
+ *
+ * Temp dirs are nested-cleaned: an `extractPosterFrame` failure still tears down
+ * the already-transcoded HLS dir instead of orphaning it.
+ */
+const processVideoToStorage = async (
+  opts: ProcessVideoOptions,
+): Promise<ProcessVideoResult> => {
+  const { bucket, bucketName, inputPath, storageDir } = opts;
+  const concurrency = opts.concurrency ?? DEFAULT_UPLOAD_CONCURRENCY;
+
+  const meta = await probeVideo(inputPath);
+
+  const hls = await convertLocalToHls(inputPath);
+  try {
+    const frame = await extractPosterFrame(inputPath, meta.duration);
+    try {
+      const poster = await buildPoster(readFileSync(frame.framePath));
+
+      const mediumPath = `${storageDir}/${POSTER_MEDIUM_NAME}`;
+      const thumbPath = `${storageDir}/${POSTER_THUMB_NAME}`;
+      const hlsFileCount = await uploadDir(
+        bucket,
+        hls.outputDir,
+        storageDir,
+        concurrency,
+      );
+      await Promise.all([
+        uploadBuffer(bucket, poster.medium, mediumPath, 'image/jpeg'),
+        uploadBuffer(bucket, poster.thumb, thumbPath, 'image/jpeg'),
+      ]);
+
+      return {
+        source: getDownloadUrl(bucketName, `${storageDir}/${PLAYLIST_NAME}`),
+        mediumUrl: getDownloadUrl(bucketName, mediumPath),
+        thumbnailUrl: getDownloadUrl(bucketName, thumbPath),
+        blurHash: poster.blurHash,
+        width: poster.width,
+        height: poster.height,
+        duration: meta.duration,
+        probedTakenAt: meta.takenAt,
+        hlsFileCount,
+      };
+    } finally {
+      await frame.cleanup();
+    }
+  } finally {
+    await hls.cleanup();
+  }
+};
+
+export {
+  isVideoFile,
+  probeVideo,
+  processVideoToStorage,
+  VIDEO_EXTENSIONS,
+  type ProcessVideoResult,
+  type VideoMeta,
+};


### PR DESCRIPTION
## Summary

Google Photos **Takeout** exports contain videos, which the Takeout import CLI (`google-photos.ts`) previously skipped as "non-image media". Now they're ingested too — a video becomes a `type='video'` photo (HLS manifest in `source`, `duration` in seconds), exactly like the single-file `look-video.ts` CLI already does.

- **New shared module** `apps/backend/src/cli/lib/video-ingest.ts` — the transcode → poster-frame → GCS-upload pipeline, still built on the same shared `convertToHLS` core the compute service uses (so the HLS format can't drift). Pure library code: explicit dependencies, no `argv`/config reads, no `main()`.
- **`google-photos.ts`** routes video files in a Takeout folder through it, with the same sidecar date resolution, dedup, and album linking as an image, under the same `photos/<userId>/<photoId>/` prefix.
- **Live/Motion Photos** (a still + a same-named video clip) ingest as just the still — the video is its motion component and is skipped (a benign `skipped` outcome, not a failure). The still always sorts ahead of its video so it wins the slug.
- **Two distinct videos** that slugify alike (no still) fail loudly — "rename to ingest both" — exactly like the image path, instead of silently dropping the second.
- Sub-second clips floor to a 1-second minimum instead of storing `duration: 0`.

`look-video.ts` is intentionally left unchanged; migrating it onto the shared module (removing its now-duplicated poster pipeline) is a mechanical follow-up.

## Test plan

- `isVideoFile` has unit coverage (extensions, case, path-vs-basename, non-video); 5/5 backend tests pass. Backend typecheck + Biome clean.
- **End-to-end against prod GCS** (`--skip-db`, synthetic clip): transcoded to fMP4 HLS (`init.mp4` + `.m4s` + `playlist.m3u8`) + poster medium/thumb under `photos/<userId>/<photoId>/`, manifest well-formed, then the test prefix was deleted from GCS (0 objects remain). No prod DB row created.
- **Dry-run over a fixture** covering every dispatch case: Live Photo pairs (`.jpg`+`.mp4`, `.png`+`.mov`) → still planned, motion video skipped; two distinct videos same base name → second fails; standalone video → planned; `.heic` → reported as unsupported.
- Manual (later, with a real Takeout): `--dry-run` first to review the image/video/skip breakdown, then ingest.