### PR TITLE
chore(claude): add .worktreeinclude for automatic worktree provisioning (SWO-646)

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,27 @@
+# Gitignored config that a fresh worktree needs, auto-copied by Claude Code when
+# it creates a worktree (--worktree, EnterWorktree, or a subagent with
+# `isolation: worktree`). Uses .gitignore syntax; only files that match a pattern
+# AND are gitignored are copied, so tracked files (e.g. .env.example) are never
+# duplicated. node_modules is intentionally NOT listed — run `pnpm install` after
+# entering the worktree (there is no worktree-entry hook to run it automatically).
+#
+# Patterns are ANCHORED (leading /) on purpose: an unanchored **/.env would also
+# match .env files vendored inside node_modules (e.g. @ffmpeg-installer) and copy
+# junk into the worktree.
+
+# Linear CLI workspace config — without it, the `linear` CLI resolves to the
+# account default workspace, not sworld (reads wrong data, writes fail "Team not found: SWO").
+/.linear.toml
+
+# Root env (VITE_ app config + Auth0 dev tenant)
+/.env
+/.env.local
+/.env.development.local
+
+# Per-app env — the leading /apps/*/ keeps this to real apps, never node_modules
+/apps/*/.env
+/apps/*/.env.local
+/apps/*/.env.development.local
+
+# packages/core/.env feeds `pnpm codegen` (HASURA_GRAPHQL_URL / HASURA_ADMIN_SECRET)
+/packages/core/.env


### PR DESCRIPTION
## Summary

First micro-PR of SWO-645 (native worktree adoption). Adds a `.worktreeinclude` file so Claude Code automatically copies the gitignored config a fresh worktree needs — `.linear.toml`, root + per-app `.env`/`.env.development.local`, and `packages/core/.env` — whenever it creates a worktree (`--worktree`, `EnterWorktree`, or a subagent with `isolation: worktree`). This replaces the manual copy steps the worktree workflow does today.

Patterns are anchored (`/apps/*/…` rather than `**/.env`) on purpose: an unanchored glob also matches `.env` files vendored inside `node_modules` (e.g. `@ffmpeg-installer`) and would copy junk into the worktree.

## Test plan

- Verified with `git ls-files -i -o --exclude-from=.worktreeinclude` that the patterns select **exactly** the intended files (16 env files + `.linear.toml`), and exclude `node_modules/**`, `.env.bak.*`, and tracked `.env.example`.
- `node_modules` is intentionally not copied; `pnpm install` remains a documented post-entry step (no worktree-entry hook exists to run it).
- End-to-end (files actually landing in a freshly-created worktree) will be dogfooded post-merge via a subagent with `isolation: worktree`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
