### PR TITLE
[WIP] docs(skills): defer completeness-sweep axes to grill-me in analyze (SWO-656)

### DIFF
--- a/.claude/skills/analyze/SKILL.md
+++ b/.claude/skills/analyze/SKILL.md
@@ -46,9 +46,9 @@ actually there, not memory.
 ### 1. Requirement re-derivation
 
 Read the spec as if you were about to grill it, and run `grill-me`'s **completeness sweep** against what's
-already written — walk the actors/roles, states & scale, and failure & timing axes and confirm each is
-either handled in the spec or *explicitly* ruled out of scope. `grill-me` owns the method; here you apply
-it to an existing document instead of a live conversation. A silent axis is a requirement nobody wrote.
+already written — walk each of its axes and confirm each is either handled in the spec or *explicitly*
+ruled out of scope. `grill-me` owns the method and the axes; here you apply it to an existing document
+instead of a live conversation. A silent axis is a requirement nobody wrote.
 
 This is the pass that catches the expensive class of gap — the actor nobody enumerated, the half-finished
 state nobody handled — at analysis time instead of during implementation self-review.
@@ -95,14 +95,14 @@ A per-user third-party login feature (connect an external account, then import f
 plus sub-issues. Here's what an up-front analyze pass catches — each of which, skipped, tends to surface the
 expensive way, mid-build in a sub-issue's self-review:
 
-- **Requirement pass (actor axis):** the connect/import actions are marked for any signed-in user, but the
+- **Requirement pass (actor gap):** the connect/import actions are marked for any signed-in user, but the
   implementation runs against a single shared account belonging to the owner — so any user could act as the
-  owner. "What does a *non-owner* user actually get here?" was never enumerated. The actor axis surfaces it
+  owner. "What does a *non-owner* user actually get here?" was never enumerated. The completeness sweep surfaces it
   before it's built.
-- **Requirement pass (failure / half-finished axis):** a user who already has a working connection starts a
+- **Requirement pass (failure / half-finished gap):** a user who already has a working connection starts a
   re-login and abandons it — and the design reuses the same field for the in-progress session, so the
   abandoned attempt overwrites and destroys their working one. Data-loss. "Returning user, login left
-  half-finished" was never handled; the failure axis names exactly that case.
+  half-finished" was never handled; the sweep names exactly that case.
 - **Breakdown integrity:** the parent sits live with a `blocked-by` pointing at a sub-issue that's already
   been closed/superseded; a schema block in the parent that never gained a column a later sub-issue added;
   and a dependency diagram labelled "unchanged" that omits a real new deploy-order blocker — one that, under


### PR DESCRIPTION
## In plain words

One of our internal how-to guides (the `analyze` skill) had copy-pasted a checklist that really belongs to another guide (`grill-me`). If we ever change that checklist in its real home, this copy would quietly go stale and start disagreeing with it. This swaps the copy for a pointer, so there's one source of truth again.

## What & why

`analyze`'s requirement-re-derivation pass spelled out `grill-me`'s **completeness-sweep axes** verbatim — "actors/roles, states & scale, failure & timing" — and its worked example echoed them as "actor axis" / "failure axis". That taxonomy is owned by `grill-me`; duplicating it means re-cutting grill-me's axes silently drifts `analyze` out of sync (the exact copy-vs-signpost regression class from the SWO-557 skill-boundary audit).

**Fix (one file, `.claude/skills/analyze/SKILL.md`):**
- Main sweep line: replace the enumerated axis list with a signpost — "walk each of its axes … `grill-me` owns the method **and the axes**".
- Worked example: relabel "(actor axis)" → "(actor gap)", "(failure / half-finished axis)" → "(failure / half-finished gap)", and "The actor axis surfaces it" / "the failure axis names exactly that case" → "The completeness sweep surfaces it" / "the sweep names exactly that case".

No behavioural content changes — `grill-me` remains the sole owner of the axis taxonomy; `analyze` now defers to it instead of restating it.

## How to verify
- `analyze/SKILL.md` contains no verbatim axis enumeration.
- `grill-me/SKILL.md` still lists the axes (Actors/roles, States & scale, Failure & timing) — unchanged, still the owner.

## Scope
- One file, docs-only. Independently mergeable and revertible.

Closes SWO-656

🤖 Generated with [Claude Code](https://claude.com/claude-code)