### PR TITLE
chore(look): add look origins to bucket CORS allow-list

### DIFF
--- a/apps/backend/bucket-cors.json
+++ b/apps/backend/bucket-cors.json
@@ -1,6 +1,11 @@
 [
   {
-    "origin": ["https://watch.shinabr2.com", "http://localhost:3002"],
+    "origin": [
+      "https://watch.shinabr2.com",
+      "https://look.shinabr2.com",
+      "http://localhost:3002",
+      "http://localhost:3006"
+    ],
     "method": ["GET", "PUT"],
     "responseHeader": ["Content-Type"],
     "maxAgeSeconds": 3600


### PR DESCRIPTION
## Summary

The Look site's videos failed to play because the storage bucket's CORS allow-list only named the Watch site. The live bucket (`gs://sworld-prod.appspot.com`) has already been updated to add the Look origins; this PR syncs the repo copy of the config so it matches what is live. The file is applied to the bucket by hand, not by CI.

Adds `https://look.shinabr2.com` and `http://localhost:3006` alongside the existing watch origins.

Refs SWO-625

## Test plan

- [ ] `apps/backend/bucket-cors.json` lists both watch origins plus `https://look.shinabr2.com` and `http://localhost:3006`.
- [ ] Playing a video on `look.shinabr2.com` no longer throws a CORS error in the browser console (already verified live).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled supported web app environments to access backend resources through CORS.
  * Added access for the Look production site and its local development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->