### PR TITLE
[WIP] docs(self-review): drop git -C anchoring — subagents inherit worktree cwd (SWO-648)

### DIFF
--- a/.claude/skills/self-review/SKILL.md
+++ b/.claude/skills/self-review/SKILL.md
@@ -110,8 +110,8 @@ Each returns findings with `file:line` and the concrete inputs that trigger them
 
 Rules:
 
-- **Anchor to the worktree.** Subagents run in the session's root cwd, not your worktree — always pass an absolute `git -C <worktree> diff origin/main`.
-- **Verify scope.** The files reported MUST match `git diff origin/main --name-only` in the worktree. A mismatch, or "no changes found", is a FAILED run, not a clean pass — fix the anchoring and re-run.
+- **Subagents inherit the worktree cwd.** Because you entered the worktree with `EnterWorktree`, a spawned finder subagent runs *inside* it — plain `git diff origin/main` resolves correctly, no absolute `git -C <worktree>` needed. (The exception is an agent whose cwd was pinned elsewhere at launch — explicit `cwd` or worktree-isolation; if you spawn one of those, it must enter this worktree first.)
+- **Verify scope.** The files reported MUST match `git diff origin/main --name-only`. A mismatch, or "no changes found", is a FAILED run, not a clean pass — confirm the subagent actually ran in this worktree and re-run.
 - **Empty is a valid result.** For a small or declarative diff it's the expected one. Never manufacture a finding to look thorough; a confident-but-wrong finding burns trust in the whole gate. When in doubt, drop it.
 - **Trust boundaries get more.** If the diff touches Hasura permissions/metadata, Hono Action/Event/webhook handlers, or auth, also run `security-reviewer`.
 


### PR DESCRIPTION
## Goal

De-hack the self-review finder sweep now that the worktree-native flow (SWO-647) is in: with `EnterWorktree`, the session cwd *is* the worktree, so finder subagents no longer need the absolute `git -C <worktree>` anchoring workaround.

## What changed

Docs-only — 2 lines in `.claude/skills/self-review/SKILL.md` (Step 3 finder-sweep rules):

- **Anchoring rule replaced.** "Subagents run in the session's root cwd — pass absolute `git -C <worktree> diff origin/main`" → "subagents inherit the worktree cwd, so plain `git diff origin/main` works." A parenthetical keeps the one real exception: an agent whose cwd was pinned elsewhere at launch (explicit `cwd` / worktree-isolation) must enter this worktree first.
- **"Verify scope"** keeps the sanity-check but drops the "fix the anchoring" phrasing.

## Verification

Empirically confirmed the premise before editing: a probe subagent spawned from the `EnterWorktree` session reported `pwd`, `git rev-parse --show-toplevel`, and `git branch --show-current` all resolving to the worktree (`.claude/worktrees/swo-648-…`), not the repo root.

## Deliberately kept

The `session_id` subagent-bucket caveat (line 48) — it's orthogonal to cwd and still real (delegated edits/reviews land in a different gate bucket).

Refs SWO-648