### PR TITLE
fix(look): open the album photo viewer by un-nesting its route

### DIFF
--- a/apps/look/src/routeTree.gen.ts
+++ b/apps/look/src/routeTree.gen.ts
@@ -13,10 +13,10 @@ import { createFileRoute } from '@tanstack/react-router'
 import { Route as rootRouteImport } from './routes/__root'
 
 const IndexLazyRouteImport = createFileRoute('/')()
-const PhotoPhotoIdLazyRouteImport = createFileRoute('/photo/$photoId')()
 const AlbumAlbumIdLazyRouteImport = createFileRoute('/album/$albumId')()
+const PhotoPhotoIdLazyRouteImport = createFileRoute('/photo/$photoId')()
 const AlbumAlbumIdPhotoPhotoIdLazyRouteImport = createFileRoute(
-  '/album/$albumId/photo/$photoId',
+  '/album/$albumId_/photo/$photoId',
 )()
 
 const IndexLazyRoute = IndexLazyRouteImport.update({
@@ -24,13 +24,6 @@ const IndexLazyRoute = IndexLazyRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any).lazy(() => import('./routes/index.lazy').then((d) => d.Route))
-const PhotoPhotoIdLazyRoute = PhotoPhotoIdLazyRouteImport.update({
-  id: '/photo/$photoId',
-  path: '/photo/$photoId',
-  getParentRoute: () => rootRouteImport,
-} as any).lazy(() =>
-  import('./routes/photo.$photoId.lazy').then((d) => d.Route),
-)
 const AlbumAlbumIdLazyRoute = AlbumAlbumIdLazyRouteImport.update({
   id: '/album/$albumId',
   path: '/album/$albumId',
@@ -38,33 +31,40 @@ const AlbumAlbumIdLazyRoute = AlbumAlbumIdLazyRouteImport.update({
 } as any).lazy(() =>
   import('./routes/album.$albumId.lazy').then((d) => d.Route),
 )
+const PhotoPhotoIdLazyRoute = PhotoPhotoIdLazyRouteImport.update({
+  id: '/photo/$photoId',
+  path: '/photo/$photoId',
+  getParentRoute: () => rootRouteImport,
+} as any).lazy(() =>
+  import('./routes/photo.$photoId.lazy').then((d) => d.Route),
+)
 const AlbumAlbumIdPhotoPhotoIdLazyRoute =
   AlbumAlbumIdPhotoPhotoIdLazyRouteImport.update({
-    id: '/photo/$photoId',
-    path: '/photo/$photoId',
-    getParentRoute: () => AlbumAlbumIdLazyRoute,
+    id: '/album/$albumId_/photo/$photoId',
+    path: '/album/$albumId/photo/$photoId',
+    getParentRoute: () => rootRouteImport,
   } as any).lazy(() =>
-    import('./routes/album.$albumId.photo.$photoId.lazy').then((d) => d.Route),
+    import('./routes/album.$albumId_.photo.$photoId.lazy').then((d) => d.Route),
   )
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexLazyRoute
-  '/album/$albumId': typeof AlbumAlbumIdLazyRouteWithChildren
+  '/album/$albumId': typeof AlbumAlbumIdLazyRoute
   '/photo/$photoId': typeof PhotoPhotoIdLazyRoute
   '/album/$albumId/photo/$photoId': typeof AlbumAlbumIdPhotoPhotoIdLazyRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexLazyRoute
-  '/album/$albumId': typeof AlbumAlbumIdLazyRouteWithChildren
+  '/album/$albumId': typeof AlbumAlbumIdLazyRoute
   '/photo/$photoId': typeof PhotoPhotoIdLazyRoute
   '/album/$albumId/photo/$photoId': typeof AlbumAlbumIdPhotoPhotoIdLazyRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexLazyRoute
-  '/album/$albumId': typeof AlbumAlbumIdLazyRouteWithChildren
+  '/album/$albumId': typeof AlbumAlbumIdLazyRoute
   '/photo/$photoId': typeof PhotoPhotoIdLazyRoute
-  '/album/$albumId/photo/$photoId': typeof AlbumAlbumIdPhotoPhotoIdLazyRoute
+  '/album/$albumId_/photo/$photoId': typeof AlbumAlbumIdPhotoPhotoIdLazyRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -84,13 +84,14 @@ export interface FileRouteTypes {
     | '/'
     | '/album/$albumId'
     | '/photo/$photoId'
-    | '/album/$albumId/photo/$photoId'
+    | '/album/$albumId_/photo/$photoId'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexLazyRoute: typeof IndexLazyRoute
-  AlbumAlbumIdLazyRoute: typeof AlbumAlbumIdLazyRouteWithChildren
+  AlbumAlbumIdLazyRoute: typeof AlbumAlbumIdLazyRoute
   PhotoPhotoIdLazyRoute: typeof PhotoPhotoIdLazyRoute
+  AlbumAlbumIdPhotoPhotoIdLazyRoute: typeof AlbumAlbumIdPhotoPhotoIdLazyRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -102,13 +103,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexLazyRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/photo/$photoId': {
-      id: '/photo/$photoId'
-      path: '/photo/$photoId'
-      fullPath: '/photo/$photoId'
-      preLoaderRoute: typeof PhotoPhotoIdLazyRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/album/$albumId': {
       id: '/album/$albumId'
       path: '/album/$albumId'
@@ -116,31 +110,28 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AlbumAlbumIdLazyRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/album/$albumId/photo/$photoId': {
-      id: '/album/$albumId/photo/$photoId'
+    '/photo/$photoId': {
+      id: '/photo/$photoId'
       path: '/photo/$photoId'
+      fullPath: '/photo/$photoId'
+      preLoaderRoute: typeof PhotoPhotoIdLazyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/album/$albumId_/photo/$photoId': {
+      id: '/album/$albumId_/photo/$photoId'
+      path: '/album/$albumId/photo/$photoId'
       fullPath: '/album/$albumId/photo/$photoId'
       preLoaderRoute: typeof AlbumAlbumIdPhotoPhotoIdLazyRouteImport
-      parentRoute: typeof AlbumAlbumIdLazyRoute
+      parentRoute: typeof rootRouteImport
     }
   }
 }
 
-interface AlbumAlbumIdLazyRouteChildren {
-  AlbumAlbumIdPhotoPhotoIdLazyRoute: typeof AlbumAlbumIdPhotoPhotoIdLazyRoute
-}
-
-const AlbumAlbumIdLazyRouteChildren: AlbumAlbumIdLazyRouteChildren = {
-  AlbumAlbumIdPhotoPhotoIdLazyRoute: AlbumAlbumIdPhotoPhotoIdLazyRoute,
-}
-
-const AlbumAlbumIdLazyRouteWithChildren =
-  AlbumAlbumIdLazyRoute._addFileChildren(AlbumAlbumIdLazyRouteChildren)
-
 const rootRouteChildren: RootRouteChildren = {
   IndexLazyRoute: IndexLazyRoute,
-  AlbumAlbumIdLazyRoute: AlbumAlbumIdLazyRouteWithChildren,
+  AlbumAlbumIdLazyRoute: AlbumAlbumIdLazyRoute,
   PhotoPhotoIdLazyRoute: PhotoPhotoIdLazyRoute,
+  AlbumAlbumIdPhotoPhotoIdLazyRoute: AlbumAlbumIdPhotoPhotoIdLazyRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/look/src/routes/album.$albumId_.photo.$photoId.lazy.tsx
+++ b/apps/look/src/routes/album.$albumId_.photo.$photoId.lazy.tsx
@@ -8,7 +8,7 @@ const Content = () => {
   return <AlbumPage albumId={albumId} activePhotoId={photoId} />;
 };
 
-export const Route = createLazyFileRoute('/album/$albumId/photo/$photoId')({
+export const Route = createLazyFileRoute('/album/$albumId_/photo/$photoId')({
   component: () => {
     return (
       <AuthRoute>


### PR DESCRIPTION
## Summary

Clicking a photo inside an album navigated the URL to `/album/$albumId/photo/$photoId` but the full-screen viewer never opened — you stayed on the grid. This makes it open, matching how the timeline already behaves.

**Why it broke:** TanStack's flat-file routing treats dots as nesting, so `album.$albumId.photo.$photoId` became a **child** of `album.$albumId`. A child route only renders inside its parent's `<Outlet />`, and the album grid page renders none — so the route instance that opens the viewer never mounted.

**The fix:** append `_` to the `$albumId` segment (TanStack's non-nested convention) so the photo route becomes a **sibling** under the root route and is swapped in by root's `<Outlet />` — the exact shape the timeline uses for `/` and `/photo/$photoId`. The URL is unchanged; only the internal route id carries the underscore.

## Test plan

- Open an album, click any photo → full-screen viewer opens
- ←/→ steps only that album's photos; Esc/back returns to the album grid
- Direct-load / refresh at `/album/<id>/photo/<id>` opens the viewer on the grid
- `typecheck` green; `ui` album-utils unit test green

Refs SWO-628

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed navigation and route resolution for photos accessed within albums.
  * Corrected album photo URLs and route hierarchy to ensure these pages load reliably.

* **Refactor**
  * Updated route mappings to reflect the revised album and photo navigation structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->