### PR TITLE
[WIP] feat(look): cache-safe versioned fMP4 reprocess (remux core)

### DIFF
--- a/apps/backend/src/apps/compute/videos/routes/repair-fmp4/index.test.ts
+++ b/apps/backend/src/apps/compute/videos/routes/repair-fmp4/index.test.ts
@@ -34,9 +34,19 @@ vi.mock('src/utils/custom-error', () => ({
 vi.mock('src/utils/envConfig', () => ({
   envConfig: { storageBucket: 'test-bucket' },
 }));
+// Stored objects the handler lists to decide the reprocess source + version.
+// Default: a stored `.ts` layout (→ hls-ts remux). Tests override via
+// setStoredFiles before invoking the handler.
+let storedFiles: Array<{ name: string; metadata: { size: string } }> = [];
+const setStoredFiles = (files: typeof storedFiles) => {
+  storedFiles = files;
+};
 vi.mock('@google-cloud/storage', () => {
   const mockFile = { save: vi.fn().mockResolvedValue(undefined) };
-  const mockBucket = { file: vi.fn(() => mockFile) };
+  const mockBucket = {
+    file: vi.fn(() => mockFile),
+    getFiles: vi.fn(async () => [storedFiles]),
+  };
   return {
     Storage: vi.fn().mockImplementation(function (this: any) {
       this.bucket = vi.fn(() => mockBucket);
@@ -64,19 +74,41 @@ const createCtx = (videoId = 'v1', userId = 'u1', taskId = 't1') => ({
   },
 });
 
+// A stored `.ts` layout — planReprocessSource picks the hls-ts remux.
+const TS_LAYOUT = [
+  { name: 'videos/u1/v1/playlist.m3u8', metadata: { size: '300' } },
+  { name: 'videos/u1/v1/0.ts', metadata: { size: '900000' } },
+];
+// A stored fMP4 layout with an empty first segment — the Infinix recovery case.
+const FMP4_LAYOUT = [
+  { name: 'videos/u1/v1/init.mp4', metadata: { size: '1533135' } },
+  { name: 'videos/u1/v1/0.m4s', metadata: { size: '24' } },
+  { name: 'videos/u1/v1/1.m4s', metadata: { size: '780340' } },
+  { name: 'videos/u1/v1/playlist.m3u8', metadata: { size: '330' } },
+];
+
 describe('repairFmp4Handler', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    setStoredFiles(TS_LAYOUT);
     vi.mocked(repackageToFmp4).mockResolvedValue({
-      playlistContent: '#EXTM3U',
-    } as any);
+      initName: 'init.mp4',
+      segmentNames: ['0.m4s', '1.m4s'],
+      manifestStoragePath: 'videos/u1/v1/v1/playlist.m3u8',
+    });
   });
 
-  it('should successfully repair and finalize', async () => {
+  it('reprocesses a stored .ts rendition into a fresh versioned dir', async () => {
     await repairFmp4Handler(createCtx() as any);
 
     expect(repackageToFmp4).toHaveBeenCalledWith(
-      { storagePath: 'videos/u1/v1' },
+      {
+        source: {
+          kind: 'hls-url',
+          url: expect.stringContaining('videos/u1/v1/playlist.m3u8'),
+        },
+        outputStoragePath: 'videos/u1/v1/v1',
+      },
       expect.any(Object),
     );
     expect(finishVideoProcess).toHaveBeenCalledWith(
@@ -84,7 +116,7 @@ describe('repairFmp4Handler', () => {
         taskId: 't1',
         videoId: 'v1',
         videoUpdates: expect.objectContaining({
-          source: expect.stringContaining('playlist-fmp4.m3u8'),
+          source: expect.stringContaining('videos/u1/v1/v1/playlist.m3u8'),
           status: 'ready',
         }),
         notificationObject: expect.objectContaining({
@@ -95,10 +127,47 @@ describe('repairFmp4Handler', () => {
     );
   });
 
-  it('should return playable video URL', async () => {
+  it('recovers from stored fMP4 parts when no .ts is present', async () => {
+    setStoredFiles(FMP4_LAYOUT);
+
+    await repairFmp4Handler(createCtx() as any);
+
+    expect(repackageToFmp4).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: {
+          kind: 'fmp4-parts',
+          partUrls: [
+            expect.stringContaining('videos/u1/v1/init.mp4'),
+            expect.stringContaining('videos/u1/v1/1.m4s'),
+          ],
+        },
+        outputStoragePath: 'videos/u1/v1/v1',
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it('bumps to the next version when a v1 rendition already exists', async () => {
+    setStoredFiles([
+      ...TS_LAYOUT,
+      { name: 'videos/u1/v1/v1/init.mp4', metadata: { size: '1368' } },
+      { name: 'videos/u1/v1/v1/playlist.m3u8', metadata: { size: '300' } },
+    ]);
+
+    await repairFmp4Handler(createCtx() as any);
+
+    expect(repackageToFmp4).toHaveBeenCalledWith(
+      expect.objectContaining({ outputStoragePath: 'videos/u1/v1/v2' }),
+      expect.any(Object),
+    );
+  });
+
+  it('returns the versioned playable video URL', async () => {
     const result: any = await repairFmp4Handler(createCtx() as any);
     expect(result.success).toBe(true);
-    expect(result.dataObject.playableVideoUrl).toContain('playlist-fmp4.m3u8');
+    expect(result.dataObject.playableVideoUrl).toContain(
+      'videos/u1/v1/v1/playlist.m3u8',
+    );
   });
 
   it('should throw error when repair fails', async () => {

--- a/apps/backend/src/apps/compute/videos/routes/repair-fmp4/index.ts
+++ b/apps/backend/src/apps/compute/videos/routes/repair-fmp4/index.ts
@@ -4,14 +4,9 @@ import type { RepairFmp4HandlerRequest } from 'src/schema/videos/repair-fmp4-han
 import { finishVideoProcess } from 'src/services/hasura/mutations/videos/finalize';
 import { getDownloadUrl } from 'src/services/videos/helpers/gcp-cloud-storage';
 import { buildFfmpegRepackage } from 'src/services/videos/processing/ffmpegRepackageAdapter';
-import { planReprocessSource } from 'src/services/videos/processing/planReprocessSource';
+import { planReprocess } from 'src/services/videos/processing/planReprocess';
 import { repackageToFmp4 } from 'src/services/videos/processing/repackageToFmp4';
-import type { StoredPart } from 'src/services/videos/processing/selectFmp4Parts';
-import type {
-  RepackageDeps,
-  RepackageSource,
-} from 'src/services/videos/processing/types';
-import { nextVersionDir } from 'src/services/videos/processing/versioning';
+import type { RepackageDeps } from 'src/services/videos/processing/types';
 import { CustomError } from 'src/utils/custom-error';
 import { envConfig } from 'src/utils/envConfig';
 import { VIDEO_ERRORS } from 'src/utils/error-codes';
@@ -21,7 +16,6 @@ import { AppResponse } from 'src/utils/schema';
 
 // ffmpeg resolves from PATH — apt-installed (>= 7) in the compute image (SWO-633).
 
-const PLAYLIST_NAME = 'playlist.m3u8';
 const SOURCE = 'apps/compute/videos/routes/repair-fmp4/index.ts';
 
 const buildRepairDeps = (
@@ -42,24 +36,6 @@ const buildRepairDeps = (
   logger: getCurrentLogger(),
 });
 
-/** Objects stored directly under `basePath` (excludes any `v<N>/` rendition). */
-const listStoredObjects = async (
-  bucket: ReturnType<Storage['bucket']>,
-  basePath: string,
-): Promise<{ relativeNames: string[]; topLevel: StoredPart[] }> => {
-  const [files] = await bucket.getFiles({ prefix: `${basePath}/` });
-  const relative = files
-    .map((file) => ({
-      name: file.name.slice(basePath.length + 1),
-      size: Number(file.metadata?.size ?? 0),
-    }))
-    .filter((part) => part.name.length > 0);
-  return {
-    relativeNames: relative.map((part) => part.name),
-    topLevel: relative.filter((part) => !part.name.includes('/')),
-  };
-};
-
 const repairFmp4Handler = async (
   context: HandlerContext<RepairFmp4HandlerRequest>,
 ) => {
@@ -79,27 +55,18 @@ const repairFmp4Handler = async (
     const storage = new Storage();
     const bucket = storage.bucket(envConfig.storageBucket as string);
 
-    const { relativeNames, topLevel } = await listStoredObjects(
-      bucket,
-      storagePath,
-    );
-    // Fresh versioned dir for ALL outputs — never overwrites a 1-year-cached
+    // Plan a cache-safe reprocess from what's stored: the source to remux and a
+    // fresh `v<N>/` dir for ALL outputs, so nothing overwrites a 1-year-cached
     // object (SWO-639).
-    const outputStoragePath = `${storagePath}/${nextVersionDir(relativeNames)}`;
-
-    const plan = planReprocessSource(topLevel);
-    const source: RepackageSource =
-      plan.kind === 'hls-ts'
-        ? {
-            kind: 'hls-url',
-            url: getDownloadUrl(`${storagePath}/${PLAYLIST_NAME}`),
-          }
-        : {
-            kind: 'fmp4-parts',
-            partUrls: plan.partNames.map((name) =>
-              getDownloadUrl(`${storagePath}/${name}`),
-            ),
-          };
+    const [files] = await bucket.getFiles({ prefix: `${storagePath}/` });
+    const { source, outputStoragePath } = planReprocess(
+      files.map((file) => ({
+        name: file.name,
+        size: Number(file.metadata?.size ?? 0),
+      })),
+      storagePath,
+      (path) => getDownloadUrl(path),
+    );
 
     const { manifestStoragePath } = await repackageToFmp4(
       { source, outputStoragePath },

--- a/apps/backend/src/apps/compute/videos/routes/repair-fmp4/index.ts
+++ b/apps/backend/src/apps/compute/videos/routes/repair-fmp4/index.ts
@@ -1,25 +1,17 @@
-import {
-  createReadStream,
-  mkdirSync,
-  mkdtempSync,
-  readdirSync,
-  readFileSync,
-} from 'node:fs';
-import { rm } from 'node:fs/promises';
-import os from 'node:os';
-import path from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import { Storage } from '@google-cloud/storage';
-import ffmpeg from 'fluent-ffmpeg';
 import type { RepairFmp4HandlerRequest } from 'src/schema/videos/repair-fmp4-handler';
 import { finishVideoProcess } from 'src/services/hasura/mutations/videos/finalize';
 import { getDownloadUrl } from 'src/services/videos/helpers/gcp-cloud-storage';
+import { buildFfmpegRepackage } from 'src/services/videos/processing/ffmpegRepackageAdapter';
+import { planReprocessSource } from 'src/services/videos/processing/planReprocessSource';
 import { repackageToFmp4 } from 'src/services/videos/processing/repackageToFmp4';
+import type { StoredPart } from 'src/services/videos/processing/selectFmp4Parts';
 import type {
-  Fmp4Artifacts,
   RepackageDeps,
-  RepackagePort,
+  RepackageSource,
 } from 'src/services/videos/processing/types';
+import { nextVersionDir } from 'src/services/videos/processing/versioning';
 import { CustomError } from 'src/utils/custom-error';
 import { envConfig } from 'src/utils/envConfig';
 import { VIDEO_ERRORS } from 'src/utils/error-codes';
@@ -30,98 +22,41 @@ import { AppResponse } from 'src/utils/schema';
 // ffmpeg resolves from PATH — apt-installed (>= 7) in the compute image (SWO-633).
 
 const PLAYLIST_NAME = 'playlist.m3u8';
-const FMP4_PLAYLIST_NAME = 'playlist-fmp4.m3u8';
-const PLAYLIST_CONTENT_TYPE = 'application/vnd.apple.mpegurl';
 const SOURCE = 'apps/compute/videos/routes/repair-fmp4/index.ts';
 
-const buildFfmpegRepackage = (): RepackagePort => ({
-  repackageToFmp4: async (sourceUrl: string) => {
-    const tempDir = mkdtempSync(path.join(os.tmpdir(), 'fmp4-repair-'));
-    const outputDir = path.join(tempDir, 'out');
-    mkdirSync(outputDir, { recursive: true });
-    const playlistPath = path.join(outputDir, PLAYLIST_NAME);
-
-    await new Promise<void>((res, rej) => {
-      ffmpeg(sourceUrl)
-        .outputOptions([
-          '-c:v',
-          'copy',
-          '-c:a',
-          'aac',
-          '-b:a',
-          '128k',
-          '-ac',
-          '2',
-          '-ar',
-          '44100',
-          '-hls_time',
-          '6',
-          '-hls_playlist_type',
-          'vod',
-          '-hls_segment_type',
-          'fmp4',
-          '-hls_fmp4_init_filename',
-          'init.mp4',
-        ])
-        .format('hls')
-        .output(playlistPath)
-        .on('end', () => res())
-        .on('error', (err, _stdout, stderr) =>
-          rej(
-            new Error(
-              `ffmpeg fMP4 remux failed: ${err.message}\n${stderr ?? ''}`,
-            ),
-          ),
-        )
-        .run();
-    });
-
-    const segmentNames = readdirSync(outputDir)
-      .filter((name) => name.endsWith('.m4s'))
-      .sort(
-        (a, b) =>
-          Number(a.match(/\d+/)?.[0] ?? 0) - Number(b.match(/\d+/)?.[0] ?? 0),
-      );
-
-    const artifacts: Fmp4Artifacts = {
-      init: {
-        name: 'init.mp4',
-        stream: createReadStream(path.join(outputDir, 'init.mp4')),
-      },
-      segments: segmentNames.map((name) => ({
-        name,
-        stream: createReadStream(path.join(outputDir, name)),
-      })),
-      playlistContent: readFileSync(playlistPath, 'utf-8'),
-    };
-
-    return {
-      artifacts,
-      cleanup: async () => {
-        await rm(tempDir, { recursive: true, force: true });
-      },
-    };
+const buildRepairDeps = (
+  bucket: ReturnType<Storage['bucket']>,
+): RepackageDeps => ({
+  storage: {
+    uploadStream: ({ stream, storagePath, contentType }) =>
+      pipeline(
+        stream,
+        bucket.file(storagePath).createWriteStream({
+          contentType,
+          metadata: { cacheControl: 'public, max-age=31536000' },
+        }),
+      ),
+    getDownloadUrl: (storagePath) => getDownloadUrl(storagePath),
   },
+  repackage: buildFfmpegRepackage(),
+  logger: getCurrentLogger(),
 });
 
-const buildRepairDeps = (): RepackageDeps => {
-  const storage = new Storage();
-  const bucket = storage.bucket(envConfig.storageBucket as string);
-
+/** Objects stored directly under `basePath` (excludes any `v<N>/` rendition). */
+const listStoredObjects = async (
+  bucket: ReturnType<Storage['bucket']>,
+  basePath: string,
+): Promise<{ relativeNames: string[]; topLevel: StoredPart[] }> => {
+  const [files] = await bucket.getFiles({ prefix: `${basePath}/` });
+  const relative = files
+    .map((file) => ({
+      name: file.name.slice(basePath.length + 1),
+      size: Number(file.metadata?.size ?? 0),
+    }))
+    .filter((part) => part.name.length > 0);
   return {
-    storage: {
-      uploadStream: ({ stream, storagePath, contentType }) =>
-        pipeline(
-          stream,
-          bucket.file(storagePath).createWriteStream({
-            contentType,
-            metadata: { cacheControl: 'public, max-age=31536000' },
-          }),
-        ),
-      getDownloadUrl: (storagePath) => getDownloadUrl(storagePath),
-    },
-    repackage: buildFfmpegRepackage(),
-    logger: getCurrentLogger(),
+    relativeNames: relative.map((part) => part.name),
+    topLevel: relative.filter((part) => !part.name.includes('/')),
   };
 };
 
@@ -141,20 +76,37 @@ const repairFmp4Handler = async (
     );
 
     const storagePath = `videos/${userId}/${videoId}`;
-    const { playlistContent } = await repackageToFmp4(
-      { storagePath },
-      buildRepairDeps(),
-    );
-
     const storage = new Storage();
     const bucket = storage.bucket(envConfig.storageBucket as string);
-    const fmp4PlaylistPath = `${storagePath}/${FMP4_PLAYLIST_NAME}`;
-    await bucket.file(fmp4PlaylistPath).save(playlistContent, {
-      contentType: PLAYLIST_CONTENT_TYPE,
-      metadata: { cacheControl: 'no-cache' },
-    });
 
-    const newSource = getDownloadUrl(fmp4PlaylistPath);
+    const { relativeNames, topLevel } = await listStoredObjects(
+      bucket,
+      storagePath,
+    );
+    // Fresh versioned dir for ALL outputs — never overwrites a 1-year-cached
+    // object (SWO-639).
+    const outputStoragePath = `${storagePath}/${nextVersionDir(relativeNames)}`;
+
+    const plan = planReprocessSource(topLevel);
+    const source: RepackageSource =
+      plan.kind === 'hls-ts'
+        ? {
+            kind: 'hls-url',
+            url: getDownloadUrl(`${storagePath}/${PLAYLIST_NAME}`),
+          }
+        : {
+            kind: 'fmp4-parts',
+            partUrls: plan.partNames.map((name) =>
+              getDownloadUrl(`${storagePath}/${name}`),
+            ),
+          };
+
+    const { manifestStoragePath } = await repackageToFmp4(
+      { source, outputStoragePath },
+      buildRepairDeps(bucket),
+    );
+
+    const newSource = getDownloadUrl(manifestStoragePath);
 
     await finishVideoProcess({
       taskId,

--- a/apps/backend/src/cli/repair-fmp4.ts
+++ b/apps/backend/src/cli/repair-fmp4.ts
@@ -33,14 +33,9 @@ import { Storage } from '@google-cloud/storage';
 import { GraphQLClient } from 'graphql-request';
 import { assertFfmpegVersion } from 'src/services/videos/helpers/ffmpeg';
 import { buildFfmpegRepackage } from 'src/services/videos/processing/ffmpegRepackageAdapter';
-import { planReprocessSource } from 'src/services/videos/processing/planReprocessSource';
+import { planReprocess } from 'src/services/videos/processing/planReprocess';
 import { repackageToFmp4 } from 'src/services/videos/processing/repackageToFmp4';
-import type { StoredPart } from 'src/services/videos/processing/selectFmp4Parts';
-import type {
-  RepackageDeps,
-  RepackageSource,
-} from 'src/services/videos/processing/types';
-import { nextVersionDir } from 'src/services/videos/processing/versioning';
+import type { RepackageDeps } from 'src/services/videos/processing/types';
 
 // ffmpeg resolves from PATH — must be >= 7 (see SWO-633). On the host this is
 // the developer's system ffmpeg; in the compute image it is apt-installed.
@@ -253,44 +248,25 @@ async function handleRepair(rawArgs: string[]) {
   const storage = createStorage(args.gcpKeyPath);
   const bucket = storage.bucket(args.gcpBucket);
 
-  // Read what's stored to decide the input mode and the next version dir. Only
-  // TOP-LEVEL objects feed the source decision — a reprocess always reads the
-  // original outputs, never a previous v<N>/ rendition.
+  // Plan a cache-safe reprocess from what's stored: the source to remux and a
+  // fresh v<N>/ dir for ALL outputs (never overwrites a 1-year-cached object).
   const [existing] = await bucket.getFiles({ prefix: `${storagePath}/` });
-  const relative = existing
-    .map((f) => ({
-      name: f.name.slice(storagePath.length + 1),
+  const { source, outputStoragePath } = planReprocess(
+    existing.map((f) => ({
+      name: f.name,
       size: Number(f.metadata?.size ?? 0),
-    }))
-    .filter((p) => p.name.length > 0);
-  const topLevel: StoredPart[] = relative.filter((p) => !p.name.includes('/'));
-  const outputStoragePath = `${storagePath}/${nextVersionDir(
-    relative.map((p) => p.name),
-  )}`;
-
-  const plan = planReprocessSource(topLevel);
-  const source: RepackageSource =
-    plan.kind === 'hls-ts'
-      ? {
-          kind: 'hls-url',
-          url: getDownloadUrl(
-            args.gcpBucket,
-            `${storagePath}/${PLAYLIST_NAME}`,
-          ),
-        }
-      : {
-          kind: 'fmp4-parts',
-          partUrls: plan.partNames.map((n) =>
-            getDownloadUrl(args.gcpBucket, `${storagePath}/${n}`),
-          ),
-        };
+    })),
+    storagePath,
+    (p) => getDownloadUrl(args.gcpBucket, p),
+  );
   const newSource = getDownloadUrl(
     args.gcpBucket,
     `${outputStoragePath}/${PLAYLIST_NAME}`,
   );
 
+  const partCount = source.kind === 'fmp4-parts' ? source.partUrls.length : 0;
   console.log(
-    `  Input mode:   ${plan.kind === 'hls-ts' ? 'remux stored .ts' : `recover fMP4 (${plan.partNames.length} parts)`}`,
+    `  Input mode:   ${source.kind === 'hls-url' ? 'remux stored .ts' : `recover fMP4 (${partCount} parts)`}`,
   );
   console.log(`  Output dir:   ${outputStoragePath}/`);
 
@@ -298,7 +274,7 @@ async function handleRepair(rawArgs: string[]) {
     console.log('');
     console.log('[DRY RUN] Would:');
     console.log(
-      `  1. ${plan.kind === 'hls-ts' ? `remux ${storagePath}/${PLAYLIST_NAME}` : `concat + remux ${plan.partNames.length} stored fMP4 part(s)`} → fMP4`,
+      `  1. ${source.kind === 'hls-url' ? `remux ${storagePath}/${PLAYLIST_NAME}` : `concat + remux ${partCount} stored fMP4 part(s)`} → fMP4`,
     );
     console.log(
       `  2. upload init.mp4 + .m4s + ${PLAYLIST_NAME} under ${outputStoragePath}/`,

--- a/apps/backend/src/cli/repair-fmp4.ts
+++ b/apps/backend/src/cli/repair-fmp4.ts
@@ -1,46 +1,46 @@
 #!/usr/bin/env tsx
 
 /**
- * CLI tool to REPAIR a noisy video by repackaging its already-stored `.ts`
- * into fMP4/CMAF (init.mp4 + .m4s). This is the on-demand fix for the hls.js
- * MPEG-TS AAC-demux noise bug (the "Gosick" case) — see
- * `src/docs/fmp4-default-output/`.
+ * CLI tool to REPROCESS a stored video into a clean, cache-safe fMP4/CMAF
+ * rendition. Repairs both defect classes: the hls.js MPEG-TS AAC-demux noise
+ * (a stored `.ts` — the "Gosick" case) and a broken fMP4 with an empty first
+ * segment (the Infinix case) — see `src/docs/look-video-pipeline-fix/`.
  *
  * The default streaming flow is UNTOUCHED. You run this by hand for one video
- * that turns out noisy after it has streamed in and gone `ready`.
+ * that turns out broken after it has streamed in and gone `ready`.
  *
- * It reads the `.ts` we already own (its public GCS playlist URL), so it works
- * even after the original third-party source URL has expired.
+ * It reads the objects we already own from GCS (their public URLs) — a stored
+ * `.ts` playlist, or the fMP4 parts to concatenate — so it works even after the
+ * original third-party source URL has expired.
+ *
+ * Every output (init, segments, manifest) is written under a FRESH versioned
+ * directory (`v<N>/`) and `videos.source` is repointed at the new manifest, so
+ * the fix is visible immediately despite GCS's 1-year immutable cache (SWO-639).
+ * The previous objects are left untouched (harmless orphans).
  *
  * Setup reuses the same `~/.sworld-cli/config.json` as `stream-m3u8.ts`
  * (gcp-key, gcp-bucket, hasura-endpoint, hasura-secret).
  *
  * Usage:
- *   npx tsx src/cli/repair-fmp4.ts repair --video-id <uuid> [--dry-run] [--delete-ts]
+ *   npx tsx src/cli/repair-fmp4.ts repair --video-id <uuid> [--dry-run]
  */
 
-import {
-  createReadStream,
-  existsSync,
-  mkdirSync,
-  mkdtempSync,
-  readdirSync,
-  readFileSync,
-} from 'node:fs';
-import { rm } from 'node:fs/promises';
+import { existsSync, readFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import { Storage } from '@google-cloud/storage';
-import ffmpeg from 'fluent-ffmpeg';
 import { GraphQLClient } from 'graphql-request';
 import { assertFfmpegVersion } from 'src/services/videos/helpers/ffmpeg';
+import { buildFfmpegRepackage } from 'src/services/videos/processing/ffmpegRepackageAdapter';
+import { planReprocessSource } from 'src/services/videos/processing/planReprocessSource';
 import { repackageToFmp4 } from 'src/services/videos/processing/repackageToFmp4';
+import type { StoredPart } from 'src/services/videos/processing/selectFmp4Parts';
 import type {
-  Fmp4Artifacts,
   RepackageDeps,
-  RepackagePort,
+  RepackageSource,
 } from 'src/services/videos/processing/types';
+import { nextVersionDir } from 'src/services/videos/processing/versioning';
 
 // ffmpeg resolves from PATH — must be >= 7 (see SWO-633). On the host this is
 // the developer's system ffmpeg; in the compute image it is apt-installed.
@@ -49,12 +49,6 @@ import type {
 
 const CONFIG_FILE = path.join(os.homedir(), '.sworld-cli', 'config.json');
 const PLAYLIST_NAME = 'playlist.m3u8';
-// The fMP4 playlist gets its OWN name (not an overwrite of playlist.m3u8). The
-// original `.ts` playlist was uploaded with a 1-year max-age, so overwriting it
-// can't reach clients/edge caches that already hold it. Publishing at a fresh
-// URL + repointing `videos.source` sidesteps caching entirely.
-const FMP4_PLAYLIST_NAME = 'playlist-fmp4.m3u8';
-const PLAYLIST_CONTENT_TYPE = 'application/vnd.apple.mpegurl';
 
 interface CliConfig {
   'user-id'?: string;
@@ -87,7 +81,6 @@ function resolve(
 interface RepairArgs {
   videoId: string;
   dryRun: boolean;
-  deleteTs: boolean;
   gcpKeyPath?: string;
   gcpBucket: string;
   hasuraEndpoint: string;
@@ -136,7 +129,6 @@ function parseRepairArgs(rawArgs: string[]): RepairArgs {
   return {
     videoId,
     dryRun: has('--dry-run'),
-    deleteTs: has('--delete-ts'),
     gcpKeyPath,
     gcpBucket,
     hasuraEndpoint,
@@ -154,88 +146,7 @@ function getDownloadUrl(bucket: string, storagePath: string): string {
   return `https://storage.googleapis.com/${bucket}/${storagePath}`;
 }
 
-// ─── ffmpeg fMP4 remux adapter (RepackagePort) ──────────────────────────────
-
-/**
- * Real `RepackagePort`: remux an HLS source URL into fMP4/CMAF in a temp dir
- * with no video transcode. Audio is re-encoded to AAC — the proven-clean recipe
- * that regenerates a correct `AudioSpecificConfig` and sidesteps the malformed
- * source config that causes the hls.js noise. Returns lazily-opened file streams
- * so a whole video never sits in memory, plus a `cleanup()` for the temp dir.
- */
-function buildFfmpegRepackage(): RepackagePort {
-  return {
-    repackageToFmp4: async (sourceUrl: string) => {
-      const tempDir = mkdtempSync(path.join(os.tmpdir(), 'fmp4-repair-'));
-      const outputDir = path.join(tempDir, 'out');
-      mkdirSync(outputDir, { recursive: true });
-      const playlistPath = path.join(outputDir, PLAYLIST_NAME);
-
-      await new Promise<void>((res, rej) => {
-        ffmpeg(sourceUrl)
-          .outputOptions([
-            '-c:v',
-            'copy', // no video transcode
-            '-c:a',
-            'aac',
-            '-b:a',
-            '128k',
-            '-ac',
-            '2',
-            '-ar',
-            '44100',
-            '-hls_time',
-            '6',
-            '-hls_playlist_type',
-            'vod',
-            '-hls_segment_type',
-            'fmp4',
-            '-hls_fmp4_init_filename',
-            'init.mp4',
-          ])
-          .format('hls')
-          .output(playlistPath)
-          .on('end', () => res())
-          .on('error', (err, _stdout, stderr) =>
-            rej(
-              new Error(
-                `ffmpeg fMP4 remux failed: ${err.message}\n${stderr ?? ''}`,
-              ),
-            ),
-          )
-          .run();
-      });
-
-      const segmentNames = readdirSync(outputDir)
-        .filter((name) => name.endsWith('.m4s'))
-        .sort(
-          (a, b) =>
-            Number(a.match(/\d+/)?.[0] ?? 0) - Number(b.match(/\d+/)?.[0] ?? 0),
-        );
-
-      const artifacts: Fmp4Artifacts = {
-        init: {
-          name: 'init.mp4',
-          stream: createReadStream(path.join(outputDir, 'init.mp4')),
-        },
-        segments: segmentNames.map((name) => ({
-          name,
-          stream: createReadStream(path.join(outputDir, name)),
-        })),
-        playlistContent: readFileSync(playlistPath, 'utf-8'),
-      };
-
-      return {
-        artifacts,
-        cleanup: async () => {
-          await rm(tempDir, { recursive: true, force: true });
-        },
-      };
-    },
-  };
-}
-
-// ─── CLI deps for the P1 engine ─────────────────────────────────────────────
+// ─── CLI deps for the reprocess engine ──────────────────────────────────────
 
 function buildRepairDeps(args: RepairArgs): RepackageDeps {
   const storage = createStorage(args.gcpKeyPath);
@@ -329,11 +240,10 @@ async function handleRepair(rawArgs: string[]) {
     process.exit(1);
   }
 
-  console.log('=== fMP4 Repair ===');
-  console.log(`  Video ID:    ${args.videoId}`);
-  console.log(`  GCP Bucket:  ${args.gcpBucket}`);
-  console.log(`  Dry run:        ${args.dryRun}`);
-  console.log(`  Delete old .ts: ${args.deleteTs}`);
+  console.log('=== fMP4 Reprocess ===');
+  console.log(`  Video ID:   ${args.videoId}`);
+  console.log(`  GCP Bucket: ${args.gcpBucket}`);
+  console.log(`  Dry run:    ${args.dryRun}`);
   console.log('');
 
   const video = await getVideo(args);
@@ -343,88 +253,97 @@ async function handleRepair(rawArgs: string[]) {
   const storage = createStorage(args.gcpKeyPath);
   const bucket = storage.bucket(args.gcpBucket);
 
-  // Count the existing .ts so the operator sees the before-state.
+  // Read what's stored to decide the input mode and the next version dir. Only
+  // TOP-LEVEL objects feed the source decision — a reprocess always reads the
+  // original outputs, never a previous v<N>/ rendition.
   const [existing] = await bucket.getFiles({ prefix: `${storagePath}/` });
-  const staleTs = existing.filter((f) => f.name.endsWith('.ts'));
-  console.log(`  Existing .ts segments: ${staleTs.length}`);
+  const relative = existing
+    .map((f) => ({
+      name: f.name.slice(storagePath.length + 1),
+      size: Number(f.metadata?.size ?? 0),
+    }))
+    .filter((p) => p.name.length > 0);
+  const topLevel: StoredPart[] = relative.filter((p) => !p.name.includes('/'));
+  const outputStoragePath = `${storagePath}/${nextVersionDir(
+    relative.map((p) => p.name),
+  )}`;
 
-  const fmp4PlaylistPath = `${storagePath}/${FMP4_PLAYLIST_NAME}`;
-  const newSource = getDownloadUrl(args.gcpBucket, fmp4PlaylistPath);
+  const plan = planReprocessSource(topLevel);
+  const source: RepackageSource =
+    plan.kind === 'hls-ts'
+      ? {
+          kind: 'hls-url',
+          url: getDownloadUrl(
+            args.gcpBucket,
+            `${storagePath}/${PLAYLIST_NAME}`,
+          ),
+        }
+      : {
+          kind: 'fmp4-parts',
+          partUrls: plan.partNames.map((n) =>
+            getDownloadUrl(args.gcpBucket, `${storagePath}/${n}`),
+          ),
+        };
+  const newSource = getDownloadUrl(
+    args.gcpBucket,
+    `${outputStoragePath}/${PLAYLIST_NAME}`,
+  );
+
+  console.log(
+    `  Input mode:   ${plan.kind === 'hls-ts' ? 'remux stored .ts' : `recover fMP4 (${plan.partNames.length} parts)`}`,
+  );
+  console.log(`  Output dir:   ${outputStoragePath}/`);
 
   if (args.dryRun) {
     console.log('');
     console.log('[DRY RUN] Would:');
-    console.log(`  1. ffmpeg-remux ${storagePath}/${PLAYLIST_NAME} → fMP4`);
-    console.log('  2. upload init.mp4 + .m4s (new names, alongside the .ts)');
     console.log(
-      `  3. write the fMP4 playlist to ${FMP4_PLAYLIST_NAME} (no-cache)`,
+      `  1. ${plan.kind === 'hls-ts' ? `remux ${storagePath}/${PLAYLIST_NAME}` : `concat + remux ${plan.partNames.length} stored fMP4 part(s)`} → fMP4`,
     );
-    console.log(`  4. point videos.source → ${newSource}`);
     console.log(
-      `  5. ${args.deleteTs ? `delete the ${staleTs.length} old .ts segment(s) + ${PLAYLIST_NAME}` : `KEEP the ${staleTs.length} old .ts (re-runnable; use --delete-ts to remove)`}`,
+      `  2. upload init.mp4 + .m4s + ${PLAYLIST_NAME} under ${outputStoragePath}/`,
     );
+    console.log(`  3. point videos.source → ${newSource}`);
+    console.log('  4. leave the previous objects untouched (harmless orphans)');
     console.log('[DRY RUN] Done — nothing written.');
     return;
   }
 
   // Enforce the ffmpeg >= 7 prerequisite (SWO-633) before any real work: the
-  // repackage below drives the same fMP4/CMAF HLS muxer whose 4.x version emits
-  // the empty first segment, so an old host ffmpeg would "repair" the video into
-  // the very bug we're fixing and upload it. Fail fast instead — compute enforces
-  // the same check at startup.
+  // remux below drives the same fMP4/CMAF HLS muxer whose 4.x version emits the
+  // empty first segment, so an old host ffmpeg would reprocess the video into the
+  // very bug we're fixing. Fail fast instead — compute enforces this at startup.
   assertFfmpegVersion();
 
-  // 1-2. Repackage + upload the new fMP4 segments (additive, non-destructive).
   console.log('');
-  console.log('Repackaging to fMP4 (ffmpeg) + uploading new segments…');
-  const { initName, segmentNames, playlistContent } = await repackageToFmp4(
-    { storagePath },
+  console.log('Reprocessing to fMP4 (ffmpeg) + uploading versioned rendition…');
+  const { initName, segmentNames, manifestStoragePath } = await repackageToFmp4(
+    { source, outputStoragePath },
     buildRepairDeps(args),
   );
   console.log(
-    `  Uploaded ${initName} + ${segmentNames.length} .m4s segment(s).`,
+    `  Uploaded ${initName} + ${segmentNames.length} .m4s segment(s) + manifest.`,
   );
 
-  // 3. Verify the new init exists before we publish (never a broken window).
-  const [initExists] = await bucket.file(`${storagePath}/${initName}`).exists();
-  if (!initExists) {
+  // Verify the new manifest is in place before repointing (never a broken
+  // window). The engine uploads it LAST, so its presence implies the whole
+  // versioned rendition is up.
+  const [manifestExists] = await bucket.file(manifestStoragePath).exists();
+  if (!manifestExists) {
     throw new Error(
-      `Aborting: ${initName} not found in storage after upload — leaving the .ts video untouched.`,
+      `Aborting: ${manifestStoragePath} not found after upload — leaving videos.source untouched.`,
     );
   }
 
-  // 4. Write the fMP4 playlist to its OWN name (no-cache), then point source at
-  //    it. A fresh URL has no cache history, so clients get the fMP4 at once —
-  //    unlike overwriting playlist.m3u8, which the edge may serve stale for up to
-  //    its original 1-year max-age. source is only flipped after the fMP4 files
-  //    are all in place, so a failure earlier leaves the .ts video serving.
-  console.log(`Writing ${FMP4_PLAYLIST_NAME} (no-cache)…`);
-  await bucket.file(fmp4PlaylistPath).save(playlistContent, {
-    contentType: PLAYLIST_CONTENT_TYPE,
-    metadata: { cacheControl: 'no-cache' },
-  });
-  console.log('Pointing videos.source → fMP4 playlist…');
+  console.log('Pointing videos.source → versioned fMP4 manifest…');
   await updateVideoSource(args, newSource);
-
-  // 5. The old .ts is now superseded. Keep it by default (the repair stays
-  //    re-runnable from the original); delete only when asked.
-  if (args.deleteTs) {
-    const stale = [
-      ...staleTs,
-      ...existing.filter((f) => f.name.endsWith(`/${PLAYLIST_NAME}`)),
-    ];
-    console.log(`Deleting ${stale.length} superseded .ts object(s)…`);
-    await Promise.all(stale.map((f) => f.delete()));
-  } else if (staleTs.length) {
-    console.log(
-      `Keeping ${staleTs.length} old .ts segment(s) (re-runnable; --delete-ts to remove).`,
-    );
-  }
 
   console.log('');
   console.log('=== Done ===');
   console.log(`  videos.source now → ${newSource}`);
-  console.log('  Verify it plays clean on desktop Chrome, then you are set.');
+  console.log(
+    '  Previous objects left untouched (orphans). Verify it plays clean.',
+  );
 }
 
 // ─── Main router ────────────────────────────────────────────────────────────
@@ -434,19 +353,19 @@ function main() {
   const command = args[0];
 
   if (!command || command === '--help' || command === '-h') {
-    console.log('sworld-cli - fMP4 Repair');
+    console.log('sworld-cli - fMP4 Reprocess');
     console.log('');
-    console.log('Repackage one already-stored noisy video from .ts to fMP4.');
+    console.log(
+      'Reprocess one stored video into a fresh, cache-safe fMP4 rendition',
+    );
+    console.log('(from a stored .ts, or by recovering a broken fMP4).');
     console.log('');
     console.log('Usage:');
-    console.log('  repair --video-id <uuid> [--dry-run] [--delete-ts]');
+    console.log('  repair --video-id <uuid> [--dry-run]');
     console.log('');
     console.log('Options:');
-    console.log('  --video-id <uuid>   Video to repair (required)');
+    console.log('  --video-id <uuid>   Video to reprocess (required)');
     console.log('  --dry-run           Show the plan, write nothing');
-    console.log(
-      '  --delete-ts         Delete the old .ts after repair (default: keep, re-runnable)',
-    );
     console.log('  --gcp-key <path>    Override GCS key file');
     console.log('  --gcp-bucket <name> Override GCS bucket');
     return;

--- a/apps/backend/src/cli/repair-fmp4.ts
+++ b/apps/backend/src/cli/repair-fmp4.ts
@@ -259,7 +259,9 @@ async function handleRepair(rawArgs: string[]) {
     storagePath,
     (p) => getDownloadUrl(args.gcpBucket, p),
   );
-  const newSource = getDownloadUrl(
+  // Preview URL for the dry-run only; the real repoint URL is derived from the
+  // engine's returned manifestStoragePath after the upload (below).
+  const plannedSource = getDownloadUrl(
     args.gcpBucket,
     `${outputStoragePath}/${PLAYLIST_NAME}`,
   );
@@ -279,7 +281,7 @@ async function handleRepair(rawArgs: string[]) {
     console.log(
       `  2. upload init.mp4 + .m4s + ${PLAYLIST_NAME} under ${outputStoragePath}/`,
     );
-    console.log(`  3. point videos.source → ${newSource}`);
+    console.log(`  3. point videos.source → ${plannedSource}`);
     console.log('  4. leave the previous objects untouched (harmless orphans)');
     console.log('[DRY RUN] Done — nothing written.');
     return;
@@ -311,6 +313,9 @@ async function handleRepair(rawArgs: string[]) {
     );
   }
 
+  // Repoint at the manifest the engine actually wrote (not a pre-guessed path),
+  // so the URL we verified above is exactly the one we point videos.source at.
+  const newSource = getDownloadUrl(args.gcpBucket, manifestStoragePath);
   console.log('Pointing videos.source → versioned fMP4 manifest…');
   await updateVideoSource(args, newSource);
 

--- a/apps/backend/src/services/videos/processing/ffmpegRepackageAdapter.ts
+++ b/apps/backend/src/services/videos/processing/ffmpegRepackageAdapter.ts
@@ -1,13 +1,20 @@
-import { createReadStream, readdirSync, readFileSync, statSync } from 'node:fs';
-import { appendFile, readFile } from 'node:fs/promises';
+import {
+  createReadStream,
+  createWriteStream,
+  readdirSync,
+  readFileSync,
+  statSync,
+} from 'node:fs';
 import path from 'node:path';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 import ffmpeg from 'fluent-ffmpeg';
 import {
   cleanupDirectory,
   createDirectory,
-  downloadFile,
   generateTempDir,
 } from 'src/services/videos/helpers/file';
+import { videoConfig } from '../config';
 import { EMPTY_SEGMENT_MAX_BYTES } from './selectFmp4Parts';
 import type { Fmp4Artifacts, RepackagePort, RepackageSource } from './types';
 
@@ -81,21 +88,32 @@ const runFfmpeg = (
  * videos, so the concatenation is a valid fMP4 byte stream ffmpeg can re-segment
  * (SWO-639, the Infinix recovery).
  *
- * Each part is a single fMP4 fragment (small by construction), so a
- * read-into-memory append keeps the concat simple and — unlike a persistent
- * write stream — has no mid-write `error` event that could crash the process
- * unhandled. Downloads reuse the shared `downloadFile` helper (size-limit guard
- * + partial-file cleanup).
+ * Each part is streamed straight into the combined file in append mode. Not the
+ * shared `downloadFile` helper: this appends (that writes a fresh file) and,
+ * more importantly, `pipeline` resolves only after the write has flushed and
+ * closed — so every part is fully on disk before ffmpeg reads the result, and a
+ * mid-write stream error surfaces as a rejection rather than an unhandled crash.
  */
 const concatParts = async (
   partUrls: string[],
   workDir: string,
 ): Promise<string> => {
   const combinedPath = path.join(workDir, 'combined.mp4');
-  for (let i = 0; i < partUrls.length; i++) {
-    const partPath = path.join(workDir, `part-${i}`);
-    await downloadFile(partUrls[i], partPath);
-    await appendFile(combinedPath, await readFile(partPath));
+  for (const url of partUrls) {
+    const response = await fetch(url);
+    if (!response.ok || !response.body) {
+      throw new Error(`Download failed (${response.status}) for ${url}`);
+    }
+    if (
+      Number(response.headers.get('content-length') ?? 0) >
+      videoConfig.maxFileSize
+    ) {
+      throw new Error(`fMP4 part exceeds the max file size: ${url}`);
+    }
+    await pipeline(
+      Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]),
+      createWriteStream(combinedPath, { flags: 'a' }),
+    );
   }
   return combinedPath;
 };
@@ -106,16 +124,23 @@ const segmentIndex = (name: string): number =>
 const readArtifacts = (outputDir: string): Fmp4Artifacts => {
   const segmentNames = readdirSync(outputDir)
     .filter((name) => name.endsWith('.m4s'))
-    // Drop any empty (moof-only, <= 24-byte) output segment. With ffmpeg >= 7
-    // the valid paths never produce one; an empty segment appears only when a
-    // media-less init was remuxed alone — dropping it collapses to the engine's
-    // "no segments" failure instead of re-shipping the empty-first-segment bug
-    // this whole fix exists to remove (SWO-633/639).
-    .filter(
-      (name) =>
-        statSync(path.join(outputDir, name)).size > EMPTY_SEGMENT_MAX_BYTES,
-    )
     .sort((a, b) => segmentIndex(a) - segmentIndex(b));
+
+  // Fail hard on ANY empty (moof-only, <= 24-byte) output segment rather than
+  // dropping it: the manifest (`playlistContent`) references every segment
+  // ffmpeg wrote, so silently omitting one from the upload would ship a
+  // rendition whose manifest points at a missing object. With ffmpeg >= 7 (both
+  // callers enforce it) the valid paths never emit one; an empty segment means
+  // either a media-less init remuxed alone or a pre-7 ffmpeg reintroducing the
+  // very empty-first-segment bug this fix removes — both must fail, not ship
+  // (SWO-633/639).
+  for (const name of segmentNames) {
+    if (statSync(path.join(outputDir, name)).size <= EMPTY_SEGMENT_MAX_BYTES) {
+      throw new Error(
+        `Remux produced an empty segment (${name}) — no playable media`,
+      );
+    }
+  }
 
   return {
     init: {

--- a/apps/backend/src/services/videos/processing/ffmpegRepackageAdapter.ts
+++ b/apps/backend/src/services/videos/processing/ffmpegRepackageAdapter.ts
@@ -6,7 +6,7 @@ import {
   statSync,
 } from 'node:fs';
 import path from 'node:path';
-import { Readable } from 'node:stream';
+import { Readable, Transform } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import ffmpeg from 'fluent-ffmpeg';
 import {
@@ -14,6 +14,8 @@ import {
   createDirectory,
   generateTempDir,
 } from 'src/services/videos/helpers/file';
+import { fetchWithError } from 'src/utils/fetch';
+import { systemConfig } from 'src/utils/systemConfig';
 import { videoConfig } from '../config';
 import { EMPTY_SEGMENT_MAX_BYTES } from './selectFmp4Parts';
 import type { Fmp4Artifacts, RepackagePort, RepackageSource } from './types';
@@ -83,6 +85,25 @@ const runFfmpeg = (
   });
 
 /**
+ * A Transform that fails the stream once more than `limit` bytes have passed
+ * through — enforces the size cap on the ACTUAL bytes received, so a response
+ * with a missing or lying `content-length` can't write an unbounded file.
+ */
+const cappedAt = (limit: number): Transform => {
+  let total = 0;
+  return new Transform({
+    transform(chunk, _encoding, callback) {
+      total += chunk.length;
+      if (total > limit) {
+        callback(new Error('fMP4 part exceeds the max file size'));
+        return;
+      }
+      callback(null, chunk);
+    },
+  });
+};
+
+/**
  * Concatenate the fMP4 parts (init + non-empty segments, in order) into one
  * file. The init already embeds the first fragment's media on the affected
  * videos, so the concatenation is a valid fMP4 byte stream ffmpeg can re-segment
@@ -93,6 +114,9 @@ const runFfmpeg = (
  * more importantly, `pipeline` resolves only after the write has flushed and
  * closed — so every part is fully on disk before ffmpeg reads the result, and a
  * mid-write stream error surfaces as a rejection rather than an unhandled crash.
+ * `fetchWithError` bounds each fetch with the external-request timeout (a stalled
+ * download can't hang the task) and classifies 4xx/5xx; `cappedAt` enforces the
+ * size limit on the real byte count.
  */
 const concatParts = async (
   partUrls: string[],
@@ -100,18 +124,15 @@ const concatParts = async (
 ): Promise<string> => {
   const combinedPath = path.join(workDir, 'combined.mp4');
   for (const url of partUrls) {
-    const response = await fetch(url);
-    if (!response.ok || !response.body) {
-      throw new Error(`Download failed (${response.status}) for ${url}`);
-    }
-    if (
-      Number(response.headers.get('content-length') ?? 0) >
-      videoConfig.maxFileSize
-    ) {
-      throw new Error(`fMP4 part exceeds the max file size: ${url}`);
+    const response = await fetchWithError(url, {
+      timeout: systemConfig.defaultExternalRequestTimeout,
+    });
+    if (!response.body) {
+      throw new Error(`Empty response body for ${url}`);
     }
     await pipeline(
       Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]),
+      cappedAt(videoConfig.maxFileSize),
       createWriteStream(combinedPath, { flags: 'a' }),
     );
   }

--- a/apps/backend/src/services/videos/processing/ffmpegRepackageAdapter.ts
+++ b/apps/backend/src/services/videos/processing/ffmpegRepackageAdapter.ts
@@ -1,0 +1,171 @@
+import {
+  createReadStream,
+  createWriteStream,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+} from 'node:fs';
+import { rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import ffmpeg from 'fluent-ffmpeg';
+import type { Fmp4Artifacts, RepackagePort, RepackageSource } from './types';
+
+// ffmpeg resolves from PATH — apt-installed (>= 7) in the compute image, system
+// ffmpeg on the host for the CLI (SWO-633/637).
+
+const INIT_FILENAME = 'init.mp4';
+const PLAYLIST_NAME = 'playlist.m3u8';
+
+// Segment/init cut is fMP4/CMAF for both source kinds; the difference is codec
+// handling. A stored `.ts` re-encodes audio to AAC (regenerates a clean
+// AudioSpecificConfig — the fix for the hls.js MPEG-TS demux noise), while
+// already-fMP4 parts are copied losslessly (a pure recovery, no re-encode).
+const HLS_URL_OUTPUT_OPTIONS = [
+  '-c:v',
+  'copy',
+  '-c:a',
+  'aac',
+  '-b:a',
+  '128k',
+  '-ac',
+  '2',
+  '-ar',
+  '44100',
+  '-hls_time',
+  '6',
+  '-hls_playlist_type',
+  'vod',
+  '-hls_segment_type',
+  'fmp4',
+  '-hls_fmp4_init_filename',
+  INIT_FILENAME,
+];
+const FMP4_PARTS_OUTPUT_OPTIONS = [
+  '-c',
+  'copy',
+  '-hls_time',
+  '6',
+  '-hls_playlist_type',
+  'vod',
+  '-hls_segment_type',
+  'fmp4',
+  '-hls_fmp4_init_filename',
+  INIT_FILENAME,
+];
+
+const runFfmpeg = (
+  inputPath: string,
+  outputOptions: string[],
+  playlistPath: string,
+): Promise<void> =>
+  new Promise<void>((resolve, reject) => {
+    ffmpeg(inputPath)
+      .outputOptions(outputOptions)
+      .format('hls')
+      .output(playlistPath)
+      .on('end', () => resolve())
+      .on('error', (err, _stdout, stderr) =>
+        reject(
+          new Error(
+            `ffmpeg fMP4 remux failed: ${err.message}\n${stderr ?? ''}`,
+          ),
+        ),
+      )
+      .run();
+  });
+
+const downloadTo = async (url: string, dest: string): Promise<void> => {
+  const response = await fetch(url);
+  if (!response.ok || !response.body) {
+    throw new Error(`Download failed (${response.status}) for ${url}`);
+  }
+  await pipeline(
+    Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]),
+    createWriteStream(dest),
+  );
+};
+
+/**
+ * Concatenate the fMP4 parts (init + non-empty segments, in order) into one
+ * file. The init already embeds the first fragment's media on the affected
+ * videos, so the concatenation is a valid fMP4 byte stream ffmpeg can re-segment
+ * (SWO-639, the Infinix recovery).
+ */
+const concatParts = async (
+  partUrls: string[],
+  workDir: string,
+): Promise<string> => {
+  const combinedPath = path.join(workDir, 'combined.mp4');
+  const out = createWriteStream(combinedPath);
+  try {
+    for (let i = 0; i < partUrls.length; i++) {
+      const partPath = path.join(workDir, `part-${i}`);
+      await downloadTo(partUrls[i], partPath);
+      await new Promise<void>((resolve, reject) => {
+        const rs = createReadStream(partPath);
+        rs.on('error', reject);
+        rs.on('end', () => resolve());
+        rs.pipe(out, { end: false });
+      });
+    }
+  } finally {
+    await new Promise<void>((resolve) => out.end(resolve));
+  }
+  return combinedPath;
+};
+
+const readArtifacts = (outputDir: string): Fmp4Artifacts => {
+  const segmentNames = readdirSync(outputDir)
+    .filter((name) => name.endsWith('.m4s'))
+    .sort(
+      (a, b) =>
+        Number(a.match(/\d+/)?.[0] ?? 0) - Number(b.match(/\d+/)?.[0] ?? 0),
+    );
+
+  return {
+    init: {
+      name: INIT_FILENAME,
+      stream: createReadStream(path.join(outputDir, INIT_FILENAME)),
+    },
+    segments: segmentNames.map((name) => ({
+      name,
+      stream: createReadStream(path.join(outputDir, name)),
+    })),
+    playlistContent: readFileSync(path.join(outputDir, PLAYLIST_NAME), 'utf-8'),
+  };
+};
+
+/**
+ * Real {@link RepackagePort}: remux a {@link RepackageSource} into fMP4/CMAF in
+ * a temp dir. Returns lazily-opened file streams (a whole video never sits in
+ * memory) plus a `cleanup()` for the temp dir. Shared by the compute route and
+ * the CLI so the recovery recipe lives in exactly one place.
+ */
+const buildFfmpegRepackage = (): RepackagePort => ({
+  repackageToFmp4: async (source: RepackageSource) => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), 'fmp4-repair-'));
+    const outputDir = path.join(tempDir, 'out');
+    mkdirSync(outputDir, { recursive: true });
+    const playlistPath = path.join(outputDir, PLAYLIST_NAME);
+
+    if (source.kind === 'hls-url') {
+      await runFfmpeg(source.url, HLS_URL_OUTPUT_OPTIONS, playlistPath);
+    } else {
+      const combinedPath = await concatParts(source.partUrls, tempDir);
+      await runFfmpeg(combinedPath, FMP4_PARTS_OUTPUT_OPTIONS, playlistPath);
+    }
+
+    return {
+      artifacts: readArtifacts(outputDir),
+      cleanup: async () => {
+        await rm(tempDir, { recursive: true, force: true });
+      },
+    };
+  },
+});
+
+export { buildFfmpegRepackage };

--- a/apps/backend/src/services/videos/processing/ffmpegRepackageAdapter.ts
+++ b/apps/backend/src/services/videos/processing/ffmpegRepackageAdapter.ts
@@ -1,17 +1,14 @@
-import {
-  createReadStream,
-  createWriteStream,
-  mkdirSync,
-  mkdtempSync,
-  readdirSync,
-  readFileSync,
-} from 'node:fs';
-import { rm } from 'node:fs/promises';
-import os from 'node:os';
+import { createReadStream, readdirSync, readFileSync, statSync } from 'node:fs';
+import { appendFile, readFile } from 'node:fs/promises';
 import path from 'node:path';
-import { Readable } from 'node:stream';
-import { pipeline } from 'node:stream/promises';
 import ffmpeg from 'fluent-ffmpeg';
+import {
+  cleanupDirectory,
+  createDirectory,
+  downloadFile,
+  generateTempDir,
+} from 'src/services/videos/helpers/file';
+import { EMPTY_SEGMENT_MAX_BYTES } from './selectFmp4Parts';
 import type { Fmp4Artifacts, RepackagePort, RepackageSource } from './types';
 
 // ffmpeg resolves from PATH — apt-installed (>= 7) in the compute image, system
@@ -78,53 +75,47 @@ const runFfmpeg = (
       .run();
   });
 
-const downloadTo = async (url: string, dest: string): Promise<void> => {
-  const response = await fetch(url);
-  if (!response.ok || !response.body) {
-    throw new Error(`Download failed (${response.status}) for ${url}`);
-  }
-  await pipeline(
-    Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]),
-    createWriteStream(dest),
-  );
-};
-
 /**
  * Concatenate the fMP4 parts (init + non-empty segments, in order) into one
  * file. The init already embeds the first fragment's media on the affected
  * videos, so the concatenation is a valid fMP4 byte stream ffmpeg can re-segment
  * (SWO-639, the Infinix recovery).
+ *
+ * Each part is a single fMP4 fragment (small by construction), so a
+ * read-into-memory append keeps the concat simple and — unlike a persistent
+ * write stream — has no mid-write `error` event that could crash the process
+ * unhandled. Downloads reuse the shared `downloadFile` helper (size-limit guard
+ * + partial-file cleanup).
  */
 const concatParts = async (
   partUrls: string[],
   workDir: string,
 ): Promise<string> => {
   const combinedPath = path.join(workDir, 'combined.mp4');
-  const out = createWriteStream(combinedPath);
-  try {
-    for (let i = 0; i < partUrls.length; i++) {
-      const partPath = path.join(workDir, `part-${i}`);
-      await downloadTo(partUrls[i], partPath);
-      await new Promise<void>((resolve, reject) => {
-        const rs = createReadStream(partPath);
-        rs.on('error', reject);
-        rs.on('end', () => resolve());
-        rs.pipe(out, { end: false });
-      });
-    }
-  } finally {
-    await new Promise<void>((resolve) => out.end(resolve));
+  for (let i = 0; i < partUrls.length; i++) {
+    const partPath = path.join(workDir, `part-${i}`);
+    await downloadFile(partUrls[i], partPath);
+    await appendFile(combinedPath, await readFile(partPath));
   }
   return combinedPath;
 };
 
+const segmentIndex = (name: string): number =>
+  Number(name.match(/\d+/)?.[0] ?? 0);
+
 const readArtifacts = (outputDir: string): Fmp4Artifacts => {
   const segmentNames = readdirSync(outputDir)
     .filter((name) => name.endsWith('.m4s'))
-    .sort(
-      (a, b) =>
-        Number(a.match(/\d+/)?.[0] ?? 0) - Number(b.match(/\d+/)?.[0] ?? 0),
-    );
+    // Drop any empty (moof-only, <= 24-byte) output segment. With ffmpeg >= 7
+    // the valid paths never produce one; an empty segment appears only when a
+    // media-less init was remuxed alone — dropping it collapses to the engine's
+    // "no segments" failure instead of re-shipping the empty-first-segment bug
+    // this whole fix exists to remove (SWO-633/639).
+    .filter(
+      (name) =>
+        statSync(path.join(outputDir, name)).size > EMPTY_SEGMENT_MAX_BYTES,
+    )
+    .sort((a, b) => segmentIndex(a) - segmentIndex(b));
 
   return {
     init: {
@@ -147,24 +138,29 @@ const readArtifacts = (outputDir: string): Fmp4Artifacts => {
  */
 const buildFfmpegRepackage = (): RepackagePort => ({
   repackageToFmp4: async (source: RepackageSource) => {
-    const tempDir = mkdtempSync(path.join(os.tmpdir(), 'fmp4-repair-'));
-    const outputDir = path.join(tempDir, 'out');
-    mkdirSync(outputDir, { recursive: true });
-    const playlistPath = path.join(outputDir, PLAYLIST_NAME);
+    const tempDir = generateTempDir();
+    try {
+      const outputDir = path.join(tempDir, 'out');
+      await createDirectory(outputDir);
+      const playlistPath = path.join(outputDir, PLAYLIST_NAME);
 
-    if (source.kind === 'hls-url') {
-      await runFfmpeg(source.url, HLS_URL_OUTPUT_OPTIONS, playlistPath);
-    } else {
-      const combinedPath = await concatParts(source.partUrls, tempDir);
-      await runFfmpeg(combinedPath, FMP4_PARTS_OUTPUT_OPTIONS, playlistPath);
+      if (source.kind === 'hls-url') {
+        await runFfmpeg(source.url, HLS_URL_OUTPUT_OPTIONS, playlistPath);
+      } else {
+        const combinedPath = await concatParts(source.partUrls, tempDir);
+        await runFfmpeg(combinedPath, FMP4_PARTS_OUTPUT_OPTIONS, playlistPath);
+      }
+
+      return {
+        artifacts: readArtifacts(outputDir),
+        cleanup: () => cleanupDirectory(tempDir),
+      };
+    } catch (error) {
+      // Any failure here happens before `cleanup` is handed back, so the engine
+      // never gets a chance to remove the temp dir — clean it up ourselves.
+      await cleanupDirectory(tempDir);
+      throw error;
     }
-
-    return {
-      artifacts: readArtifacts(outputDir),
-      cleanup: async () => {
-        await rm(tempDir, { recursive: true, force: true });
-      },
-    };
   },
 });
 

--- a/apps/backend/src/services/videos/processing/planReprocess.test.ts
+++ b/apps/backend/src/services/videos/processing/planReprocess.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { planReprocess, toStoredParts } from './planReprocess';
+import type { StoredObject } from './planReprocess';
+
+const BASE = 'videos/u1/vid1';
+const toUrl = (storagePath: string) => `https://cdn.test/${storagePath}`;
+const named = (names: Array<[string, number]>): StoredObject[] =>
+  names.map(([name, size]) => ({ name: `${BASE}/${name}`, size }));
+
+describe('toStoredParts', () => {
+  it('splits into versioning names (all) and top-level parts (no v<N>/)', () => {
+    const { relativeNames, topLevel } = toStoredParts(
+      named([
+        ['playlist.m3u8', 300],
+        ['0.ts', 900_000],
+        ['v1/init.mp4', 1368],
+        ['v1/playlist.m3u8', 300],
+      ]),
+      BASE,
+    );
+    expect(relativeNames).toEqual([
+      'playlist.m3u8',
+      '0.ts',
+      'v1/init.mp4',
+      'v1/playlist.m3u8',
+    ]);
+    expect(topLevel).toEqual([
+      { name: 'playlist.m3u8', size: 300 },
+      { name: '0.ts', size: 900_000 },
+    ]);
+  });
+
+  it('drops the base prefix itself (empty relative name)', () => {
+    const { relativeNames } = toStoredParts(
+      [{ name: `${BASE}/`, size: 0 }, ...named([['0.ts', 10]])],
+      BASE,
+    );
+    expect(relativeNames).toEqual(['0.ts']);
+  });
+});
+
+describe('planReprocess', () => {
+  it('plans a .ts remux into v1 for a fresh base', () => {
+    const { source, outputStoragePath } = planReprocess(
+      named([
+        ['playlist.m3u8', 300],
+        ['0.ts', 900_000],
+      ]),
+      BASE,
+      toUrl,
+    );
+    expect(source).toEqual({
+      kind: 'hls-url',
+      url: `https://cdn.test/${BASE}/playlist.m3u8`,
+    });
+    expect(outputStoragePath).toBe(`${BASE}/v1`);
+  });
+
+  it('plans an fMP4 recovery (empty first segment dropped) into v1', () => {
+    const { source, outputStoragePath } = planReprocess(
+      named([
+        ['init.mp4', 1_533_135],
+        ['0.m4s', 24],
+        ['1.m4s', 780_340],
+        ['playlist.m3u8', 330],
+      ]),
+      BASE,
+      toUrl,
+    );
+    expect(source).toEqual({
+      kind: 'fmp4-parts',
+      partUrls: [
+        `https://cdn.test/${BASE}/init.mp4`,
+        `https://cdn.test/${BASE}/1.m4s`,
+      ],
+    });
+    expect(outputStoragePath).toBe(`${BASE}/v1`);
+  });
+
+  it('bumps past the highest existing version, reading original top-level parts', () => {
+    const { source, outputStoragePath } = planReprocess(
+      named([
+        ['playlist.m3u8', 300],
+        ['0.ts', 900_000],
+        ['v1/init.mp4', 1368],
+        ['v2/init.mp4', 1368],
+      ]),
+      BASE,
+      toUrl,
+    );
+    // Source still comes from the original top-level .ts, not a prior rendition.
+    expect(source.kind).toBe('hls-url');
+    expect(outputStoragePath).toBe(`${BASE}/v3`);
+  });
+
+  it('throws when nothing is stored', () => {
+    expect(() => planReprocess([], BASE, toUrl)).toThrow(/Nothing stored/);
+  });
+});

--- a/apps/backend/src/services/videos/processing/planReprocess.ts
+++ b/apps/backend/src/services/videos/processing/planReprocess.ts
@@ -61,5 +61,5 @@ const planReprocess = (
   return { source, outputStoragePath };
 };
 
-export { planReprocess, toStoredParts, PLAYLIST_NAME };
+export { planReprocess, toStoredParts };
 export type { StoredObject };

--- a/apps/backend/src/services/videos/processing/planReprocess.ts
+++ b/apps/backend/src/services/videos/processing/planReprocess.ts
@@ -1,0 +1,65 @@
+import { planReprocessSource } from './planReprocessSource';
+import type { StoredPart } from './selectFmp4Parts';
+import type { RepackageSource } from './types';
+import { nextVersionDir } from './versioning';
+
+const PLAYLIST_NAME = 'playlist.m3u8';
+
+/** A stored object as listed from GCS: full object name + byte size. */
+interface StoredObject {
+  name: string;
+  size: number;
+}
+
+/**
+ * Split the objects stored under `basePath` into the names used for versioning
+ * (ALL of them, including nested `v<N>/…` renditions, so the max version is
+ * found) and the TOP-LEVEL parts that feed the source decision (a reprocess
+ * always reads the original outputs, never a prior `v<N>/` rendition).
+ */
+const toStoredParts = (
+  objects: StoredObject[],
+  basePath: string,
+): { relativeNames: string[]; topLevel: StoredPart[] } => {
+  const relative = objects
+    .map((object) => ({
+      name: object.name.slice(basePath.length + 1),
+      size: object.size,
+    }))
+    .filter((part) => part.name.length > 0);
+  return {
+    relativeNames: relative.map((part) => part.name),
+    topLevel: relative.filter((part) => !part.name.includes('/')),
+  };
+};
+
+/**
+ * Plan a cache-safe reprocess from the objects stored under a video's base path:
+ * pick the reprocess source (remux a stored `.ts`, or recover from stored fMP4
+ * parts) and the fresh `v<N>/` output dir every output lands under. `toUrl`
+ * turns a storage path into the download URL the remux reads — the compute route
+ * and the CLI differ only in how they build that URL, so the rest of the glue
+ * lives here once (SWO-639).
+ *
+ * @throws (via {@link planReprocessSource}) when nothing recoverable is stored.
+ */
+const planReprocess = (
+  objects: StoredObject[],
+  basePath: string,
+  toUrl: (storagePath: string) => string,
+): { source: RepackageSource; outputStoragePath: string } => {
+  const { relativeNames, topLevel } = toStoredParts(objects, basePath);
+  const outputStoragePath = `${basePath}/${nextVersionDir(relativeNames)}`;
+  const plan = planReprocessSource(topLevel);
+  const source: RepackageSource =
+    plan.kind === 'hls-ts'
+      ? { kind: 'hls-url', url: toUrl(`${basePath}/${PLAYLIST_NAME}`) }
+      : {
+          kind: 'fmp4-parts',
+          partUrls: plan.partNames.map((name) => toUrl(`${basePath}/${name}`)),
+        };
+  return { source, outputStoragePath };
+};
+
+export { planReprocess, toStoredParts, PLAYLIST_NAME };
+export type { StoredObject };

--- a/apps/backend/src/services/videos/processing/planReprocessSource.test.ts
+++ b/apps/backend/src/services/videos/processing/planReprocessSource.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { planReprocessSource } from './planReprocessSource';
+import type { StoredPart } from './selectFmp4Parts';
+
+describe('planReprocessSource', () => {
+  it('picks the .ts remux when a stored MPEG-TS playlist is present', () => {
+    const parts: StoredPart[] = [
+      { name: 'playlist.m3u8', size: 300 },
+      { name: '0.ts', size: 900_000 },
+      { name: '1.ts', size: 850_000 },
+    ];
+    expect(planReprocessSource(parts)).toEqual({ kind: 'hls-ts' });
+  });
+
+  it('recovers from stored fMP4 parts when there is no .ts', () => {
+    const parts: StoredPart[] = [
+      { name: 'init.mp4', size: 1_533_135 },
+      { name: '0.m4s', size: 24 },
+      { name: '1.m4s', size: 780_340 },
+      { name: 'playlist.m3u8', size: 330 },
+    ];
+    expect(planReprocessSource(parts)).toEqual({
+      kind: 'fmp4-parts',
+      partNames: ['init.mp4', '1.m4s'],
+    });
+  });
+
+  it('propagates the recovery error when nothing is recoverable', () => {
+    expect(() =>
+      planReprocessSource([{ name: 'playlist.m3u8', size: 300 }]),
+    ).toThrow(/no init\.mp4/);
+  });
+});

--- a/apps/backend/src/services/videos/processing/planReprocessSource.test.ts
+++ b/apps/backend/src/services/videos/processing/planReprocessSource.test.ts
@@ -30,4 +30,8 @@ describe('planReprocessSource', () => {
       planReprocessSource([{ name: 'playlist.m3u8', size: 300 }]),
     ).toThrow(/no init\.mp4/);
   });
+
+  it('throws a clear error when nothing is stored at all', () => {
+    expect(() => planReprocessSource([])).toThrow(/Nothing stored/);
+  });
 });

--- a/apps/backend/src/services/videos/processing/planReprocessSource.ts
+++ b/apps/backend/src/services/videos/processing/planReprocessSource.ts
@@ -1,0 +1,33 @@
+import { type StoredPart, selectFmp4Parts } from './selectFmp4Parts';
+
+/**
+ * How a reprocess should read a video's media, decided from the objects already
+ * stored at its base (SWO-639):
+ * - `hls-ts`: a stored MPEG-TS playlist is present → remux `playlist.m3u8`.
+ * - `fmp4-parts`: no `.ts`, so recover from the stored fMP4 objects → concat the
+ *   listed part names (init + non-empty segments) and remux.
+ */
+type ReprocessSourcePlan =
+  | { kind: 'hls-ts' }
+  | { kind: 'fmp4-parts'; partNames: string[] };
+
+/**
+ * Decide the reprocess source from the TOP-LEVEL objects at the video's storage
+ * base (callers exclude any previous `v<N>/` rendition — a reprocess always
+ * reads the original outputs, never a prior reprocess).
+ *
+ * @throws (via {@link selectFmp4Parts}) when there is no `.ts` and no recoverable
+ *   fMP4 either — there is nothing to reprocess.
+ */
+const planReprocessSource = (
+  topLevelParts: StoredPart[],
+): ReprocessSourcePlan => {
+  const hasTs = topLevelParts.some((part) => part.name.endsWith('.ts'));
+  if (hasTs) {
+    return { kind: 'hls-ts' };
+  }
+  return { kind: 'fmp4-parts', partNames: selectFmp4Parts(topLevelParts) };
+};
+
+export { planReprocessSource };
+export type { ReprocessSourcePlan };

--- a/apps/backend/src/services/videos/processing/planReprocessSource.ts
+++ b/apps/backend/src/services/videos/processing/planReprocessSource.ts
@@ -16,12 +16,15 @@ type ReprocessSourcePlan =
  * base (callers exclude any previous `v<N>/` rendition — a reprocess always
  * reads the original outputs, never a prior reprocess).
  *
- * @throws (via {@link selectFmp4Parts}) when there is no `.ts` and no recoverable
- *   fMP4 either — there is nothing to reprocess.
+ * @throws when nothing is stored at the base, or (via {@link selectFmp4Parts})
+ *   when there is no `.ts` and no recoverable fMP4 either — nothing to reprocess.
  */
 const planReprocessSource = (
   topLevelParts: StoredPart[],
 ): ReprocessSourcePlan => {
+  if (!topLevelParts.length) {
+    throw new Error('Nothing stored to reprocess at this path');
+  }
   const hasTs = topLevelParts.some((part) => part.name.endsWith('.ts'));
   if (hasTs) {
     return { kind: 'hls-ts' };

--- a/apps/backend/src/services/videos/processing/repackageToFmp4.test.ts
+++ b/apps/backend/src/services/videos/processing/repackageToFmp4.test.ts
@@ -1,10 +1,13 @@
-import { Readable } from 'node:stream';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { repackageToFmp4 } from './repackageToFmp4';
-import type { Fmp4Artifacts, RepackageDeps } from './types';
+import type { Fmp4Artifacts, RepackageDeps, RepackageSource } from './types';
+import { Readable } from 'node:stream';
 
-const STORAGE_PATH = 'videos/user-1/video-1';
-const PLAYLIST_URL = `https://storage.test/${STORAGE_PATH}/playlist.m3u8`;
+const OUTPUT_PATH = 'videos/user-1/video-1/v2';
+const SOURCE: RepackageSource = {
+  kind: 'hls-url',
+  url: 'https://storage.test/videos/user-1/video-1/playlist.m3u8',
+};
 
 const FMP4_PLAYLIST = `#EXTM3U
 #EXT-X-VERSION:7
@@ -48,66 +51,71 @@ const makeDeps = (
   return { deps, cleanup };
 };
 
+const run = (deps: RepackageDeps) =>
+  repackageToFmp4({ source: SOURCE, outputStoragePath: OUTPUT_PATH }, deps);
+
 describe('repackageToFmp4', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('feeds the stored playlist URL to the repackage port', async () => {
+  it('feeds the source through to the repackage port', async () => {
     const { deps } = makeDeps();
 
-    await repackageToFmp4({ storagePath: STORAGE_PATH }, deps);
+    await run(deps);
 
-    expect(deps.storage.getDownloadUrl).toHaveBeenCalledWith(
-      `${STORAGE_PATH}/playlist.m3u8`,
-    );
-    expect(deps.repackage.repackageToFmp4).toHaveBeenCalledWith(PLAYLIST_URL);
+    expect(deps.repackage.repackageToFmp4).toHaveBeenCalledWith(SOURCE);
   });
 
-  it('uploads init + each .m4s with the right content types and paths', async () => {
+  it('uploads init + each .m4s + the manifest, all under the versioned dir', async () => {
     const { deps } = makeDeps();
 
-    const result = await repackageToFmp4({ storagePath: STORAGE_PATH }, deps);
+    const result = await run(deps);
 
-    // 1 init + 2 segments = 3 uploads. NOT the playlist (P2 swaps that).
-    expect(deps.storage.uploadStream).toHaveBeenCalledTimes(3);
+    // 1 init + 2 segments + 1 manifest = 4 uploads, every one under v2/.
+    expect(deps.storage.uploadStream).toHaveBeenCalledTimes(4);
     expect(deps.storage.uploadStream).toHaveBeenCalledWith(
       expect.objectContaining({
-        storagePath: `${STORAGE_PATH}/init.mp4`,
+        storagePath: `${OUTPUT_PATH}/init.mp4`,
         contentType: 'video/mp4',
       }),
     );
     expect(deps.storage.uploadStream).toHaveBeenCalledWith(
       expect.objectContaining({
-        storagePath: `${STORAGE_PATH}/0.m4s`,
+        storagePath: `${OUTPUT_PATH}/0.m4s`,
         contentType: 'video/iso.segment',
+      }),
+    );
+    expect(deps.storage.uploadStream).toHaveBeenCalledWith(
+      expect.objectContaining({
+        storagePath: `${OUTPUT_PATH}/playlist.m3u8`,
+        contentType: 'application/vnd.apple.mpegurl',
       }),
     );
 
     expect(result).toEqual({
       initName: 'init.mp4',
       segmentNames: ['0.m4s', '1.m4s'],
-      playlistContent: FMP4_PLAYLIST,
+      manifestStoragePath: `${OUTPUT_PATH}/playlist.m3u8`,
     });
   });
 
-  it('never writes the shared playlist.m3u8 (additive only)', async () => {
+  it('uploads the manifest last, after every segment', async () => {
     const { deps } = makeDeps();
 
-    await repackageToFmp4({ storagePath: STORAGE_PATH }, deps);
+    await run(deps);
 
-    const wrotePlaylist = (
+    const calls = (
       deps.storage.uploadStream as ReturnType<typeof vi.fn>
-    ).mock.calls.some(([arg]) =>
-      (arg as { storagePath: string }).storagePath.endsWith('playlist.m3u8'),
-    );
-    expect(wrotePlaylist).toBe(false);
+    ).mock.calls.map(([arg]) => (arg as { storagePath: string }).storagePath);
+    const manifestIdx = calls.findIndex((p) => p.endsWith('playlist.m3u8'));
+    expect(manifestIdx).toBe(calls.length - 1);
   });
 
   it('always cleans up temp resources on success', async () => {
     const { deps, cleanup } = makeDeps();
 
-    await repackageToFmp4({ storagePath: STORAGE_PATH }, deps);
+    await run(deps);
 
     expect(cleanup).toHaveBeenCalledTimes(1);
   });
@@ -115,9 +123,7 @@ describe('repackageToFmp4', () => {
   it('throws and still cleans up when no segments were produced', async () => {
     const { deps, cleanup } = makeDeps({ artifacts: makeArtifacts(0) });
 
-    await expect(
-      repackageToFmp4({ storagePath: STORAGE_PATH }, deps),
-    ).rejects.toThrow('Repackage produced no segments');
+    await expect(run(deps)).rejects.toThrow('Repackage produced no segments');
     expect(deps.storage.uploadStream).not.toHaveBeenCalled();
     expect(cleanup).toHaveBeenCalledTimes(1);
   });
@@ -129,11 +135,11 @@ describe('repackageToFmp4', () => {
       },
     });
 
-    const result = await repackageToFmp4({ storagePath: STORAGE_PATH }, deps);
+    const result = await run(deps);
 
     expect(result.initName).toBe('init.mp4');
     expect(deps.logger.warn).toHaveBeenCalledWith(
-      expect.objectContaining({ storagePath: STORAGE_PATH }),
+      expect.objectContaining({ outputStoragePath: OUTPUT_PATH }),
       'fMP4 repackage cleanup failed',
     );
   });
@@ -148,9 +154,7 @@ describe('repackageToFmp4', () => {
       },
     });
 
-    await expect(
-      repackageToFmp4({ storagePath: STORAGE_PATH }, deps),
-    ).rejects.toThrow('Failed to upload fMP4 artifacts');
+    await expect(run(deps)).rejects.toThrow('Failed to upload fMP4 artifacts');
     expect(deps.logger.warn).toHaveBeenCalled();
   });
 
@@ -161,9 +165,7 @@ describe('repackageToFmp4', () => {
       },
     });
 
-    await expect(
-      repackageToFmp4({ storagePath: STORAGE_PATH }, deps),
-    ).rejects.toThrow('Failed to upload fMP4 artifacts');
+    await expect(run(deps)).rejects.toThrow('Failed to upload fMP4 artifacts');
     expect(cleanup).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/backend/src/services/videos/processing/repackageToFmp4.ts
+++ b/apps/backend/src/services/videos/processing/repackageToFmp4.ts
@@ -1,5 +1,5 @@
+import path from 'node:path';
 import { Readable } from 'node:stream';
-import path from 'path';
 import { CustomError } from 'src/utils/custom-error';
 import { VIDEO_ERRORS } from 'src/utils/error-codes';
 import type { RepackageDeps, RepackageInput, RepackageResult } from './types';
@@ -105,6 +105,16 @@ const repackageToFmp4 = async (
       });
     }
   } finally {
+    // Close any artifact stream that wasn't consumed. An upload failure above
+    // leaves the not-yet-uploaded segment streams — and, on the no-segments
+    // guard, the init stream — open; their fds would otherwise linger until GC
+    // in the long-lived compute worker. Fully-uploaded streams are already
+    // destroyed (pipeline destroys on completion), so this is a no-op for them.
+    for (const artifact of [artifacts.init, ...artifacts.segments]) {
+      if (!artifact.stream.destroyed) {
+        artifact.stream.destroy();
+      }
+    }
     // Cleanup (temp dir removal) must never mask the real failure above, nor
     // fail an otherwise-successful reprocess — a leaked temp dir is only worth a
     // warning. So swallow-and-log; the primary error always propagates.

--- a/apps/backend/src/services/videos/processing/repackageToFmp4.ts
+++ b/apps/backend/src/services/videos/processing/repackageToFmp4.ts
@@ -1,3 +1,4 @@
+import { Readable } from 'node:stream';
 import path from 'path';
 import { CustomError } from 'src/utils/custom-error';
 import { VIDEO_ERRORS } from 'src/utils/error-codes';
@@ -6,59 +7,53 @@ import type { RepackageDeps, RepackageInput, RepackageResult } from './types';
 const PLAYLIST_NAME = 'playlist.m3u8';
 const INIT_CONTENT_TYPE = 'video/mp4';
 const SEGMENT_CONTENT_TYPE = 'video/iso.segment';
+const PLAYLIST_CONTENT_TYPE = 'application/vnd.apple.mpegurl';
 const SOURCE = 'services/videos/processing/repackageToFmp4.ts';
 
 /**
- * Repackage an already-stored `.ts` video into fMP4/CMAF (`init.mp4` + `.m4s`)
- * and upload the new objects alongside the existing `.ts`.
+ * Reprocess a stored video into a clean fMP4/CMAF rendition (`init.mp4` +
+ * `.m4s` + `playlist.m3u8`) via a lossless `-c copy` remux, and upload EVERY
+ * output under a fresh versioned directory (`outputStoragePath`).
  *
- * This is the on-demand repair for the hls.js MPEG-TS AAC-demux noise bug (see
- * `src/docs/fmp4-default-output/`): the default streaming flow is untouched; a
- * human runs this for a single `ready` video that turns out noisy.
- *
- * It is **purely additive and non-destructive** — it never overwrites
- * `playlist.m3u8` and never deletes the old `.ts`. The destructive swap (point
- * the shared playlist at the fMP4 files) and the cleanup of the old `.ts` are
- * the caller's job (P2). That split guarantees a failed repackage can never
- * leave a broken video.
+ * Cache-safety is the whole point (SWO-639): stored objects carry a 1-year
+ * `max-age` and `storage.googleapis.com` never purges its edge on overwrite, so
+ * re-uploading under an existing name is invisible for a year. Writing the
+ * entire rendition — manifest included — under a never-before-used `v<N>/` path
+ * sidesteps caching, and the caller then repoints `videos.source` at the new
+ * manifest. The previous objects are left untouched (harmless orphans), so a
+ * failed reprocess can never break the currently-playing video.
  *
  * Framework-/env-agnostic: every effect goes through an injected port, so it's
- * unit-testable with fakes. The real ffmpeg + GCS wiring is the adapter's (P2).
+ * unit-testable with fakes. The real ffmpeg + GCS wiring is the adapter's.
  */
 const repackageToFmp4 = async (
   input: RepackageInput,
   deps: RepackageDeps,
 ): Promise<RepackageResult> => {
-  const { storagePath } = input;
-  // The repair reads the `.ts` we already own — its public playlist URL, fed to
-  // ffmpeg as the remux source. (No original third-party URL: it's likely gone.)
-  const sourceUrl = deps.storage.getDownloadUrl(
-    path.posix.join(storagePath, PLAYLIST_NAME),
-  );
+  const { source, outputStoragePath } = input;
   deps.logger.info(
-    { storagePath, sourceUrl },
-    'Repackaging stored .ts to fMP4',
+    { outputStoragePath, sourceKind: source.kind },
+    'Reprocessing stored video to a versioned fMP4 rendition',
   );
 
-  const { artifacts, cleanup } =
-    await deps.repackage.repackageToFmp4(sourceUrl);
+  const { artifacts, cleanup } = await deps.repackage.repackageToFmp4(source);
 
   try {
     if (!artifacts.segments.length) {
       throw CustomError.medium('Repackage produced no segments', {
         errorCode: VIDEO_ERRORS.INVALID_LENGTH,
-        context: { storagePath },
+        context: { outputStoragePath },
         source: SOURCE,
       });
     }
 
     try {
-      // Upload init first, then each `.m4s`. New filenames never collide with
-      // the existing `.ts`, so this only adds objects — the video keeps playing
-      // off its current `.ts` playlist until the caller (P2) swaps it.
+      // Everything lands under the fresh versioned dir, so no upload can
+      // overwrite a cache-immutable object — the video keeps playing off its
+      // current manifest until the caller repoints `source` to the new one.
       await deps.storage.uploadStream({
         stream: artifacts.init.stream,
-        storagePath: path.posix.join(storagePath, artifacts.init.name),
+        storagePath: path.posix.join(outputStoragePath, artifacts.init.name),
         contentType: INIT_CONTENT_TYPE,
       });
 
@@ -66,24 +61,38 @@ const repackageToFmp4 = async (
       for (const segment of artifacts.segments) {
         await deps.storage.uploadStream({
           stream: segment.stream,
-          storagePath: path.posix.join(storagePath, segment.name),
+          storagePath: path.posix.join(outputStoragePath, segment.name),
           contentType: SEGMENT_CONTENT_TYPE,
         });
         segmentNames.push(segment.name);
       }
 
+      // The manifest is versioned too (it lives at a fresh URL, so a 1-year
+      // cache is correct here — unlike an in-place overwrite, which had to be
+      // `no-cache`). Uploaded LAST so the manifest never references a segment
+      // that isn't up yet.
+      const manifestStoragePath = path.posix.join(
+        outputStoragePath,
+        PLAYLIST_NAME,
+      );
+      await deps.storage.uploadStream({
+        stream: Readable.from(artifacts.playlistContent),
+        storagePath: manifestStoragePath,
+        contentType: PLAYLIST_CONTENT_TYPE,
+      });
+
       const result: RepackageResult = {
         initName: artifacts.init.name,
         segmentNames,
-        playlistContent: artifacts.playlistContent,
+        manifestStoragePath,
       };
       deps.logger.info(
         {
-          storagePath,
+          outputStoragePath,
           initName: result.initName,
           segmentCount: segmentNames.length,
         },
-        'fMP4 repackage uploaded (playlist swap pending)',
+        'Versioned fMP4 rendition uploaded (source repoint pending)',
       );
       return result;
     } catch (error) {
@@ -91,19 +100,19 @@ const repackageToFmp4 = async (
         originalError: error,
         errorCode: VIDEO_ERRORS.STORAGE_UPLOAD_FAILED,
         shouldRetry: true,
-        context: { storagePath },
+        context: { outputStoragePath },
         source: SOURCE,
       });
     }
   } finally {
     // Cleanup (temp dir removal) must never mask the real failure above, nor
-    // fail an otherwise-successful repair — a leaked temp dir is only worth a
+    // fail an otherwise-successful reprocess — a leaked temp dir is only worth a
     // warning. So swallow-and-log; the primary error always propagates.
     try {
       await cleanup();
     } catch (cleanupError) {
       deps.logger.warn(
-        { storagePath, cleanupError },
+        { outputStoragePath, cleanupError },
         'fMP4 repackage cleanup failed',
       );
     }

--- a/apps/backend/src/services/videos/processing/selectFmp4Parts.test.ts
+++ b/apps/backend/src/services/videos/processing/selectFmp4Parts.test.ts
@@ -37,12 +37,14 @@ describe('selectFmp4Parts', () => {
     );
   });
 
-  it('throws when every segment is empty (nothing to recover)', () => {
-    expect(() =>
+  it('returns the init alone when every .m4s is empty (single-fragment recovery)', () => {
+    // A short video whose whole media lives in the (large) init, with only an
+    // empty 0.m4s — [init] alone is still a valid remuxable stream.
+    expect(
       selectFmp4Parts([
-        { name: 'init.mp4', size: 1400 },
+        { name: 'init.mp4', size: 1_533_135 },
         { name: '0.m4s', size: 24 },
       ]),
-    ).toThrow(/no non-empty/);
+    ).toEqual(['init.mp4']);
   });
 });

--- a/apps/backend/src/services/videos/processing/selectFmp4Parts.test.ts
+++ b/apps/backend/src/services/videos/processing/selectFmp4Parts.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { selectFmp4Parts, type StoredPart } from './selectFmp4Parts';
+
+describe('selectFmp4Parts', () => {
+  it('recovers the Infinix layout: init first, skip the empty 0.m4s, keep the rest in order', () => {
+    const parts: StoredPart[] = [
+      { name: 'init.mp4', size: 1_533_135 },
+      { name: '0.m4s', size: 24 },
+      { name: '2.m4s', size: 2_214_688 },
+      { name: '1.m4s', size: 780_340 },
+      { name: 'playlist.m3u8', size: 330 },
+    ];
+    expect(selectFmp4Parts(parts)).toEqual(['init.mp4', '1.m4s', '2.m4s']);
+  });
+
+  it('sorts segments numerically, not lexically', () => {
+    const parts: StoredPart[] = [
+      { name: 'init.mp4', size: 1000 },
+      { name: '10.m4s', size: 500 },
+      { name: '2.m4s', size: 500 },
+    ];
+    expect(selectFmp4Parts(parts)).toEqual(['init.mp4', '2.m4s', '10.m4s']);
+  });
+
+  it('keeps a healthy first segment when it is not empty', () => {
+    const parts: StoredPart[] = [
+      { name: 'init.mp4', size: 1400 },
+      { name: '0.m4s', size: 500_000 },
+      { name: '1.m4s', size: 400_000 },
+    ];
+    expect(selectFmp4Parts(parts)).toEqual(['init.mp4', '0.m4s', '1.m4s']);
+  });
+
+  it('throws when there is no init.mp4 to recover from', () => {
+    expect(() => selectFmp4Parts([{ name: '0.m4s', size: 500_000 }])).toThrow(
+      /no init\.mp4/,
+    );
+  });
+
+  it('throws when every segment is empty (nothing to recover)', () => {
+    expect(() =>
+      selectFmp4Parts([
+        { name: 'init.mp4', size: 1400 },
+        { name: '0.m4s', size: 24 },
+      ]),
+    ).toThrow(/no non-empty/);
+  });
+});

--- a/apps/backend/src/services/videos/processing/selectFmp4Parts.ts
+++ b/apps/backend/src/services/videos/processing/selectFmp4Parts.ts
@@ -24,7 +24,13 @@ const segmentIndex = (name: string): number =>
  * Returns `[init.mp4, <non-empty .m4s in numeric order>]`. Concatenating these
  * yields a valid fMP4 byte stream (the init already embeds the first fragment's
  * media) that ffmpeg re-segments into a clean playlist with a non-empty first
- * segment. The empty `0.m4s` is skipped — it holds nothing.
+ * segment. Empty (<= 24-byte) segments are skipped — they hold nothing.
+ *
+ * A single-fragment video whose entire media lives in the (unusually large)
+ * `init.mp4` — an empty `0.m4s` and no later segment — yields `[init.mp4]`
+ * alone, which is still a valid remuxable stream. If such an init turns out
+ * media-less, the remux produces only an empty segment, which the adapter drops
+ * → the engine fails it cleanly rather than shipping a broken rendition.
  *
  * @throws if no `init.mp4` is present (nothing to recover from)
  */
@@ -41,10 +47,6 @@ const selectFmp4Parts = (parts: StoredPart[]): string[] => {
     )
     .sort((a, b) => segmentIndex(a.name) - segmentIndex(b.name))
     .map((part) => part.name);
-
-  if (!segments.length) {
-    throw new Error('Cannot recover: no non-empty .m4s segments stored');
-  }
 
   return [init.name, ...segments];
 };

--- a/apps/backend/src/services/videos/processing/selectFmp4Parts.ts
+++ b/apps/backend/src/services/videos/processing/selectFmp4Parts.ts
@@ -1,0 +1,53 @@
+/** A stored fMP4 object considered for a lossless recovery remux. */
+interface StoredPart {
+  /** Object name relative to the storage base, e.g. `init.mp4`, `0.m4s`. */
+  name: string;
+  /** Object size in bytes. */
+  size: number;
+}
+
+/**
+ * ffmpeg 4.4 wrote a 24-byte (moof-only, no mdat) empty first segment. Any
+ * `.m4s` at or below this size carries no media and must be skipped — its media
+ * lives in the (unusually large) `init.mp4` on the affected videos.
+ */
+const EMPTY_SEGMENT_MAX_BYTES = 24;
+
+const segmentIndex = (name: string): number =>
+  Number(name.match(/(\d+)\.m4s$/)?.[1] ?? 0);
+
+/**
+ * Order the stored fMP4 objects to concatenate for a lossless `-c copy` recovery
+ * remux — the Infinix case: a media-bearing `init.mp4`, an empty 24-byte
+ * `0.m4s`, and good later segments (SWO-639).
+ *
+ * Returns `[init.mp4, <non-empty .m4s in numeric order>]`. Concatenating these
+ * yields a valid fMP4 byte stream (the init already embeds the first fragment's
+ * media) that ffmpeg re-segments into a clean playlist with a non-empty first
+ * segment. The empty `0.m4s` is skipped — it holds nothing.
+ *
+ * @throws if no `init.mp4` is present (nothing to recover from)
+ */
+const selectFmp4Parts = (parts: StoredPart[]): string[] => {
+  const init = parts.find((part) => part.name === 'init.mp4');
+  if (!init) {
+    throw new Error('Cannot recover: no init.mp4 among stored fMP4 objects');
+  }
+
+  const segments = parts
+    .filter(
+      (part) =>
+        part.name.endsWith('.m4s') && part.size > EMPTY_SEGMENT_MAX_BYTES,
+    )
+    .sort((a, b) => segmentIndex(a.name) - segmentIndex(b.name))
+    .map((part) => part.name);
+
+  if (!segments.length) {
+    throw new Error('Cannot recover: no non-empty .m4s segments stored');
+  }
+
+  return [init.name, ...segments];
+};
+
+export { selectFmp4Parts, EMPTY_SEGMENT_MAX_BYTES };
+export type { StoredPart };

--- a/apps/backend/src/services/videos/processing/types.ts
+++ b/apps/backend/src/services/videos/processing/types.ts
@@ -139,13 +139,25 @@ interface RepackageOutput {
 }
 
 /**
- * Port that reads an HLS source URL and remuxes it to fMP4/CMAF — no video
+ * Where a reprocess reads its media from. Both variants produce a clean fMP4 via
+ * a lossless `-c copy` remux (SWO-639):
+ * - `hls-url`: remux an HLS playlist URL directly (a stored `.ts` playlist).
+ * - `fmp4-parts`: download the given fMP4 object URLs, concatenate them, and
+ *   remux the result — recovers a broken fMP4 (the Infinix case: a media-bearing
+ *   `init.mp4` + an empty first `.m4s`) whose playlist ffmpeg can't read directly.
+ */
+type RepackageSource =
+  | { kind: 'hls-url'; url: string }
+  | { kind: 'fmp4-parts'; partUrls: string[] };
+
+/**
+ * Port that turns a {@link RepackageSource} into fMP4/CMAF artifacts — no video
  * transcode. The real implementation (fluent-ffmpeg + a temp dir) is the
- * adapter's (P2); the engine only sees this interface, which keeps it
- * env-agnostic and unit-testable with a fake.
+ * adapter's; the engine only sees this interface, which keeps it env-agnostic
+ * and unit-testable with a fake.
  */
 interface RepackagePort {
-  repackageToFmp4(sourceUrl: string): Promise<RepackageOutput>;
+  repackageToFmp4(source: RepackageSource): Promise<RepackageOutput>;
 }
 
 interface RepackageDeps {
@@ -156,17 +168,27 @@ interface RepackageDeps {
 }
 
 interface RepackageInput {
-  /** Base storage path of the already-streamed video, e.g. `videos/<user>/<id>`. */
-  storagePath: string;
+  /** The media to remux (a stored `.ts` playlist URL, or fMP4 parts to concat). */
+  source: RepackageSource;
+  /**
+   * Versioned directory ALL outputs (init, segments, manifest) are written
+   * under, e.g. `videos/<user>/<id>/v2`. A fresh `v<N>/` per reprocess is what
+   * makes the fix cache-safe — it never overwrites a 1-year-cached object.
+   */
+  outputStoragePath: string;
 }
 
 interface RepackageResult {
-  /** Uploaded init object name (relative to `storagePath`). */
+  /** Uploaded init object name (relative to `outputStoragePath`). */
   initName: string;
-  /** Uploaded `.m4s` object names (relative to `storagePath`). */
+  /** Uploaded `.m4s` object names (relative to `outputStoragePath`). */
   segmentNames: string[];
-  /** fMP4 playlist text for the caller to swap into `playlist.m3u8` (P2). */
-  playlistContent: string;
+  /**
+   * Full storage path of the uploaded manifest, e.g.
+   * `videos/<user>/<id>/v2/playlist.m3u8`. The caller repoints `videos.source`
+   * at this object's download URL.
+   */
+  manifestStoragePath: string;
 }
 
 export type {
@@ -185,6 +207,7 @@ export type {
   Fmp4Artifact,
   Fmp4Artifacts,
   RepackageOutput,
+  RepackageSource,
   RepackagePort,
   RepackageDeps,
   RepackageInput,

--- a/apps/backend/src/services/videos/processing/versioning.test.ts
+++ b/apps/backend/src/services/videos/processing/versioning.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { nextVersionDir } from './versioning';
+
+describe('nextVersionDir', () => {
+  it('returns v1 when no version directory exists yet', () => {
+    expect(nextVersionDir(['playlist.m3u8', 'init.mp4', '0.m4s'])).toBe('v1');
+  });
+
+  it('returns v1 for an empty base', () => {
+    expect(nextVersionDir([])).toBe('v1');
+  });
+
+  it('returns the next version after the highest existing one', () => {
+    expect(nextVersionDir(['playlist.m3u8', 'v1/init.mp4', 'v1/0.m4s'])).toBe(
+      'v2',
+    );
+  });
+
+  it('picks the max, not the count, when versions are non-contiguous', () => {
+    expect(nextVersionDir(['v1/init.mp4', 'v3/init.mp4'])).toBe('v4');
+  });
+
+  it('handles double-digit versions numerically (not lexically)', () => {
+    expect(nextVersionDir(['v9/init.mp4', 'v10/init.mp4'])).toBe('v11');
+  });
+
+  it('ignores names that merely start with v but are not version dirs', () => {
+    expect(nextVersionDir(['video.mp4', 'v1beta/init.mp4', 'vtt.txt'])).toBe(
+      'v1',
+    );
+  });
+});

--- a/apps/backend/src/services/videos/processing/versioning.ts
+++ b/apps/backend/src/services/videos/processing/versioning.ts
@@ -1,0 +1,28 @@
+const VERSION_DIR = /^v(\d+)\//;
+
+/**
+ * The next reprocess version directory (`v1`, `v2`, …) for a video's storage
+ * base, given the object names already stored under it.
+ *
+ * Reprocess writes EVERY output (init, segments, manifest) under this fresh
+ * subfolder so it never overwrites a cache-immutable object: stored objects
+ * carry a 1-year `max-age`, and `storage.googleapis.com` does not purge its edge
+ * on overwrite — so re-uploading under an existing name is invisible for a year.
+ * A brand-new `v<N>/` path sidesteps caching entirely (SWO-639).
+ *
+ * @param existingObjectNames object names relative to the storage base (e.g.
+ *   `playlist.m3u8`, `init.mp4`, `v1/init.mp4`)
+ * @returns the next unused `v<N>` directory name
+ */
+const nextVersionDir = (existingObjectNames: string[]): string => {
+  let max = 0;
+  for (const name of existingObjectNames) {
+    const match = name.match(VERSION_DIR);
+    if (match) {
+      max = Math.max(max, Number(match[1]));
+    }
+  }
+  return `v${max + 1}`;
+};
+
+export { nextVersionDir };


### PR DESCRIPTION
## Summary

Reprocesses a broken Look video's stored HLS into a **fresh versioned subfolder** (`videos/<user>/<id>/v<N>/`) and repoints `videos.source` at the new manifest. Because stored objects carry a 1-year immutable cache and `storage.googleapis.com` never purges its edge on overwrite, a fix has to land at a never-before-used URL to be visible — so every output (init, segments, manifest) goes under a new `v<N>/`, and the previous objects are left untouched (harmless orphans). A failed reprocess therefore can never break the currently-playing video.

Two lossless source paths, both a `-c copy` remux (no transcode):
- **hls-url** — remux a stored `.ts` playlist (audio re-encoded to AAC to clear the hls.js MPEG-TS demux noise).
- **fmp4-parts** — concat the media-bearing `init.mp4` + non-empty `.m4s` and remux — recovers the Infinix empty-first-segment case whose playlist ffmpeg can't read directly. A single-fragment video whose whole media lives in `init.mp4` recovers from `[init]` alone; a media-less init fails hard rather than shipping an empty segment.

A shared ffmpeg adapter (`buildFfmpegRepackage`) and a shared `planReprocess` helper are used by **both** the compute task handler and the operator CLI, so the recovery recipe and the plan→source glue live in exactly one place. ffmpeg ≥7 (enforced in the compute image and by the CLI) guarantees the muxer never re-emits the empty first segment.

## Test plan

- **Unit:** 988 backend tests pass; new focused tests for `versioning`, `selectFmp4Parts` (incl. init-only recovery), `planReprocessSource`, `planReprocess`, and the reworked engine + compute route.
- **End-to-end against real ffmpeg 7** (real engine + adapter, no mocks, fixtures served over HTTP, uploads written to disk, output decoded):
  - `.ts` remux → non-empty first segment, 200 frames decode.
  - Infinix multi-part recovery → empty `0.m4s` dropped, first segment 1.5MB, 1724 frames decode.
  - Single-fragment init-only recovery → 196 frames decode.
  - Media-less init → rejected ("Remux produced an empty segment"), nothing uploaded.
  - Every path: manifest uploaded last, under the versioned dir.

Refs SWO-639

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved video repair and reprocessing for stored HLS and fMP4 content.
  * Recovers videos with missing or empty initial segments when sufficient media data is available.
  * Stores repaired outputs in a new versioned location and updates playback links automatically.
  * Supports dry-run planning for safer repair operations.

* **Bug Fixes**
  * Prevents overwriting existing video renditions.
  * Ensures generated manifests are published only after all media segments are uploaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->