### PR TITLE
fix(look): group album view by taken date like the timeline

### DIFF
--- a/packages/ui/src/look/albums/album-detail/index.tsx
+++ b/packages/ui/src/look/albums/album-detail/index.tsx
@@ -38,10 +38,10 @@ interface AlbumDetailContainerProps {
   LinkComponent: LinkComponentType;
 }
 
-// One album's photos, in stored position order. Reuses the same square PhotoCard
-// + blur placeholder as the timeline, and the same virtualized row model so a
-// large album mounts only the visible rows — but as a flat header + grid (no
-// month grouping), since an album is a single ordered set.
+// One album's photos, grouped by the month they were taken like the timeline,
+// under a fixed album header (title, description, count). Reuses the same square
+// PhotoCard + blur placeholder and the same virtualized row model, so a large
+// album mounts only the visible rows.
 const AlbumDetailContainer = (props: AlbumDetailContainerProps) => {
   const { queryRs, LinkComponent } = props;
   const { album, isLoading } = queryRs;
@@ -146,6 +146,15 @@ const AlbumDetailContainer = (props: AlbumDetailContainerProps) => {
                     No photos in this album
                   </Typography>
                 </Stack>
+              ) : null}
+              {row.type === 'month' ? (
+                <Typography
+                  variant="h6"
+                  component="h2"
+                  sx={{ pt: 3, pb: 1, color: 'text.primary' }}
+                >
+                  {row.label}
+                </Typography>
               ) : null}
               {row.type === 'photos' ? (
                 <Grid container spacing={1} columns={columns} sx={{ pb: 1 }}>

--- a/packages/ui/src/look/albums/utils.test.ts
+++ b/packages/ui/src/look/albums/utils.test.ts
@@ -2,20 +2,25 @@ import type { TransformedPhoto } from 'core/look/query-hooks/types';
 import { describe, expect, it } from 'vitest';
 import { buildAlbumRows, formatPhotoCount } from './utils';
 
+const makePhoto = (id: string, takenAt: string | null): TransformedPhoto => ({
+  id,
+  type: 'image',
+  source: `https://example.com/${id}.jpg`,
+  mediumUrl: `https://example.com/${id}-medium.jpg`,
+  thumbnailUrl: `https://example.com/${id}-thumb.jpg`,
+  blurHash: 'LEHV6nWB2yk8pyo0adR*.7kCMdnj',
+  width: 1200,
+  height: 1200,
+  duration: null,
+  takenAt,
+  slug: id,
+});
+
+// All in the same month (June 2023) so grouping produces a single month group.
 const makePhotos = (count: number): TransformedPhoto[] =>
-  Array.from({ length: count }, (_, index) => ({
-    id: `photo-${index}`,
-    type: 'image',
-    source: `https://example.com/${index}.jpg`,
-    mediumUrl: `https://example.com/${index}-medium.jpg`,
-    thumbnailUrl: `https://example.com/${index}-thumb.jpg`,
-    blurHash: 'LEHV6nWB2yk8pyo0adR*.7kCMdnj',
-    width: 1200,
-    height: 1200,
-    duration: null,
-    takenAt: '2023-06-01T10:00:00Z',
-    slug: `photo-${index}`,
-  }));
+  Array.from({ length: count }, (_, index) =>
+    makePhoto(`photo-${index}`, '2023-06-01T10:00:00Z'),
+  );
 
 describe('formatPhotoCount', () => {
   it('uses the singular noun for exactly one photo', () => {
@@ -40,23 +45,49 @@ describe('buildAlbumRows', () => {
     ]);
   });
 
-  it('chunks photos into rows of `columns` after the header, in order', () => {
+  it('groups photos by month under the header, chunked in order', () => {
     const photos = makePhotos(5);
     const rows = buildAlbumRows(photos, 2);
     expect(rows).toEqual([
       { type: 'header', key: 'album-header' },
-      { type: 'photos', key: 'album-row-0', photos: [photos[0], photos[1]] },
-      { type: 'photos', key: 'album-row-1', photos: [photos[2], photos[3]] },
-      { type: 'photos', key: 'album-row-2', photos: [photos[4]] },
+      { type: 'month', key: 'album-month-2023-06', label: 'June 2023' },
+      {
+        type: 'photos',
+        key: 'album-row-2023-06-0',
+        photos: [photos[0], photos[1]],
+      },
+      {
+        type: 'photos',
+        key: 'album-row-2023-06-1',
+        photos: [photos[2], photos[3]],
+      },
+      { type: 'photos', key: 'album-row-2023-06-2', photos: [photos[4]] },
     ]);
   });
 
-  it('puts every photo in a single row when columns exceeds the count', () => {
+  it('puts a month group in a single row when columns exceeds the count', () => {
     const photos = makePhotos(3);
     const rows = buildAlbumRows(photos, 6);
     expect(rows).toEqual([
       { type: 'header', key: 'album-header' },
-      { type: 'photos', key: 'album-row-0', photos },
+      { type: 'month', key: 'album-month-2023-06', label: 'June 2023' },
+      { type: 'photos', key: 'album-row-2023-06-0', photos },
+    ]);
+  });
+
+  it('emits a month heading per month, newest first, undated last', () => {
+    const july = makePhoto('july', '2023-07-15T10:00:00Z');
+    const june = makePhoto('june', '2023-06-15T10:00:00Z');
+    const undated = makePhoto('undated', null);
+    const rows = buildAlbumRows([june, undated, july], 3);
+    expect(rows).toEqual([
+      { type: 'header', key: 'album-header' },
+      { type: 'month', key: 'album-month-2023-07', label: 'July 2023' },
+      { type: 'photos', key: 'album-row-2023-07-0', photos: [july] },
+      { type: 'month', key: 'album-month-2023-06', label: 'June 2023' },
+      { type: 'photos', key: 'album-row-2023-06-0', photos: [june] },
+      { type: 'month', key: 'album-month-undated', label: 'Undated' },
+      { type: 'photos', key: 'album-row-undated-0', photos: [undated] },
     ]);
   });
 });

--- a/packages/ui/src/look/albums/utils.ts
+++ b/packages/ui/src/look/albums/utils.ts
@@ -1,13 +1,14 @@
 import type { TransformedPhoto } from 'core/look/query-hooks/types';
-import { chunk } from '../home-page/utils';
+import { chunk, groupPhotosByMonth } from '../home-page/utils';
 
-// The virtualizer's row model for one album: a single header row (album title,
-// description, count), then either an empty-state row or the photos chunked into
-// rows of `columns`. Unlike the timeline there is no month grouping — an album
-// is one ordered set — so this is a flat list with a fixed leading header.
+// The virtualizer's row model for one album: a fixed leading header row (album
+// title, description, count), then either an empty-state row or — like the
+// timeline — the photos grouped by the month they were taken, each month a
+// heading row followed by its photos chunked into rows of `columns`.
 type AlbumRow =
   | { type: 'header'; key: string }
   | { type: 'empty'; key: string }
+  | { type: 'month'; key: string; label: string }
   | { type: 'photos'; key: string; photos: TransformedPhoto[] };
 
 const buildAlbumRows = (
@@ -21,9 +22,20 @@ const buildAlbumRows = (
     return rows;
   }
 
-  chunk(photos, columns).forEach((rowPhotos, index) => {
-    rows.push({ type: 'photos', key: `album-row-${index}`, photos: rowPhotos });
-  });
+  for (const group of groupPhotosByMonth(photos)) {
+    rows.push({
+      type: 'month',
+      key: `album-month-${group.key}`,
+      label: group.label,
+    });
+    chunk(group.photos, columns).forEach((rowPhotos, index) => {
+      rows.push({
+        type: 'photos',
+        key: `album-row-${group.key}-${index}`,
+        photos: rowPhotos,
+      });
+    });
+  }
   return rows;
 };
 


### PR DESCRIPTION
## Summary

Opening one album in the Look site showed all its photos in a single flat grid, while the main listing page groups photos under a heading for each month they were taken. This makes the album view group by taken date the same way, so both grids read consistently and a large album is easier to scan.

The album title, description, and photo count still sit at the top; within each month photos keep their stored order, newest month first, undated last — reusing the timeline's existing `groupPhotosByMonth`.

Refs SWO-626

## Test plan

- [ ] Open an album whose photos span multiple months → photos are grouped under month headings, newest month first, matching the home timeline.
- [ ] The album title, description, and photo count still appear at the top.
- [ ] An empty album still shows the "No photos in this album" state.
