### PR TITLE
fix(look): closing the photo viewer returns to where you were

### DIFF
--- a/apps/look/src/components/timeline-page/index.tsx
+++ b/apps/look/src/components/timeline-page/index.tsx
@@ -1,4 +1,9 @@
-import { Link, useNavigate } from '@tanstack/react-router';
+import {
+  Link,
+  useCanGoBack,
+  useNavigate,
+  useRouter,
+} from '@tanstack/react-router';
 import { useLoadPhotos } from 'core/look/query-hooks/photos';
 import { useAuthContext } from 'core/providers/auth';
 import { PhotoTimelineContainer } from 'ui/look/home-page/container';
@@ -15,9 +20,16 @@ interface TimelinePageProps {
 // link, deleted photo, load error → empty list) leaves the lightbox closed and
 // the user on the grid rather than a blank screen. Stepping replaces the URL so
 // Back leaves the lightbox in one step instead of walking every photo visited.
+//
+// Closing goes back in history so it returns to wherever the photo was opened
+// from — the timeline, or the album grid when opened from an album — instead of
+// always jumping home. When there's no in-app history to return to (a photo URL
+// opened directly, or reloaded), it falls back to the home route.
 const TimelinePage = (props: TimelinePageProps) => {
   const { activePhotoId } = props;
   const navigate = useNavigate();
+  const router = useRouter();
+  const canGoBack = useCanGoBack();
   const { getAccessToken } = useAuthContext();
   const photosResult = useLoadPhotos({ getAccessToken });
   const { photos } = photosResult;
@@ -32,7 +44,11 @@ const TimelinePage = (props: TimelinePageProps) => {
         photos={photos}
         activeId={activePhotoId ?? ''}
         open={isPhotoOpen}
-        onClose={() => navigate({ to: '/', replace: true })}
+        onClose={() =>
+          canGoBack
+            ? router.history.back()
+            : navigate({ to: '/', replace: true })
+        }
         onActiveIdChange={(id) =>
           navigate({
             to: '/photo/$photoId',


### PR DESCRIPTION
## Summary

In the Look site, opening a photo full-screen and then closing it always sent you to the home page — even when you opened the photo from inside an album. Closing now returns you to wherever you opened the photo from: the timeline, or the album grid. When there is no in-app history to return to (a photo link opened directly, or the page reloaded on a photo), it falls back to the home page so there's no dead-end.

Shareable photo URLs and Back-to-close still work — the viewer stays URL-driven; only the close destination changed.

Refs SWO-627

## Test plan

- [ ] Home timeline → open a photo → close → back on the timeline.
- [ ] Open an album → open a photo → close → back on that album (not the home page).
- [ ] Open a photo URL directly (fresh tab or refresh) → close → lands on the home page (no dead-end).
- [ ] Escape key and clicking the backdrop close the same way as the ✕ button.
