### PR TITLE
feat(look): album-scoped photo viewing

### DIFF
--- a/apps/look/src/components/album-page/index.tsx
+++ b/apps/look/src/components/album-page/index.tsx
@@ -1,0 +1,70 @@
+import {
+  Link,
+  useCanGoBack,
+  useNavigate,
+  useRouter,
+} from '@tanstack/react-router';
+import { useLoadAlbumDetail } from 'core/look/query-hooks/albums';
+import { useAuthContext } from 'core/providers/auth';
+import { AlbumDetailContainer } from 'ui/look/albums/album-detail';
+import { PhotoLightbox } from 'ui/look/photo-detail-page/containers';
+import { Layout } from '../layout';
+
+interface AlbumPageProps {
+  albumId: string;
+  activePhotoId?: string;
+}
+
+// One album as a grid + full-screen viewer — the album counterpart of
+// TimelinePage. The URL decides whether a photo is open, but scoped to this
+// album: the viewer steps ←/→ through the album's photos (not the whole
+// library) and an unknown id leaves the viewer closed on the grid. Stepping
+// replaces the URL so Back leaves the viewer in one step. Closing goes back in
+// history so it returns to wherever the photo was opened from, falling back to
+// the album grid when there's no in-app history (a photo URL opened directly or
+// reloaded).
+const AlbumPage = (props: AlbumPageProps) => {
+  const { albumId, activePhotoId } = props;
+  const navigate = useNavigate();
+  const router = useRouter();
+  const canGoBack = useCanGoBack();
+  const { getAccessToken } = useAuthContext();
+  const albumResult = useLoadAlbumDetail({ id: albumId, getAccessToken });
+  const photos = albumResult.album?.photos ?? [];
+  const isPhotoOpen =
+    activePhotoId !== undefined &&
+    photos.some((photo) => photo.id === activePhotoId);
+
+  return (
+    <Layout collectionValue={albumId}>
+      <AlbumDetailContainer
+        queryRs={albumResult}
+        LinkComponent={Link}
+        albumId={albumId}
+      />
+      <PhotoLightbox
+        photos={photos}
+        activeId={activePhotoId ?? ''}
+        open={isPhotoOpen}
+        onClose={() =>
+          canGoBack
+            ? router.history.back()
+            : navigate({
+                to: '/album/$albumId',
+                params: { albumId },
+                replace: true,
+              })
+        }
+        onActiveIdChange={(id) =>
+          navigate({
+            to: '/album/$albumId/photo/$photoId',
+            params: { albumId, photoId: id },
+            replace: true,
+          })
+        }
+      />
+    </Layout>
+  );
+};
+
+export { AlbumPage };

--- a/apps/look/src/routeTree.gen.ts
+++ b/apps/look/src/routeTree.gen.ts
@@ -15,6 +15,9 @@ import { Route as rootRouteImport } from './routes/__root'
 const IndexLazyRouteImport = createFileRoute('/')()
 const PhotoPhotoIdLazyRouteImport = createFileRoute('/photo/$photoId')()
 const AlbumAlbumIdLazyRouteImport = createFileRoute('/album/$albumId')()
+const AlbumAlbumIdPhotoPhotoIdLazyRouteImport = createFileRoute(
+  '/album/$albumId/photo/$photoId',
+)()
 
 const IndexLazyRoute = IndexLazyRouteImport.update({
   id: '/',
@@ -35,34 +38,58 @@ const AlbumAlbumIdLazyRoute = AlbumAlbumIdLazyRouteImport.update({
 } as any).lazy(() =>
   import('./routes/album.$albumId.lazy').then((d) => d.Route),
 )
+const AlbumAlbumIdPhotoPhotoIdLazyRoute =
+  AlbumAlbumIdPhotoPhotoIdLazyRouteImport.update({
+    id: '/photo/$photoId',
+    path: '/photo/$photoId',
+    getParentRoute: () => AlbumAlbumIdLazyRoute,
+  } as any).lazy(() =>
+    import('./routes/album.$albumId.photo.$photoId.lazy').then((d) => d.Route),
+  )
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexLazyRoute
-  '/album/$albumId': typeof AlbumAlbumIdLazyRoute
+  '/album/$albumId': typeof AlbumAlbumIdLazyRouteWithChildren
   '/photo/$photoId': typeof PhotoPhotoIdLazyRoute
+  '/album/$albumId/photo/$photoId': typeof AlbumAlbumIdPhotoPhotoIdLazyRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexLazyRoute
-  '/album/$albumId': typeof AlbumAlbumIdLazyRoute
+  '/album/$albumId': typeof AlbumAlbumIdLazyRouteWithChildren
   '/photo/$photoId': typeof PhotoPhotoIdLazyRoute
+  '/album/$albumId/photo/$photoId': typeof AlbumAlbumIdPhotoPhotoIdLazyRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexLazyRoute
-  '/album/$albumId': typeof AlbumAlbumIdLazyRoute
+  '/album/$albumId': typeof AlbumAlbumIdLazyRouteWithChildren
   '/photo/$photoId': typeof PhotoPhotoIdLazyRoute
+  '/album/$albumId/photo/$photoId': typeof AlbumAlbumIdPhotoPhotoIdLazyRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/album/$albumId' | '/photo/$photoId'
+  fullPaths:
+    | '/'
+    | '/album/$albumId'
+    | '/photo/$photoId'
+    | '/album/$albumId/photo/$photoId'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/album/$albumId' | '/photo/$photoId'
-  id: '__root__' | '/' | '/album/$albumId' | '/photo/$photoId'
+  to:
+    | '/'
+    | '/album/$albumId'
+    | '/photo/$photoId'
+    | '/album/$albumId/photo/$photoId'
+  id:
+    | '__root__'
+    | '/'
+    | '/album/$albumId'
+    | '/photo/$photoId'
+    | '/album/$albumId/photo/$photoId'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexLazyRoute: typeof IndexLazyRoute
-  AlbumAlbumIdLazyRoute: typeof AlbumAlbumIdLazyRoute
+  AlbumAlbumIdLazyRoute: typeof AlbumAlbumIdLazyRouteWithChildren
   PhotoPhotoIdLazyRoute: typeof PhotoPhotoIdLazyRoute
 }
 
@@ -89,12 +116,30 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AlbumAlbumIdLazyRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/album/$albumId/photo/$photoId': {
+      id: '/album/$albumId/photo/$photoId'
+      path: '/photo/$photoId'
+      fullPath: '/album/$albumId/photo/$photoId'
+      preLoaderRoute: typeof AlbumAlbumIdPhotoPhotoIdLazyRouteImport
+      parentRoute: typeof AlbumAlbumIdLazyRoute
+    }
   }
 }
 
+interface AlbumAlbumIdLazyRouteChildren {
+  AlbumAlbumIdPhotoPhotoIdLazyRoute: typeof AlbumAlbumIdPhotoPhotoIdLazyRoute
+}
+
+const AlbumAlbumIdLazyRouteChildren: AlbumAlbumIdLazyRouteChildren = {
+  AlbumAlbumIdPhotoPhotoIdLazyRoute: AlbumAlbumIdPhotoPhotoIdLazyRoute,
+}
+
+const AlbumAlbumIdLazyRouteWithChildren =
+  AlbumAlbumIdLazyRoute._addFileChildren(AlbumAlbumIdLazyRouteChildren)
+
 const rootRouteChildren: RootRouteChildren = {
   IndexLazyRoute: IndexLazyRoute,
-  AlbumAlbumIdLazyRoute: AlbumAlbumIdLazyRoute,
+  AlbumAlbumIdLazyRoute: AlbumAlbumIdLazyRouteWithChildren,
   PhotoPhotoIdLazyRoute: PhotoPhotoIdLazyRoute,
 }
 export const routeTree = rootRouteImport

--- a/apps/look/src/routes/album.$albumId.photo.$photoId.lazy.tsx
+++ b/apps/look/src/routes/album.$albumId.photo.$photoId.lazy.tsx
@@ -3,12 +3,12 @@ import { AuthRoute } from 'ui/universal/authRoute';
 import { AlbumPage } from '../components/album-page';
 
 const Content = () => {
-  const { albumId } = Route.useParams();
+  const { albumId, photoId } = Route.useParams();
 
-  return <AlbumPage albumId={albumId} />;
+  return <AlbumPage albumId={albumId} activePhotoId={photoId} />;
 };
 
-export const Route = createLazyFileRoute('/album/$albumId')({
+export const Route = createLazyFileRoute('/album/$albumId/photo/$photoId')({
   component: () => {
     return (
       <AuthRoute>

--- a/packages/ui/src/look/albums/album-detail/index.stories.tsx
+++ b/packages/ui/src/look/albums/album-detail/index.stories.tsx
@@ -52,7 +52,7 @@ const meta: Meta<typeof AlbumDetailContainer> = {
       </Stack>
     ),
   ],
-  args: { LinkComponent: MockLink },
+  args: { LinkComponent: MockLink, albumId: 'album-1' },
   tags: ['autodocs'],
 };
 

--- a/packages/ui/src/look/albums/album-detail/index.tsx
+++ b/packages/ui/src/look/albums/album-detail/index.tsx
@@ -8,11 +8,15 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import type { useLoadAlbumDetail } from 'core/look/query-hooks/albums';
 import { useMemo, useRef } from 'react';
-import { genPhotoLinkProps, resolveColumns } from '../../home-page/utils';
+import { resolveColumns } from '../../home-page/utils';
 import { PhotoCard } from '../../photos/photo-card';
 import { PhotoSkeleton } from '../../photos/photo-card/skeleton';
 import type { LinkComponentType } from '../../photos/types';
-import { buildAlbumRows, formatPhotoCount } from '../utils';
+import {
+  buildAlbumRows,
+  formatPhotoCount,
+  genAlbumPhotoLinkProps,
+} from '../utils';
 
 // Row-height estimates (px) the virtualizer starts from before it measures the
 // real DOM heights — a virtualizer API contract, not a styling value.
@@ -36,6 +40,10 @@ const CONTENT_SX = {
 interface AlbumDetailContainerProps {
   queryRs: ReturnType<typeof useLoadAlbumDetail>;
   LinkComponent: LinkComponentType;
+  // The album these photos belong to — its id namespaces each photo card's link
+  // to the album-scoped viewer route (`/album/$albumId/photo/$photoId`), so the
+  // viewer stays in album context instead of the whole-library route.
+  albumId: string;
 }
 
 // One album's photos, grouped by the month they were taken like the timeline,
@@ -43,7 +51,7 @@ interface AlbumDetailContainerProps {
 // PhotoCard + blur placeholder and the same virtualized row model, so a large
 // album mounts only the visible rows.
 const AlbumDetailContainer = (props: AlbumDetailContainerProps) => {
-  const { queryRs, LinkComponent } = props;
+  const { queryRs, LinkComponent, albumId } = props;
   const { album, isLoading } = queryRs;
   const scrollRef = useRef<HTMLDivElement>(null);
   const theme = useTheme();
@@ -163,7 +171,7 @@ const AlbumDetailContainer = (props: AlbumDetailContainerProps) => {
                       <PhotoCard
                         photo={photo}
                         LinkComponent={LinkComponent}
-                        linkProps={genPhotoLinkProps(photo)}
+                        linkProps={genAlbumPhotoLinkProps(albumId, photo)}
                       />
                     </Grid>
                   ))}

--- a/packages/ui/src/look/albums/utils.test.ts
+++ b/packages/ui/src/look/albums/utils.test.ts
@@ -1,6 +1,10 @@
 import type { TransformedPhoto } from 'core/look/query-hooks/types';
 import { describe, expect, it } from 'vitest';
-import { buildAlbumRows, formatPhotoCount } from './utils';
+import {
+  buildAlbumRows,
+  formatPhotoCount,
+  genAlbumPhotoLinkProps,
+} from './utils';
 
 const makePhoto = (id: string, takenAt: string | null): TransformedPhoto => ({
   id,
@@ -89,5 +93,15 @@ describe('buildAlbumRows', () => {
       { type: 'month', key: 'album-month-undated', label: 'Undated' },
       { type: 'photos', key: 'album-row-undated-0', photos: [undated] },
     ]);
+  });
+});
+
+describe('genAlbumPhotoLinkProps', () => {
+  it('links to the album-scoped photo route with both ids', () => {
+    const photo = makePhoto('photo-9', '2023-06-01T10:00:00Z');
+    expect(genAlbumPhotoLinkProps('album-3', photo)).toEqual({
+      to: '/album/$albumId/photo/$photoId',
+      params: { albumId: 'album-3', photoId: 'photo-9' },
+    });
   });
 });

--- a/packages/ui/src/look/albums/utils.ts
+++ b/packages/ui/src/look/albums/utils.ts
@@ -1,6 +1,17 @@
 import type { TransformedPhoto } from 'core/look/query-hooks/types';
 import { chunk, groupPhotosByMonth } from '../home-page/utils';
 
+const ALBUM_PHOTO_ROUTE = '/album/$albumId/photo/$photoId';
+
+// The album-scoped photo route: opening a photo from an album keeps the album
+// as the collection, so the viewer's ←/→ arrows step the album's photos (not
+// the whole library) and closing returns to the album. Mirrors the timeline's
+// genPhotoLinkProps, but carries the album id so the URL names the album.
+const genAlbumPhotoLinkProps = (albumId: string, photo: TransformedPhoto) => ({
+  to: ALBUM_PHOTO_ROUTE,
+  params: { albumId, photoId: photo.id },
+});
+
 // The virtualizer's row model for one album: a fixed leading header row (album
 // title, description, count), then either an empty-state row or — like the
 // timeline — the photos grouped by the month they were taken, each month a
@@ -42,5 +53,5 @@ const buildAlbumRows = (
 const formatPhotoCount = (count: number): string =>
   count === 1 ? '1 photo' : `${count} photos`;
 
-export { buildAlbumRows, formatPhotoCount };
+export { buildAlbumRows, formatPhotoCount, genAlbumPhotoLinkProps };
 export type { AlbumRow };


### PR DESCRIPTION
## Summary

Opening a photo from inside an album on the Look site behaved as if you'd opened it from the whole library: the ←/→ arrows stepped through every photo you own, and the grid behind the viewer was the full timeline. This gives albums their own photo URL (`/album/{albumId}/photo/{photoId}`) so the viewer stays in the album — the arrows step only that album's photos, and closing returns you to the album (matching Google Photos' shared-album behaviour).

A new `AlbumPage` renders the album grid with the viewer scoped to the album's photo list; it mirrors the existing timeline page. Closing goes back in history, falling back to the album grid when there's no in-app history (a photo URL opened directly or reloaded). The whole-library route `/photo/{photoId}` is unchanged.

Builds on SWO-627 (close-returns-back) and SWO-626 (album grouping).

Refs SWO-628

## Test plan

- [ ] Open an album → open a photo → the ←/→ arrows step through only that album's photos.
- [ ] Close → back on the album grid (not the home timeline).
- [ ] Open an album photo URL directly (fresh tab / refresh) → close → lands on that album (no dead-end, no jump home).
- [ ] Opening a photo from the home timeline still steps the whole library and closes to the timeline (unchanged).
