### PR TITLE
docs(task-tracker): repoint when-a-blocker-is-earned to dependency-analysis (SWO-654)

### DIFF
--- a/.claude/skills/task-tracker/SKILL.md
+++ b/.claude/skills/task-tracker/SKILL.md
@@ -109,8 +109,8 @@ and add `--no-interactive` when creating issues so it never prompts.
 - Remove one: `linear issue relation delete SWO-<child> blocked-by SWO-<dep>`
 - List an issue's relations: `linear issue relation list SWO-NNN`
 
-`blocked-by` is the dependency edge; a set of them is what encodes waves. `writing-task-specs` owns
-*when* a blocker is earned; this skill owns the command that records it.
+`blocked-by` is the dependency edge; a set of them is what encodes waves. `dependency-analysis` owns
+*when* a blocker is earned (the real-vs-fake test); this skill owns the command that records it.
 
 ### Projects & documents
 


### PR DESCRIPTION
## What

`task-tracker`'s Relations section pointed at `writing-task-specs` as the owner of *"when a blocker is earned"* — a stale signpost written before `dependency-analysis` existed. SWO-557's D7 moved that ownership to `dependency-analysis` (and `writing-task-specs` itself now defers there). Repoint it; `task-tracker` keeps ownership of only the command that records the edge.

Part of the SWO-651 skill re-audit (S2). A wrong-owner pointer for the exact principle that governs how work is sequenced.

## Verification
- Grep confirmed this was the **only** such mis-attribution in the skills tree.
- Confirmed `dependency-analysis` genuinely claims the ownership ("This skill owns that question"; "Flat is the default; waves are earned").

Closes SWO-654.

🤖 Generated with [Claude Code](https://claude.com/claude-code)