### PR TITLE
[WIP] docs(skills): model code-conventions in error-handling hook examples (SWO-657)

### DIFF
--- a/.claude/skills/error-handling/SKILL.md
+++ b/.claude/skills/error-handling/SKILL.md
@@ -50,12 +50,14 @@ Hook has no `onError`; call-site has no `onError` → the global handler shows a
 
 ```ts
 // Hook — no onError
-export function useArchiveProjectMutation() {
+const useArchiveProjectMutation = () => {
   return useMutation({
     mutationFn: async (input) => { ... },
     onSuccess: () => { queryClient.invalidateQueries(...); },
   });
-}
+};
+
+export { useArchiveProjectMutation };
 
 // Component — no onError
 archiveMutation.mutate({ id, isArchived: true });
@@ -67,7 +69,7 @@ Hook defines `onError` for rollback only — does *not* show a toast. Call-site 
 
 ```ts
 // Hook — onError for rollback only (suppresses global handler)
-export function useCreateProjectMutation() {
+const useCreateProjectMutation = () => {
   return useMutation({
     mutationFn: async (input) => { ... },
     onError: (_err, _vars, context) => {
@@ -75,7 +77,9 @@ export function useCreateProjectMutation() {
     },
     onSuccess: () => { queryClient.invalidateQueries(...); },
   });
-}
+};
+
+export { useCreateProjectMutation };
 
 // Component — handles inline display
 createMutation.mutate(data, {
@@ -92,7 +96,7 @@ Hook defines `onError` for rollback *and* toast; call-site shows nothing.
 
 ```ts
 // Hook — rollback + toast
-export function useUpdateLineItemMutation() {
+const useUpdateLineItemMutation = () => {
   return useMutation({
     mutationFn: async (input) => { ... },
     onError: (error, _vars, context) => {
@@ -102,7 +106,9 @@ export function useUpdateLineItemMutation() {
     },
     onSuccess: () => { queryClient.invalidateQueries(...); },
   });
-}
+};
+
+export { useUpdateLineItemMutation };
 ```
 
 ## Rules


### PR DESCRIPTION
## In plain words

One of our internal how-to guides (the `error-handling` skill) showed example code that broke our own house style rules — it used the old `function` form and put exports in the wrong place. Since this guide sits right next to the rules it was breaking, it was quietly teaching the wrong habit. This rewrites the three examples so they follow the style we actually require.

## What & why

`error-handling/SKILL.md`'s three illustrative mutation-hook examples were written as:

```ts
export function useArchiveProjectMutation() { return useMutation(...) }
```

That's a `function` declaration with an inline `export` — both forbidden by `code-conventions` (arrow functions only; named exports at the bottom of the file, no inline `export`). A convention-adjacent skill modelling the anti-pattern in its own examples is a credibility leak.

**Fix (one file, `.claude/skills/error-handling/SKILL.md`):** each example becomes

```ts
const useArchiveProjectMutation = () => { return useMutation(...) };

export { useArchiveProjectMutation };
```

with the `export { … }` placed at the end of the *hook* portion of each snippet (before the separate `// Component` file portion where present), so the two-file structure stays faithful. No prose or behavioural change.

## How to verify
- No `export function` / function declarations remain in `error-handling/SKILL.md`.
- Each example uses an arrow-function `const` and a trailing `export { … }`.

## Scope
- One file, docs-only. Independently mergeable and revertible.

Closes SWO-657

🤖 Generated with [Claude Code](https://claude.com/claude-code)