### PR TITLE
docs(skills): give schema-lands-first a single owner in micro-prs (SWO-655)

### DIFF
--- a/.claude/skills/micro-prs/SKILL.md
+++ b/.claude/skills/micro-prs/SKILL.md
@@ -25,7 +25,7 @@ Everything now lives in one repo, so nothing stops you combining pieces that sho
 - A single PR touches **at most one** of: one `apps/<app>` directory — including `apps/backend` and `apps/hasura` — or `packages/core`, or `packages/ui`.
 - Touching two apps in one PR is wrong. An app plus `packages/core` in one PR is wrong. `packages/core` plus `packages/ui` in one PR is wrong.
 - Each layer carries different review and verification concerns — an app PR is checked by running that app; a `packages/core` PR is checked by its unit tests and `pnpm codegen`; a `packages/ui` PR is checked in Storybook. A PR mixing them can't be reviewed properly or reverted cleanly.
-- **One repo is not permission to merge layers.** A Hasura migration in `apps/hasura` and the frontend's regenerated types in `packages/core` are still two PRs, in that order (see `parallel-workflow`) — the schema has to be live before the generated types mean anything. Sharing a repo removes the friction, not the dependency.
+- **One repo is not permission to merge layers.** A Hasura migration in `apps/hasura` and the frontend's regenerated types in `packages/core` are still two PRs, in that order — the schema has to be live before the generated types mean anything. Sharing a repo removes the friction, not the dependency.
 
 ## Blockers land first, as their own PRs
 

--- a/.claude/skills/parallel-workflow/SKILL.md
+++ b/.claude/skills/parallel-workflow/SKILL.md
@@ -16,7 +16,7 @@ user-invocable: false
 Everything ships from a single repo — the frontend apps, the shared packages, the Hono backend (`apps/backend`), and the Hasura data layer (`apps/hasura`). One lockfile, one branch, one PR flow. These rules apply to every part of it, frontend or not: tracker issue first, dedicated worktree, commit often / push immediately, self-review loop before PR, CI loop after. Two adjustments by area:
 
 - **Trust boundaries get the deep treatment.** Hasura permissions/metadata and Hono Action/Event/webhook handlers are trust boundaries — a change touching them MUST also run `security-reviewer` inside the self-review loop (step 11).
-- **Hasura changes are not done when their PR is clean.** A schema change ripples into the frontend: apply the migration locally, re-run `pnpm codegen` in `packages/core` (it introspects the LOCAL Hasura), and land the regenerated types as a follow-up PR — linked in the tracker with a blocking relation from the Hasura issue. One repo doesn't collapse that ripple: the schema still has to be live before the generated types mean anything, so the migration lands and deploys first.
+- **Hasura changes are not done when their PR is clean.** A schema change ripples into the frontend: after the migration, re-run `pnpm codegen` in `packages/core` (it introspects the LOCAL Hasura) and land the regenerated types as a follow-up PR, linked in the tracker with a blocking relation from the Hasura issue. That these are two PRs in that order — schema first, because the schema must be live before the generated types mean anything — is `micro-prs`' slicing rule ("Blockers land first"), not restated here.
 
 ## Git fundamentals
 


### PR DESCRIPTION
## What

The "Hasura migration lands first, frontend codegen follows as a blocked PR" rule was spelled out in **two** skills — `micro-prs` (with a muddying back-pointer `(see parallel-workflow)`) and `parallel-workflow` (the full rule). Bidirectional, no clean owner, free to drift.

`micro-prs` owns PR-slicing-by-layer, so it owns this rule (its "Blockers land first" section). This makes that ownership clean:
- **micro-prs** — drop the `(see parallel-workflow)` back-pointer so it cleanly owns the rule.
- **parallel-workflow** — keep the actionable workflow steps (re-run `pnpm codegen` in `packages/core` against the LOCAL Hasura, land the regenerated types as a follow-up PR, link a blocking relation from the Hasura issue), but defer the *ordering rule* to `micro-prs` ("Blockers land first"), not restate it.

Part of the SWO-651 skill re-audit (S3).

## Verification
- No bidirectional pointer remains (`micro-prs` no longer says "see parallel-workflow" for this rule).
- `micro-prs`' "Blockers land first" section still fully carries the rule `parallel-workflow` now defers to — nothing orphaned.
- The codegen-runs-against-LOCAL-Hasura gotcha is preserved in `parallel-workflow`.

Closes SWO-655.

🤖 Generated with [Claude Code](https://claude.com/claude-code)