### PR TITLE
refactor(hooks): downgrade blockMainWorktreeWrites to a backstop for EnterWorktree (SWO-650)

### DIFF
--- a/.claude/hooks/blockMainWorktreeWrites.sh
+++ b/.claude/hooks/blockMainWorktreeWrites.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
-# Blocks file writes to a repo's main worktree, unconditionally — the main
-# worktree of every repo in this workspace must only ever hold `main`, never
-# feature work (see .claude/skills/parallel-workflow: "NEVER create branches or
-# make changes in the main worktree"). Unlike the branch-aware variants elsewhere,
-# there is no "a branch is deliberately checked out here" exception: any write to
-# a main worktree is the accident this guards against.
+# Backstop for the worktree-native workflow. The primary mechanism is the
+# EnterWorktree tool: all feature work happens in a linked worktree it creates and
+# moves the session into (see .claude/skills/parallel-workflow), so the main worktree
+# should only ever hold `main`. This hook is the safety net, not the primary rule —
+# it catches the accidental case, a stray Edit/Write that lands on the main worktree
+# instead of a worktree. It blocks regardless of which branch the main worktree sits
+# on: unlike the branch-aware variants elsewhere, there is no "a branch is deliberately
+# checked out here" exception, because any write to a main worktree is exactly the
+# accident it guards against. The one exception is a single local-config file — the
+# narrow carve-out (below): `.claude/settings.local.json`, local machine config that
+# only ever lives in the main worktree and is never copied into a worktree.
 #
 # A linked worktree's git dir (.git/worktrees/<name>) differs from its common dir
 # (.git); in the main worktree the two are identical. That is the whole worktree
@@ -51,6 +56,15 @@ common_dir=$(git -C "$dir" rev-parse --path-format=absolute --git-common-dir 2>/
 
 toplevel=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null)
 
+# Narrow carve-out: settings.local.json is local, gitignored machine config that ONLY
+# ever lives at the repo root's .claude/ in the main worktree — never copied into a
+# linked worktree — so editing it there is legitimate config work (e.g. permissions,
+# env), not stray feature work on main. Match the repo-root file EXACTLY, comparing the
+# physically-resolved parent dir ($dir) against $toplevel/.claude — a trailing-suffix
+# glob would also allow vendored node_modules/**/.claude/settings.local.json. Everything
+# else on a main worktree is blocked.
+[ "$dir" = "$toplevel/.claude" ] && [ "$(basename -- "$target")" = "settings.local.json" ] && exit 0
+
 resolved_note=""
 [ "$target" = "$file_path" ] || resolved_note="
   (via symlink, resolves to $target)"
@@ -64,8 +78,10 @@ All work happens in a linked worktree — the main worktree is never edited, wha
 branch it currently sits on. To do this work, use a worktree (see the
 parallel-workflow skill):
   1. Make sure a Linear issue exists for this work.
-  2. git -C $toplevel fetch origin main
-  3. git -C $toplevel worktree add -b swo-NNN-<slug> .claude/worktrees/swo-NNN-<slug> origin/main
+  2. git -C $toplevel fetch origin main   (EnterWorktree's own base fetch is 24h-throttled)
+  3. Enter a worktree with the EnterWorktree tool, named swo-NNN-<slug> — it creates
+     .claude/worktrees/swo-NNN-<slug> off origin/main, provisions gitignored config,
+     and moves the session into it.
   4. Re-run this edit against the path inside that worktree.
 
 This hook gates the Edit, Write and NotebookEdit tools. Reading the main worktree

--- a/.claude/hooks/blockMainWorktreeWrites.sh
+++ b/.claude/hooks/blockMainWorktreeWrites.sh
@@ -78,13 +78,13 @@ All work happens in a linked worktree — the main worktree is never edited, wha
 branch it currently sits on. To do this work, use a worktree (see the
 parallel-workflow skill):
   1. Make sure a Linear issue exists for this work.
-  2. git -C $toplevel fetch origin main   (EnterWorktree's own base fetch is 24h-throttled)
+  2. git -C "$toplevel" fetch origin main   (EnterWorktree's own base fetch is 24h-throttled)
   3. Enter a worktree with the EnterWorktree tool, named swo-NNN-<slug> — it creates
      .claude/worktrees/swo-NNN-<slug> off origin/main, provisions gitignored config,
      and moves the session into it.
   4. Re-run this edit against the path inside that worktree.
 
 This hook gates the Edit, Write and NotebookEdit tools. Reading the main worktree
-is fine, as is advancing it with: git -C $toplevel pull --ff-only origin main
+is fine, as is advancing it with: git -C "$toplevel" pull --ff-only origin main
 EOF
 exit 2


### PR DESCRIPTION
## What

Final ticket of the worktree-native redesign (epic SWO-645). Two things:

1. **Downgrade the framing of `blockMainWorktreeWrites.sh`.** Now that all feature work is created and entered via the `EnterWorktree` tool (SWO-647), this hook is the *safety net*, not the primary rule. The header is reframed from "blocks unconditionally" to "backstop for the worktree-native workflow", and the remediation message points at `EnterWorktree` instead of a manual `git worktree add`.

2. **Add a narrow carve-out for `.claude/settings.local.json`.** That file is local, gitignored machine config that only ever lives at the repo root's `.claude/` in the main worktree and is never copied into a linked worktree. Editing it there is legitimate config work (permissions, env), not stray feature work on `main` — but the hook was false-positive-blocking it, which broke automation (you had to route around it via Bash `cat >`). The carve-out allows it.

   The match is **exact** — `[ "$dir" = "$toplevel/.claude" ] && [ basename == settings.local.json ]` — not a suffix glob. A suffix glob (`*/.claude/settings.local.json`) would also allow vendored `node_modules/**/.claude/settings.local.json` (several such files exist in the tree); the exact match keeps those blocked.

## Scope note — SWO-650 was overscoped

The ticket also named de-hacking absolute-path/cwd anchoring in `e2e-testing`, `security-reviewer`, `supply-chain-security`, and `skill-creator`. On inspection **none of those skills have a git-`-C`/cwd anchoring hack** — the e2e-testing worktree references are about dev-server port collisions, not subagent cwd. So there is nothing to de-hack there and no edits were made to them. The real work of this ticket is entirely this hook change.

## Testing

Pipe-tested the hook with 7 cases, all pass:
- main worktree normal file → BLOCK (exit 2)
- main `.claude/settings.local.json` → ALLOW (exit 0)
- main `.claude/settings.json` (tracked) → BLOCK
- `node_modules/**/.claude/settings.local.json` → BLOCK (the over-match fix)
- linked-worktree files → ALLOW
- no path → ALLOW

`bash -n` clean; verified single `toplevel=` assignment (no duplicate) and that `$toplevel` is assigned before the carve-out uses it. Empty-`$toplevel` fails safe (falls through to block).

Closes SWO-650.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the worktree-based workflow and restrictions on writing to the main worktree.
  * Documented the exception for the repository’s local settings file.
  * Updated remediation guidance to use the recommended worktree entry process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->